### PR TITLE
dashboard theme + theme and style documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -57,7 +57,7 @@ theme: [auto-alt, wide]
 
 The path to a custom stylesheet. This option takes precedence over [themes](#theme) (if any), providing more control by allowing you to remove or alter the default stylesheet and define a custom theme.
 
-The custom stylesheet should typically import the `"observablehq:default.css"` to build on the default styles. You can also import any of the built-in themes. For example, to create a stylesheet that builds up on the *light* theme, create a `custom-style.css` file in the `docs` folder, then set the **style** option to `"docs/custom-style.css"`:
+The custom stylesheet should typically import the `"observablehq:default.css"` to build on the default styles. You can also import any of the built-in themes. For example, to create a stylesheet that builds up on the *light* theme, create a `custom-style.css` file in the `docs` folder, then set the **style** option to `"custom-style.css"`:
 
 ```css
 @import url("observablehq:theme-light.css");

--- a/src/build.ts
+++ b/src/build.ts
@@ -83,7 +83,7 @@ export async function build(
     files.push(...render.files.map(resolveFile));
     imports.push(...render.imports.filter((i) => i.type === "local").map(resolveFile));
     await effects.writeFile(outputPath, render.html);
-    const style = mergeStyle(render.data?.style, render.data?.theme, config.style);
+    const style = mergeStyle(path, render.data?.style, render.data?.theme, config.style);
     if (style) {
       if ("path" in style) style.path = resolvePath(sourceFile, style.path);
       if (!styles.some((s) => styleEquals(s, style))) styles.push(style);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import {readFile} from "node:fs/promises";
 import {basename, dirname, extname, join} from "node:path";
 import {visitFiles} from "./files.js";
 import {parseMarkdown} from "./markdown.js";
+import {resolvePath} from "./url.js";
 
 export interface Page {
   name: string;
@@ -118,12 +119,12 @@ export function mergeToc(spec: any, toc: TableOfContents): TableOfContents {
   return {label, show};
 }
 
-export function mergeStyle(style: any, theme: any, defaultStyle: null | Style): null | Style {
+export function mergeStyle(path: string, style: any, theme: any, defaultStyle: null | Style): null | Style {
   return style === undefined && theme === undefined
     ? defaultStyle
     : style === null
     ? null // disable
     : style !== undefined
-    ? {path: String(style)} // TODO resolve path?
+    ? {path: resolvePath(path, style)}
     : {theme: normalizeTheme(theme)};
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -22,7 +22,7 @@ import type {ParseResult, ReadMarkdownResult} from "./markdown.js";
 import {renderPreview} from "./render.js";
 import {bundleStyles, getClientPath, rollupClient} from "./rollup.js";
 import {bold, faint, green, underline} from "./tty.js";
-import {relativeUrl, resolvePath} from "./url.js";
+import {relativeUrl} from "./url.js";
 
 const publicRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "public");
 
@@ -257,11 +257,11 @@ function getWatchPaths(parseResult: ParseResult): string[] {
 }
 
 export function getPreviewStylesheet(path: string, data: ParseResult["data"], style: Config["style"]): string | null {
-  style = mergeStyle(data?.style, data?.theme, style);
+  style = mergeStyle(path, data?.style, data?.theme, style);
   return !style
     ? null
     : "path" in style
-    ? relativeUrl(path, `/_import/${resolvePath(path, style.path)}`)
+    ? relativeUrl(path, `/_import/${style.path}`)
     : relativeUrl(path, `/_observablehq/theme-${style.theme.join(",")}.css`);
 }
 


### PR DESCRIPTION
In this PR the dashboard theme does not try to control colors; this makes it compatible with auto, light and dark, and the result does not depend on the order in which the themes are specified.

```yaml
---
theme: [dashboard, auto]
--- 
```

However, this means that the dashboard theme does not stand on its own, and must be specified together with one of dark, light or auto. I haven't found a neat way to, say, have it use auto implicitly when the page is set to `theme: dashboard`.

TODO:
- [x] rebase on #449 
- [ ] document all the variables exposed from each theme
- [ ] document the grid (see grid.md)
- [ ] update with the new themes
