### PR TITLE
throw on invalid config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,8 @@ export async function readDefaultConfig(root?: string): Promise<Config> {
   for (const ext of [".js", ".ts"]) {
     try {
       return await readConfig("observablehq.config" + ext, root);
-    } catch (error) {
+    } catch (error: any) {
+      if (error.code !== "ERR_MODULE_NOT_FOUND") throw error;
       continue;
     }
   }


### PR DESCRIPTION
Only ignore ERR_MODULE_NOT_FOUND, not all errors. Fixes #470.