### PR TITLE
Fix position of the sidebar button on older firefox

### DIFF
--- a/src/style/layout.css
+++ b/src/style/layout.css
@@ -278,14 +278,14 @@
     height 150ms ease;
 }
 
-#observablehq-sidebar-toggle:has(~ #observablehq-sidebar:focus-within)::before{
+#observablehq-sidebar-toggle:has(~ #observablehq-sidebar:focus-within)::before {
   transform: scaleX(-1);
 }
 #observablehq-sidebar-toggle:checked::before {
   transform: scaleX(-1);
 }
 
-#observablehq-sidebar-toggle:has(~ #observablehq-sidebar:focus-within){
+#observablehq-sidebar-toggle:has(~ #observablehq-sidebar:focus-within) {
   cursor: w-resize;
   top: 1rem;
   left: calc(272px - 2.7rem);
@@ -335,13 +335,13 @@
   #observablehq-sidebar-toggle {
     transition: none;
   }
-  #observablehq-sidebar-toggle:has(~ #observablehq-sidebar:focus-within)::before{
+  #observablehq-sidebar-toggle:has(~ #observablehq-sidebar:focus-within)::before {
     transform: scaleX(-1);
   }
   #observablehq-sidebar-toggle:indeterminate::before {
     transform: scaleX(-1);
   }
-  #observablehq-sidebar-toggle:has(~ #observablehq-sidebar:focus-within){
+  #observablehq-sidebar-toggle:has(~ #observablehq-sidebar:focus-within) {
     cursor: w-resize;
     top: 1rem;
     left: calc(272px - 2.7rem);


### PR DESCRIPTION
This seems like a minor inconvenience (the UI is still functional), but it can be fixed if we split the selector into two and repeat the rules :-/

(I haven't done it on all the occurrences of `:has`, because I'm not seeing a difference with the others—not sure what I'm missing.)

This issue is impacting (currently) less than 2% usage according to https://caniuse.com/?search=%3Ahas
I don't know how fast the new versions of FF are rolling out, but we could revisit in a few months, maybe.

Closes #428

![](https://github.com/observablehq/cli/assets/7001/636c8893-c934-430c-bd33-82d6d2dd765e)

