### PR TITLE
css

### DIFF
--- a/src/client/stdlib/css.ts
+++ b/src/client/stdlib/css.ts
@@ -1,0 +1,11 @@
+export default function css({raw: strings}) {
+  let string = strings[0];
+  for (let i = 1, n = arguments.length; i < n; ++i) {
+    const value = arguments[i]; // eslint-disable-line prefer-rest-params
+    if (value != null) string += `${value}`;
+    string += strings[i];
+  }
+  const style = document.createElement("style");
+  style.textContent = string;
+  return style;
+}

--- a/src/client/stdlib/recommendedLibraries.js
+++ b/src/client/stdlib/recommendedLibraries.js
@@ -2,6 +2,7 @@ export const _ = () => import("npm:lodash").then((lodash) => lodash.default);
 export const aq = () => import("npm:arquero");
 export const Arrow = () => import("npm:apache-arrow");
 export const d3 = () => import("npm:d3");
+export const css = () => import("observablehq:stdlib/css").then((css) => css.default); // TODO move to htl?
 export const dot = () => import("observablehq:stdlib/dot").then((dot) => dot.default);
 export const duckdb = () => import("npm:@duckdb/duckdb-wasm");
 export const DuckDBClient = () => import("observablehq:stdlib/duckdb").then((duckdb) => duckdb.DuckDBClient);

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -91,6 +91,8 @@ function getLiveSource(content: string, tag: string): string | undefined {
     ? transpileTag(content, "html", true)
     : tag === "svg"
     ? transpileTag(content, "svg", true)
+    : tag === "css"
+    ? transpileTag(content, "css", true)
     : tag === "dot"
     ? transpileTag(content, "dot", false)
     : tag === "mermaid"


### PR DESCRIPTION
Fixes #666. Not sure there’s a lot of value here (especially relative to #597), but it’s easy to do. My silly test case:

````html

```css
body {
  color: hsl(${x}, 50%, 50%);
}
```

```js
const x = Generators.observe((notify) => {
  notify(0);
  const pointermove = (event) => notify(event.clientX);
  addEventListener("pointermove", pointermove);
  return () => removeEventListener("pointermove", pointermove);
});
```
````