### PR TITLE
Don’t allow Starter tier to deploy too many projects

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -325,6 +325,12 @@ async function promptDeployTarget(
     });
     if (clack.isCancel(chosenProject)) {
       throw new CliError("User cancelled deploy.", {print: false, exitCode: 0});
+    } else if (chosenProject === null && workspace.tier === "starter_2024") {
+      effects.clack.log.error(
+        `The Starter tier can only deploy one project. Upgrade to unlimited projects at ${underline(`https://observablehq.com/team/@${workspace.login}/settings`)}.`
+      );
+      effects.clack.outro(yellow("Deploy cancelled."));
+      throw new CliError("Deploy cancelled.", {print: false, exitCode: 0});
     } else if (chosenProject !== null) {
       return {create: false, workspace, project: existingProjects.find((p) => p.slug === chosenProject)!};
     }


### PR DESCRIPTION
Idk how best to approach this. Here’s the _status quo ante_ when you try to deploy to a workspace that’s at its cap:

<img width="749" alt="image" src="https://github.com/observablehq/framework/assets/841829/31d3eac7-17ff-44ec-8ee3-aebdf61c4702">

One approach is that, here, we should log an error if the error codes include TOO_MANY_PROJECTS:

https://github.com/observablehq/framework/blob/ab7b2429ac179d629cee2b0957fecf1d7230e780/src/observableApiClient.ts#L59-L74

But we don’t have all the clack & workspace context there, so it feels too low-level. Ok, so maybe it should return that code as part of the error, but then I feel like it wouldn’t be throwing an HttpError; maybe a new class? I chickened out of getting into that.

So instead, this PR adds a check in the deploy script. If you say you want a new project, but are on the Starter tier, it tells you you’re at your cap and exits:

<img width="1154" alt="1C6A5D62-AA43-43E1-9C2D-CB5C1BAC55F1-876-0003299505D1F8E4" src="https://github.com/observablehq/framework/assets/841829/d0e0d78e-fc74-443e-8e6b-fa01bc194b25">

This has its own issues: it leads you down a dead end by asking if you want to create a new project when you can’t. I tried instead replacing this question with a question like “You’re only allowed one project. Do you want to: [Use that project], [Upgrade for unlimited projects], [Cancel].” But that felt weird if you’re just trying to use your existing project and don’t care about the upsell. So maybe it’s fine to first capture the intent (creating a new project) that makes the cap relevant.

I was also unsure if this duplicates the business logic of TOO_MANY_PROJECTS too much, or if that should just be a backstop. Idk!!!