### PR TITLE
Allow event propagation from platform integration hook

### DIFF
--- a/src/client/deploy.js
+++ b/src/client/deploy.js
@@ -5,7 +5,6 @@ const parent = window.parent; // capture to prevent reassignment
 
 function messaged(event) {
   if (!event.isTrusted || event.origin !== origin || event.source !== parent) return;
-  event.stopImmediatePropagation();
   const message = event.data;
   if (message.type === "hello") {
     postMessage({type: "hello"});


### PR DESCRIPTION
The platform integration script needs to also be able to handle postMessages from the parent. Having this stopImmediatePropogation call prevents that. This was something I accidentally included in my previous PR, but didn't notice because I was testing with an old deploy on my local build.
