### PR TITLE
page-level themes, specified in the front-matter

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -18,6 +18,7 @@ import {parseInfo} from "./info.js";
 import type {FileReference, ImportReference, PendingTranspile, Transpile} from "./javascript.js";
 import {transpileJavaScript} from "./javascript.js";
 import {transpileTag} from "./tag.js";
+import {normalizeTheme} from "./theme.js";
 import {resolvePath} from "./url.js";
 
 export interface ReadMarkdownResult {
@@ -47,6 +48,7 @@ export interface ParseResult {
   pieces: HtmlPiece[];
   cells: CellPiece[];
   hash: string;
+  theme?: string;
 }
 
 interface RenderPiece {
@@ -439,7 +441,8 @@ export async function parseMarkdown(source: string, root: string, sourcePath: st
     imports: context.imports,
     pieces: toParsePieces(context.pieces),
     cells: await toParseCells(context.pieces),
-    hash: await computeMarkdownHash(source, root, sourcePath, context.imports)
+    hash: await computeMarkdownHash(source, root, sourcePath, context.imports),
+    theme: normalizeTheme(parts.data.theme)
   };
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,23 @@
+import {createHash} from "node:crypto";
+import type {ParseResult} from "./markdown.js";
+import {relativeUrl} from "./url.js";
+
+export function styleUrl(path: string, theme?: string, preview?: boolean): string {
+  const [name, query] =
+    theme !== undefined ? ["style-" + styleHash(theme), preview ? `?${encodeURIComponent(theme)}` : ""] : ["style", ""];
+  return relativeUrl(path, `/_observablehq/${name}.css${query}`);
+}
+
+export function styleHash(str: string): string {
+  return createHash("sha256").update(str).digest("hex").slice(0, 16);
+}
+
+export function normalizeTheme(theme: any): ParseResult["theme"] {
+  return theme ? (typeof theme === "string" ? validate(theme) : Array.from(theme, validate).join(",")) : undefined;
+}
+
+function validate(theme: any): string {
+  theme = String(theme);
+  if (theme.match(/[^\w-]/)) throw new Error(`unsupported theme name ${theme}`);
+  return theme;
+}


### PR DESCRIPTION
All these definitions are valid syntax:

```yaml
---
theme: dark
---
```

```yaml
---
theme: [auto, comic-sans]
---
```

```yaml
---
theme:
  - dark
  - comic-sans
---
```

Any custom theme (as opposed to the default theme indicated in the configuration file) get bundled with rollup as `_observablehq/style-{hash}.css` (the default theme is unchanged, bundled as `_observablehq/style.css`).

Note that a page-level theme does not _add_ to the default theme configuration (this is necessary because you don't necessarily want the default theme; we could debate how to indicate that you extend the default, maybe by having a reserved word such as _default_: [default, solarized] ? This can't be _auto_ since it's not guaranteed that the default theme in the configuration is auto…). 

The theme names must be strings containing only letters, numbers, underscores and dashes (`\w-`). Commas in particular are not allowed because they will be the separator for multiple themes.

On **preview**, the server needs to know what the hash means, so we pass add a search parameter in the URL, with the theme name(s), possibly joined by a comma, in the clear. The server then does a safety check against the hash, and if it passes builds the combined stylesheet.

On **build**, this stuff is not necessary, so for the sake of minimizing the HTML, the URL is passed only as `style-{hash}.css`.

This means, however, that the rendered page is not strictly the same in preview and in build. If we think this is an issue, there are two possibilities, and I have not been able to choose:
- either leave the search params in build (easy, it will just remove 3 lines of code); a bit ugly, but maybe that's OK?
- or memoize the information in the preview server when it builds a page. Not sure if that's a good idea, because it would mean that the preview server can't serve a css bundle after a cold-start.

I have _not_ pushed the theme-comic-sans.css file so you can't test this:
![theme-comic](https://github.com/observablehq/cli/assets/7001/41237c3c-977a-4c6f-9e3d-d2da44907f05)

(It could be nice to have more built-in theme files to test, but I think it's more important to have a theme resolution mechanism that first checks if the `docs/{theme}.css` file exists, then the built-in, and then errors. It could be for a different PR though.)