### PR TITLE
Change commands in getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ After you’ve initialized your project, use the `preview` command to develop yo
 To start the preview server:
 
 ```sh
-yarn preview
+yarn dev
 ```
 
 Then visit <http://localhost:3000> to develop.


### PR DESCRIPTION
This changes the commands from `observable` to `yarn`. It also changes the final sentence to tell people about the project URL being printed by the deploy command rather than to go to the Observable main page.