### PR TITLE
robust title escaping

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -66,6 +66,7 @@ export async function create({output = ""}: {output?: string}, effects: CreateEf
   const context = {
     projectDir,
     ...results,
+    projectTitleString: JSON.stringify(results.projectTitle),
     devInstructions: devDirections.map((l) => `$ ${l}`).join("\n")
   };
 

--- a/templates/default/observablehq.config.ts.tmpl
+++ b/templates/default/observablehq.config.ts.tmpl
@@ -1,7 +1,7 @@
 // See https://cli.observablehq.com/config for documentation.
 export default {
   // The project’s title; used in the sidebar and webpage titles.
-  title: "{{ projectTitle }}",
+  title: {{ projectTitleString }},
 
   // The pages and sections in the sidebar. (If you comment this out, all pages
   // will be listed in alphabetical order. Listing pages explicitly lets you


### PR DESCRIPTION
Alternative to part of #587. The key with escaping is to know the “type” of the string. In some contexts, the type might be (human-readable) text, in others, it needs to be (JSON or JavaScript) code. You can’t safely escape text by wrapping it in double quotes, and the template language doesn’t provide the ability to escape or invoke arbitrary code, so to make this safe we have to provide an already-escaped value that is suitable for interpolation into code.