### PR TITLE
set max-width on footer, align to content, buttons equal size

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -48,7 +48,8 @@ body {
   margin: 0;
 }
 
-#observablehq-main {
+#observablehq-main,
+#observablehq-footer {
   margin: 2rem auto;
   max-width: 1152px;
 }
@@ -59,7 +60,6 @@ body {
 
 #observablehq-footer {
   display: block;
-  max-width: 640px;
   margin-top: 10rem;
   font: 12px var(--sans-serif);
   color: var(--theme-foreground-faint);
@@ -67,6 +67,7 @@ body {
 
 #observablehq-footer nav {
   display: grid;
+  max-width: 640px;
   grid-template-columns: 1fr 1fr;
   column-gap: 1rem;
   margin-bottom: 1rem;


### PR DESCRIPTION
a quick patch to set max-width on the footer to 640px, and equalize the prev & next button sizes.

closes: #188.

looks like this:

<img width="676" alt="image" src="https://github.com/observablehq/cli/assets/12802394/0c8032c4-bf7e-4ff1-a735-c42a49c53af3">