### PR TITLE
purge caches from test/input/build/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "rm -rf dist && ./bin/observable.ts build",
     "test": "yarn test:mocha && yarn test:tsc && yarn test:lint",
     "test:coverage": "c8 yarn test:mocha",
-    "test:mocha": "rm -rf test/.observablehq/cache && tsx ./node_modules/.bin/mocha 'test/**/*-test.*'",
+    "test:mocha": "rm -rf test/.observablehq/cache test/input/build/*/.observablehq/cache && tsx ./node_modules/.bin/mocha 'test/**/*-test.*'",
     "test:lint": "eslint src test public",
     "test:tsc": "tsc --noEmit"
   },


### PR DESCRIPTION
Running the build tests populates their caches. With dynamic payloads we run the risk of having a test validate because it used a cache.