### PR TITLE
remove deploy section from config template

### DIFF
--- a/templates/empty/observablehq.config.ts.tmpl
+++ b/templates/empty/observablehq.config.ts.tmpl
@@ -14,16 +14,7 @@ export default {
   //       {name: "Report", path: "/example-report"}
   //     ]
   //   }
-  // ]
-
-  // How to deploy to the Observable Cloud. Replace the workspace field below to
-  // point to your Observable workspace (the part after the “@”), and set the
-  // project field to your project’s desired slug. If you haven’t deployed this
-  // project before, one will be created automatically on deploy.
-  // deploy: {
-  //   workspace: "my-observablehq-workspace",
-  //   project: "my-project-slug"
-  // },
+  // ],
 
   // Some additional configuration options and their defaults:
   // theme: "default", // try "light", "dark", "slate", etc.


### PR DESCRIPTION
In https://github.com/observablehq/framework/pull/634, the target deploy workspace and slug are now read from `deploy.json` instead of `observablehq.config.ts`