### PR TITLE
Rename OBSERVABLEHQ_ constants to drop HQ suffix

### DIFF
--- a/src/client/deploy.js
+++ b/src/client/deploy.js
@@ -1,6 +1,6 @@
 export * from "./index.js";
 
-const origin = process.env.OBSERVABLEHQ_ORIGIN;
+const origin = process.env.OBSERVABLE_ORIGIN;
 const parent = window.parent; // capture to prevent reassignment
 
 let listener = null;

--- a/src/javascript/databases.ts
+++ b/src/javascript/databases.ts
@@ -21,7 +21,7 @@ interface DatabaseConfig {
 }
 
 function getDatabaseProxyConfig(env: typeof process.env, name: string): DatabaseConfig | undefined {
-  const property = `OBSERVABLEHQ_DB_SECRET_${name}`;
+  const property = `OBSERVABLE_DB_SECRET_${name}`;
   const secret = env[property];
   if (!secret) return;
   const config = JSON.parse(Buffer.from(secret, "base64").toString("utf-8")) as DatabaseConfig;

--- a/src/observableApiAuth.ts
+++ b/src/observableApiAuth.ts
@@ -10,7 +10,7 @@ import type {Logger} from "./logger.js";
 import {ObservableApiClient, getObservableUiHost} from "./observableApiClient.js";
 import {type ApiKey, getObservableApiKey, setObservableApiKey} from "./observableApiConfig.js";
 
-const OBSERVABLEHQ_UI_HOST = getObservableUiHost();
+const OBSERVABLE_UI_HOST = getObservableUiHost();
 
 export const commandRequiresAuthenticationMessage = `You need to be authenticated to ${
   getObservableUiHost().hostname
@@ -42,7 +42,7 @@ export async function login(effects = defaultEffects) {
   const server = new LoginServer({nonce, effects});
   await server.start();
 
-  const url = new URL("/settings/api-keys/generate", OBSERVABLEHQ_UI_HOST);
+  const url = new URL("/settings/api-keys/generate", OBSERVABLE_UI_HOST);
   const name = `Observable CLI on ${os.hostname()}`;
   const request = {
     nonce,
@@ -78,7 +78,7 @@ export async function whoami(effects = defaultEffects) {
   try {
     const user = await apiClient.getCurrentUser();
     logger.log();
-    logger.log(`You are logged into ${OBSERVABLEHQ_UI_HOST.hostname} as ${formatUser(user)}.`);
+    logger.log(`You are logged into ${OBSERVABLE_UI_HOST.hostname} as ${formatUser(user)}.`);
     logger.log();
     logger.log("You have access to the following workspaces:");
     for (const workspace of user.workspaces) {
@@ -234,9 +234,9 @@ class LoginServer {
       return false;
     }
     return (
-      parsedOrigin.protocol === OBSERVABLEHQ_UI_HOST.protocol &&
-      parsedOrigin.host === OBSERVABLEHQ_UI_HOST.host &&
-      parsedOrigin.port === OBSERVABLEHQ_UI_HOST.port
+      parsedOrigin.protocol === OBSERVABLE_UI_HOST.protocol &&
+      parsedOrigin.host === OBSERVABLE_UI_HOST.host &&
+      parsedOrigin.port === OBSERVABLE_UI_HOST.port
     );
   }
 }

--- a/src/observableApiClient.ts
+++ b/src/observableApiClient.ts
@@ -29,21 +29,21 @@ export interface GetProjectResponse {
 }
 
 export function getObservableUiHost(env = process.env): URL {
-  const urlText = env["OBSERVABLEHQ_HOST"] ?? "https://observablehq.com";
+  const urlText = env["OBSERVABLE_HOST"] ?? "https://observablehq.com";
   try {
     return new URL(urlText);
   } catch (error) {
-    throw new CliError(`Invalid OBSERVABLEHQ_HOST environment variable: ${error}`, {cause: error});
+    throw new CliError(`Invalid OBSERVABLE_HOST environment variable: ${error}`, {cause: error});
   }
 }
 
 export function getObservableApiHost(env = process.env): URL {
-  const urlText = env["OBSERVABLEHQ_API_HOST"];
+  const urlText = env["OBSERVABLE_API_HOST"];
   if (urlText) {
     try {
       return new URL(urlText);
     } catch (error) {
-      throw new CliError(`Invalid OBSERVABLEHQ_API_HOST environment variable: ${error}`, {cause: error});
+      throw new CliError(`Invalid OBSERVABLE_API_HOST environment variable: ${error}`, {cause: error});
     }
   }
 

--- a/src/observableApiConfig.ts
+++ b/src/observableApiConfig.ts
@@ -23,7 +23,7 @@ export type ApiKey =
   | {source: "test"; key: string};
 
 export async function getObservableApiKey(logger: Logger = console): Promise<ApiKey> {
-  const envVar = "OBSERVABLEHQ_TOKEN";
+  const envVar = "OBSERVABLE_TOKEN";
   if (process.env[envVar]) {
     return {source: "env", envVar, key: process.env[envVar]};
   }

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -85,7 +85,7 @@ export async function rollupClient(clientPath: string, {minify = false} = {}): P
         exclude: [], // don’t exclude node_modules
         minify,
         define: {
-          "process.env.OBSERVABLEHQ_ORIGIN": JSON.stringify(String(getObservableUiHost()).replace(/\/$/, ""))
+          "process.env.OBSERVABLE_ORIGIN": JSON.stringify(String(getObservableUiHost()).replace(/\/$/, ""))
         }
       }),
       importMetaResolve()

--- a/test/javascript/databases-test.ts
+++ b/test/javascript/databases-test.ts
@@ -16,7 +16,7 @@ const snow2 = {
 };
 
 const env = {
-  OBSERVABLEHQ_DB_SECRET_snow2: Buffer.from(JSON.stringify(snow2), "utf-8").toString("base64")
+  OBSERVABLE_DB_SECRET_snow2: Buffer.from(JSON.stringify(snow2), "utf-8").toString("base64")
 };
 
 describe("resolveDatabase", () => {

--- a/test/observableApiClient-test.ts
+++ b/test/observableApiClient-test.ts
@@ -4,15 +4,15 @@ import {getObservableApiHost, getObservableUiHost} from "../src/observableApiCli
 
 describe("getObservableUiHost", () => {
   it("works", () => {
-    assert.deepEqual(getObservableUiHost({OBSERVABLEHQ_HOST: "https://example.com"}), new URL("https://example.com"));
+    assert.deepEqual(getObservableUiHost({OBSERVABLE_HOST: "https://example.com"}), new URL("https://example.com"));
   });
 
   it("throws an appropriate error for malformed URLs", () => {
     try {
-      getObservableUiHost({OBSERVABLEHQ_HOST: "bad url"});
+      getObservableUiHost({OBSERVABLE_HOST: "bad url"});
       assert.fail("expected error");
     } catch (error) {
-      CliError.assert(error, {message: /^Invalid OBSERVABLEHQ_HOST environment variable: /});
+      CliError.assert(error, {message: /^Invalid OBSERVABLE_HOST environment variable: /});
     }
   });
 });
@@ -20,33 +20,33 @@ describe("getObservableUiHost", () => {
 describe("getObservableApiHost", () => {
   it("works", () => {
     assert.deepEqual(
-      getObservableApiHost({OBSERVABLEHQ_API_HOST: "https://example.com"}),
+      getObservableApiHost({OBSERVABLE_API_HOST: "https://example.com"}),
       new URL("https://example.com")
     );
   });
 
   it("throws an appropriate error for malformed URLs", () => {
     try {
-      getObservableApiHost({OBSERVABLEHQ_API_HOST: "bad url"});
+      getObservableApiHost({OBSERVABLE_API_HOST: "bad url"});
       assert.fail("expected error");
     } catch (error) {
-      CliError.assert(error, {message: /^Invalid OBSERVABLEHQ_API_HOST environment variable: /});
+      CliError.assert(error, {message: /^Invalid OBSERVABLE_API_HOST environment variable: /});
     }
   });
 
-  it("prefers OBSERVABLEHQ_API_HOST", () => {
+  it("prefers OBSERVABLE_API_HOST", () => {
     assert.deepEqual(
       getObservableApiHost({
-        OBSERVABLEHQ_API_HOST: "https://example.com/api",
-        OBSERVABLEHQ_HOST: "https://example.com/ui"
+        OBSERVABLE_API_HOST: "https://example.com/api",
+        OBSERVABLE_HOST: "https://example.com/ui"
       }),
       new URL("https://example.com/api")
     );
   });
 
-  it("falls back to OBSERVABLEHQ_HOST", () => {
+  it("falls back to OBSERVABLE_HOST", () => {
     assert.deepEqual(
-      getObservableApiHost({OBSERVABLEHQ_API_HOST: "https://example.com/api"}),
+      getObservableApiHost({OBSERVABLE_API_HOST: "https://example.com/api"}),
       new URL("https://example.com/ui")
     );
   });


### PR DESCRIPTION
Standardize on a more user-memorable prefix. Are there any downstream things that need to be updated because of this?