### PR TITLE
alter getting started section for early access

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-The Observable CLI is a Node.js application and is published to npm as [`@observablehq/cli`](https://www.npmjs.com/package/@observablehq/cli). As the name suggests, the CLI lives on the command line; the instructions below are intended to run in your [terminal](https://support.apple.com/guide/terminal/open-or-quit-terminal-apd5265185d-f365-44cb-8b09-71a064a42125/mac). You’ll need to install [Node.js 20 or later](https://nodejs.org/) before you can install the CLI.
+The Observable CLI is a Node.js application<!-- and is published to npm as [`@observablehq/cli`](https://www.npmjs.com/package/@observablehq/cli)-->. As the name suggests, the CLI lives on the command line; the instructions below are intended to run in your [terminal](https://support.apple.com/guide/terminal/open-or-quit-terminal-apd5265185d-f365-44cb-8b09-71a064a42125/mac). You’ll need to install [Node.js 20 or later](https://nodejs.org/) before you can install the CLI.
 
 ## Installing
 
@@ -10,7 +10,7 @@ We recommend starting with our default project template <!-- https://github.com/
 yarn --version
 ```
 
-Otherwise, or if some later version of Yarn is installed, you can install Yarn via npm:
+Otherwise, or if some other version of Yarn is installed, you can install Yarn via npm:
 
 ```sh
 npm install --global yarn
@@ -18,7 +18,7 @@ npm install --global yarn
 
 See the [Yarn 1.x installation instructions](https://classic.yarnpkg.com/docs/install) for details.
 
-Once Yarn is installed, you can install `observablehq-create`, the project template. This package won’t be made publicly available until the Observable CLI is released, so the command below uses an access token to download it from our private repo. Please do not share this token with anyone outside the Early Access program.
+Once Yarn is installed, you can install `observablehq-create`, our project template. This package won’t be made publicly available until the Observable CLI is released, so the command below uses an access token to download it from our private repo. Please do not share this token with anyone outside the Early Access program.
 
 ```sh
 yarn global add https://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@github.com/observablehq/create
@@ -40,7 +40,7 @@ After answering a few questions, this command will create a new project folder i
 
 ## Project structure
 
-A typical project might look like this:
+A typical project looks like this:
 
 ```
 .
@@ -124,7 +124,11 @@ To deploy your project to Observable:
 yarn deploy
 ```
 
-Once done, the command will print the URL where you can view your project on the Observable Cloud. It will follow the pattern, `https://observablehq.com/@<workspace>/<project-slug>`.
+Once done, the command will print the URL where you can view your project on the Observable Cloud. It will follow this pattern:
+
+```
+https://observablehq.com/@<workspace>/<project-slug>
+```
 
 ## Advanced usage
 


### PR DESCRIPTION
this changes the [getting started](https://cli.observablehq.com/getting-started) documentation to better dovetail with the instructions provided to the EA and ambassador users.  when the cli goes public we will restore the doc as per #532.

fixes #529.