### PR TITLE
ignore executable bit

### DIFF
--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -1,6 +1,6 @@
 import {spawn} from "node:child_process";
 import {type Stats} from "node:fs";
-import {constants, open, rename, unlink} from "node:fs/promises";
+import {open, rename, unlink} from "node:fs/promises";
 import {maybeStat, prepareOutput} from "./files.js";
 
 const runningCommands = new Map<string, Promise<void>>();
@@ -13,7 +13,7 @@ export interface Loader {
 function makeCommand(commandPath) {
   if (commandPath.endsWith(".js")) return {command: "node", options: [commandPath]};
   if (commandPath.endsWith(".ts")) return {command: "tsx", options: [commandPath]};
-  return {command: commandPath, options: []};
+  return {command: "sh", options: [commandPath]};
 }
 
 export async function runLoader(commandPath: string, outputPath: string) {
@@ -54,8 +54,6 @@ export async function findLoader(name: string): Promise<Loader | undefined> {
   for (const ext of [".js", ".ts", ".sh"]) {
     const path = name + ext;
     const stats = await maybeStat(path);
-    if (stats && stats.mode & constants.S_IXUSR) {
-      return {path, stats};
-    }
+    if (stats) return {path, stats};
   }
 }


### PR DESCRIPTION
This ignores the executable bit before determining and running a dataloader.

Here are a few arguments in favor of this approach:

1. current UX for setting the x bit is very poor: it's easy to lose the x bit when copying files around, and the errors are unclear. On MacOS, the Finder doesn't show it, so only Terminal-savvy users will find their way.
2. while watching files, we don't track the changes to the x bit, so a change made by the user will not be reflected live (one may have to reload the page, and even in some cases where another dataloader took precedence, purge the cache).
3. if we imagine that in the future dataloaders might be written as a code block inside a .md file, where would we read the x bit? on the md file?
4. for js and ts loaders, we state (#96) that we don't want to have to set the x bit — however those languages have the same capabilities as any shell script
5. as a security model, this seems both clunky and not enough. It might even (arguably) be _better_ in terms of security to avoid having +x files that could be executed directly, since they're meant to be used as dataloaders.

related to #96 

I don't know if Windows users have access to "sh", though, so maybe something is needed in that department to substitute with "cmd.exe".


(Needs to be reappraised wrt #114)