### PR TITLE
build statistics

### DIFF
--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -301,7 +301,7 @@ const extractors = [
   [".tgz", TarGzExtractor]
 ] as const;
 
-function formatSize(size: number): string {
+export function formatSize(size: number): string {
   if (!size) return yellow("empty output");
   const e = Math.floor(Math.log(size) / Math.log(1024));
   return `${+(size / 1024 ** e).toFixed(2)} ${["bytes", "KiB", "MiB", "GiB", "TiB"][e]}`;


### PR DESCRIPTION
Just a draft. This doesn't feel 100% useful, but it's a start.

I think I want to have a notion of the maximum and median page "weight", but that might be a mixture of html, css, scripts etc?

![Capture d’écran 2023-12-05 à 16 38 54](https://github.com/observablehq/cli/assets/7001/856e986d-5208-4b3c-9ebb-12b7253071b6)

The total weight might be interesting for **platform** too. Although it's not saying how this compresses, if it's duplicate contents across versions, etc.