### PR TITLE
add grid class documentation

### DIFF
--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -9,8 +9,6 @@ The CLI provides a set of grid CSS classes to help layout page content. These gr
 
 To see these examples change dynamically, adjust the page width or collapse the sidebar on the left.
 
-As with any CSS provided by the CLI, you can mix in standard CSS to customize pages.
-
 ## Classes
 
 The following CSS classes are provided for grid layouts:


### PR DESCRIPTION
add documentation for the grid CSS classes.  i'm not sure if we want to use the js echo for the example code.

<img width="663" alt="image" src="https://github.com/observablehq/cli/assets/12802394/fae1143f-f55b-4e1b-9f87-f353170f730e">

i worry that that it will nudge them to use the hypertext literal when they might not need to.  i could duplicate the example code into fenced blocks and not use echo, but then we have two copies of the code.

here is how the full page renders.

![image](https://github.com/observablehq/cli/assets/12802394/1386b42b-159c-45c8-bb39-42e490206a5d)
