### PR TITLE
hide empty cells

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -634,6 +634,10 @@ a[href].observablehq-header-anchor {
   color: inherit;
 }
 
+.observablehq--block:empty {
+  display: none;
+}
+
 .observablehq--block {
   margin: 1rem 0;
 }


### PR DESCRIPTION
closes #251 

To test, try this in a markdown file:

````md
<style>
div.observablehq--block { margin-bottom: 9em; }
</style>

```js
display(await new Promise(r => setTimeout(() => r(html`Hello`), 2000)))
```

# Title

...
````

(is there a more obvious way to exhibit the original problem?)