### PR TITLE
observable analytics

### DIFF
--- a/docs/.eslintrc.json
+++ b/docs/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "browser": true
+  }
+}

--- a/docs/analytics.js
+++ b/docs/analytics.js
@@ -1,0 +1,39 @@
+let queue = [];
+let user;
+
+if (location.origin === "https://observablehq.com") {
+  emit({
+    type: "pageLoad",
+    event_version: 1,
+    data: {referrer: document.referrer.replace(/\?.*/, "")},
+    tags: {}
+  });
+
+  fetch("https://api.observablehq.com/user", {credentials: "include"})
+    .then((response) => (response.ok ? response.json() : null))
+    .then((u) => (user = u), () => (user = null))
+    .then(() => (sendEvents(queue), (queue = null))); // prettier-ignore
+}
+
+function emit(event) {
+  event.time = new Date().toISOString();
+  event.location = `${location.origin}${location.pathname}${location.search}`; // drop hash
+  if (queue) queue.push(event);
+  else sendEvents([event]);
+}
+
+function sendEvents(events) {
+  if (!events.length) return;
+  navigator.sendBeacon(
+    "https://events.observablehq.com/beacon-events",
+    JSON.stringify({
+      events: events.map((event) => ({
+        ...event,
+        release: null,
+        user_id: user?.id ?? null,
+        user_agent: navigator.userAgent
+      })),
+      send_time: new Date().toISOString()
+    })
+  );
+}

--- a/observablehq.config.ts
+++ b/observablehq.config.ts
@@ -99,6 +99,7 @@ export default {
     },
     {name: "Contributing", path: "/contributing"}
   ],
+  scripts: [{type: "module", async: true, src: "analytics.js"}],
   head: `<link rel="apple-touch-icon" href="https://static.observablehq.com/favicon-512.0667824687f99c942a02e06e2db1a060911da0bf3606671676a255b1cf97b4fe.png">
 <link rel="icon" type="image/png" href="https://static.observablehq.com/favicon-512.0667824687f99c942a02e06e2db1a060911da0bf3606671676a255b1cf97b4fe.png" sizes="512x512">
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>

--- a/src/build.ts
+++ b/src/build.ts
@@ -97,6 +97,13 @@ export async function build(
     if (style && !styles.some((s) => styleEquals(s, style))) styles.push(style);
   }
 
+  // Add imported local scripts.
+  for (const script of config.scripts) {
+    if (!/^\w+:/.test(script.src)) {
+      imports.push(script.src);
+    }
+  }
+
   // Generate the client bundles.
   if (addPublic) {
     for (const [entry, name] of clientBundles(clientEntry)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,12 +25,19 @@ export type Style =
   | {path: string} // custom stylesheet
   | {theme: string[]}; // zero or more named theme
 
+export interface Script {
+  src: string;
+  async: boolean;
+  type: string | null;
+}
+
 export interface Config {
   root: string; // defaults to docs
   output: string; // defaults to dist
   title?: string;
   pages: (Page | Section)[]; // TODO rename to sidebar?
   pager: boolean; // defaults to true
+  scripts: Script[]; // defaults to empty array
   head: string; // defaults to empty string
   header: string; // defaults to empty string
   footer: string; // defaults to “Built with Observable on [date].”
@@ -83,6 +90,7 @@ export async function normalizeConfig(spec: any = {}, defaultRoot = "docs"): Pro
     style,
     theme = "default",
     deploy,
+    scripts = [],
     head = "",
     header = "",
     footer = `Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="${formatIsoDate(
@@ -98,16 +106,26 @@ export async function normalizeConfig(spec: any = {}, defaultRoot = "docs"): Pro
   if (title !== undefined) title = String(title);
   pages = Array.from(pages, normalizePageOrSection);
   pager = Boolean(pager);
+  scripts = Array.from(scripts, normalizeScript);
   head = String(head);
   header = String(header);
   footer = String(footer);
   toc = normalizeToc(toc);
   deploy = deploy ? {workspace: String(deploy.workspace).replace(/^@+/, ""), project: String(deploy.project)} : null;
-  return {root, output, title, pages, pager, head, header, footer, toc, style, deploy};
+  return {root, output, title, pages, pager, scripts, head, header, footer, toc, style, deploy};
 }
 
 function normalizeTheme(spec: any): string[] {
   return resolveTheme(typeof spec === "string" ? [spec] : spec === null ? [] : Array.from(spec, String));
+}
+
+function normalizeScript(spec: any): Script {
+  if (typeof spec === "string") spec = {src: spec};
+  let {src, async = false, type} = spec;
+  src = String(src);
+  async = Boolean(async);
+  type = type == null ? null : String(type);
+  return {src, async, type};
 }
 
 function normalizePageOrSection(spec: any): Page | Section {

--- a/test/config-test.ts
+++ b/test/config-test.ts
@@ -19,6 +19,7 @@ describe("readConfig(undefined, root)", () => {
       title: undefined,
       toc: {label: "On this page", show: true},
       pager: true,
+      scripts: [],
       head: "",
       header: "",
       footer:
@@ -38,6 +39,7 @@ describe("readConfig(undefined, root)", () => {
       title: undefined,
       toc: {label: "Contents", show: true},
       pager: true,
+      scripts: [],
       head: "",
       header: "",
       footer:


### PR DESCRIPTION
Adds a new **scripts** option to the config allowing you to specify scripts to include across all pages. Adopts this feature for first-party analytics. Note that since Framework is a multi-page app, we only have `pageLoad` events; we never emit `routeChanged` events. I haven’t documented the **scripts** option yet, but I figure we can add that as a followup if we want to support this functionality for other users.