### PR TITLE
display.root

### DIFF
--- a/docs/javascript/display.md
+++ b/docs/javascript/display.md
@@ -119,6 +119,10 @@ The current gain is ${gain}!
 
 If `value` is a DOM node, adds it to the DOM. Otherwise, converts the given `value` to a suitable DOM node and displays that instead. Returns the given `value`.
 
+## display.root
+
+The DOM element into which [`display`](#displayvalue) will append.
+
 ## view(*element*)
 
 The `view` function displays the given input *element* and then returns its corresponding [generator](./generators) via [`Generators.input`](../lib/generators#input(element)). Use this to display an input element while also exposing the input’s value as a [reactive variable](./reactivity).

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -38,9 +38,10 @@ export function define(cell) {
       }
     : (v) => {
         reset?.();
-        root.append(isNode(v) ? v : inspect(v));
+        root.append(isNode(v) && root !== v ? v : inspect(v));
         return v;
       };
+  display.root = root;
   const v = main.variable(
     {
       _node: root, // for visibility promise


### PR DESCRIPTION
Exposes `display.root` which I thought might be useful with `IntersectionObserver`, possibly among other things. But there’s a somewhat confusing interaction with how we reset (clear) the display root when a variable is fulfilled or rejected. That probably needs rethinking before we expose this.