### PR TITLE
Symbol.for("observablehq.display")

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -96,7 +96,9 @@ export function define(cell) {
       }
     : (v) => {
         reset?.();
-        inspector().fulfilled(v);
+        const custom = v?.[Symbol.for("observablehq.display")];
+        if (custom != null && typeof custom !== "function") throw new Error(`Unsupported custom inspector ${custom}`);
+        inspector().fulfilled(custom ? custom(v) : v);
         return v;
       };
   const v = main.variable(


### PR DESCRIPTION
closes #51

To use:

~~~
```js
display(
  Object.assign([...penguins], {
    [Symbol.for("observablehq.display")]: Inputs.table
  })
);
```
~~~


TODO:
* Should it also work in ${} interpolations? (This currently applies only in the display function.)
* Test
* Document

_Note: it doesn't seem urgent, we could try and see how far we go without this._