### PR TITLE
subtler 404 redirect

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,7 +1,8 @@
 <script type="module">
 
 if (location.pathname.endsWith("/")) {
-  location.replace(`${location.pathname.slice(0, -1)}.html${location.search}${location.hash}`);
+  fetch(`${location.pathname.slice(0, -1)}.html`, { method: 'HEAD' })
+    .then((resp) => resp.ok && location.replace(`${location.pathname.slice(0, -1)}.html${location.search}${location.hash}`));
 }
 
 </script>


### PR DESCRIPTION
If javascript/ is 404, check if javascript.html exists before redirecting.

Here we're targeting a static file server such as `npx http-server`.

If you call `/javascript?param=1#hash` the server doesn't find it, but it finds the directory javascript/, enters it, doesn't find an index.html and returns a 404. Now this piece of javascript checks (HEAD) if /javascript.html exists (as a file), then in that case redirects to `/javascript.html?param=1#hash`. 