### PR TITLE
link from template to documentation

### DIFF
--- a/templates/default/docs/index.md
+++ b/templates/default/docs/index.md
@@ -48,7 +48,7 @@ toc: false
 <div class="hero">
   <h1>Hello, Observable Framework</h1>
   <h2>Welcome to your new project! Edit&nbsp;<code style="font-size: 90%;">docs/index.md</code> to change this page.</h2>
-  <a href="./getting-started" target="_blank">Get started<span style="display: inline-block; margin-left: 0.25rem;">↗︎</span></a>
+  <a href="https://observablehq.com/framework/getting-started" target="_blank">Get started<span style="display: inline-block; margin-left: 0.25rem;">↗︎</span></a>
 </div>
 
 <div class="grid grid-cols-2" style="grid-auto-rows: 504px;">


### PR DESCRIPTION
The link in the template must show the actual documentation page, not the local server which might or might not have it.