### PR TITLE
When a data loader fails, unlink any previously cached output.

### DIFF
--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -35,6 +35,7 @@ export async function runLoader(commandPath: string, outputPath: string) {
       await rename(outputTempPath, outputPath);
     } else {
       await unlink(outputTempPath);
+      unlink(outputPath);
     }
   })();
   command.finally(() => runningCommands.delete(commandPath));


### PR DESCRIPTION
To test, open a page that has a working data loader, then edit the loader into an error state; the page should display an "Error: Unable to load file", instead of the older data from a previous successful run.

Implementation note: we're not sure there is an old file at the outputPath, but we don't check, and don't await, which ignores any error.


(Needs to be reappraised wrt #114)