### PR TITLE
fix .ts import, again

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -70,7 +70,7 @@ export async function rollupClient(clientPath: string, {minify = false} = {}): P
 // rewrite the import back to what it was supposed to be. This is a dirty hack
 // but it gets the job done. 🤷 https://github.com/observablehq/cli/issues/478
 function rewriteTypeScriptImports(code: string): string {
-  return code.replace(/(?<=\bimport\('[\w./]+)\.ts(?='\))/g, ".js");
+  return code.replace(/(?<=\bimport\(([`'"])[\w./]+)\.ts(?=\1\))/g, ".js");
 }
 
 function importResolve(clientPath: string): Plugin {


### PR DESCRIPTION
When minified, the code looks like

```js
import("./stdlib/dash.ts")
```

When not minified, the code looks like

```js
import('./stdlib/dash.ts')
```

I only detected single quotes before, so now we handle both. (I should really use a parser here… and maybe have a test, but let’s go with this for now.)