### PR TITLE
Add data loader caching to build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-.observablehq
+docs/.observablehq/
 dist/
 node_modules/
 test/output/*-changed.*

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,5 +1,5 @@
 import {accessSync, constants, statSync, type Stats} from "node:fs";
-import {mkdir, readdir, stat} from "node:fs/promises";
+import {copyFile, mkdir, readdir, stat} from "node:fs/promises";
 import {dirname, extname, join, normalize, relative} from "node:path";
 import {isNodeError} from "./error.js";
 
@@ -64,4 +64,10 @@ export async function prepareOutput(outputPath: string): Promise<void> {
   const outputDir = dirname(outputPath);
   if (outputDir === ".") return;
   await mkdir(outputDir, {recursive: true});
+}
+
+export async function copyBuildFile(sourcePath: string, outputPath: string, message: string = "copy"): Promise<void> {
+  console.log(message, sourcePath, "→", outputPath);
+  await prepareOutput(outputPath);
+  await copyFile(sourcePath, outputPath);
 }


### PR DESCRIPTION
This PR does two things:

- Changes the location of the data loader cache in the preview command so that it defaults to docs/.observablehq (under the serving root)
- Adds data loader caching to the build command as a command line option. When invoked with the `--cache dir` option, the output of the data loaders is cached in the given directory