### PR TITLE
Improve telemetry banner

### DIFF
--- a/test/telemetry-test.ts
+++ b/test/telemetry-test.ts
@@ -30,13 +30,13 @@ describe("telemetry", () => {
   it("shows a banner", async () => {
     const logger = new MockLogger();
     const telemetry = new Telemetry({
-      ...noopEffects,
+      env: {npm_config_user_agent: "yarn/1.22.10 npm/? node/v14.15.4 darwin x64"},
       logger,
       getPersistentId: async (name, generator = randomUUID) => generator()
     });
     telemetry.record({event: "build", step: "start", test: true});
     await telemetry.flush();
-    logger.assertExactErrors([/Attention.*telemetry.*https:\/\/cli.observablehq.com/s]);
+    logger.assertExactErrors([/Attention.*cli.observablehq.com.*OBSERVABLE_TELEMETRY_DISABLE=true/s]);
   });
 
   it("can be disabled", async () => {


### PR DESCRIPTION
Give telemetry disable instructions upfront. Tries to give you a context-aware command to re-run with. Wraps at 80 columns and formats more aesthetically.

Before
<img width="762" alt="Screenshot 2024-01-12 at 12 21 54 PM" src="https://github.com/observablehq/cli/assets/10444/c92afbe2-c92b-48ab-9b76-8a54468519d9">

After
<img width="762" alt="Screenshot 2024-01-12 at 11 19 26 AM" src="https://github.com/observablehq/cli/assets/10444/bff11bad-1e74-4221-a243-c74eb2f1eba9">

After after
<img width="762" alt="Screenshot 2024-01-12 at 1 42 09 PM" src="https://github.com/observablehq/cli/assets/10444/142efab8-672a-490a-ab77-426ae0aefb12">
