### PR TITLE
fix typo on filter in python example

### DIFF
--- a/examples/python/docs/index.md
+++ b/examples/python/docs/index.md
@@ -47,7 +47,7 @@ const predictions = FileAttachment("data/predictions.csv").csv({typed: true});
 ## Analysis
 
 ```js
-const misclassified = predictions.filter((d) => d.species !== d.speciecs_predicted);
+const misclassified = predictions.filter((d) => d.species !== d.species_predicted);
 ```
 
 The logistic regression failed to classify ${misclassified.length} individuals. Let’s check what was amiss, with this faceted chart:


### PR DESCRIPTION
Small typo in the filter for counting the number of wrong predictions. 