### PR TITLE
hoist css external @imports

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -42,7 +42,14 @@ export async function bundleStyles({path, theme}: {path?: string; theme?: string
     write: false,
     alias: STYLE_MODULES
   });
+  console.warn(result.outputFiles[0].text.slice(0, 100));
   return result.outputFiles[0].text;
+}
+
+export async function hoistStyleImport(cf): Promise<string[]> {
+  const styles = Array.from((await bundleStyles(cf)).matchAll(/^@import .*/), ([match]) => match);
+  console.warn({styles});
+  return styles;
 }
 
 export async function rollupClient(clientPath: string, {minify = false} = {}): Promise<string> {

--- a/src/style/default.css
+++ b/src/style/default.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Source+Serif+Pro:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap");
 @import url("./global.css");
 @import url("./layout.css");
 @import url("./grid.css");


### PR DESCRIPTION
WIP for #423

`bundleStyles` correctly puts the `@import "url";` lines at the top of its text. In the preview or build scripts, we can easily detect these lines with RegExp and maybe remove them from the bundled CSS—though that is not even strictly necessary.

Hoisting them as stand-alone links (with the additional preconnect) is what will give the performance boost, and it's a bit more difficult, because in both cases (preview and render) we bundle much later than we link, so it looks like we have to change the order of operations. I think it's doable but I'm not fully there yet.

I learned a lot by reading https://sia.codes/posts/making-google-fonts-faster/