### PR TITLE
last modified fixes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -77,10 +77,10 @@ async function readPages(root: string): Promise<Page[]> {
   return pages;
 }
 
-let currentDate = new Date();
+globalThis.currentDate = new Date();
 
 export function setCurrentDate(date = new Date()): void {
-  currentDate = date;
+  globalThis.currentDate = date;
 }
 
 export async function normalizeConfig(spec: any = {}, defaultRoot = "docs"): Promise<Config> {
@@ -94,8 +94,8 @@ export async function normalizeConfig(spec: any = {}, defaultRoot = "docs"): Pro
     head = "",
     header = "",
     footer = `Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="${formatIsoDate(
-      currentDate
-    )}">${formatLocaleDate(currentDate)}</a>.`
+      globalThis.currentDate
+    )}">${formatLocaleDate(globalThis.currentDate)}</a>.`
   } = spec;
   root = String(root);
   output = String(output);

--- a/src/files.ts
+++ b/src/files.ts
@@ -31,7 +31,10 @@ export function fileReference(name: string, root: string, sourcePath: string): F
     name: relativeUrl(sourcePath, name),
     mimeType: mime.getType(name),
     path: relativeUrl(sourcePath, join("_file", name)),
-    lastModified: maybeLastModified(join(root, resolvePath(sourcePath, "/" + name)))
+    lastModified:
+      maybeLastModified(join(root, resolvePath(sourcePath, "/" + name))) ??
+      maybeLastModified(join(root, ".observablehq", "cache", resolvePath(sourcePath, "/" + name))) ??
+      +globalThis.currentDate
   };
 }
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -31,7 +31,7 @@ export function fileReference(name: string, root: string, sourcePath: string): F
     name: relativeUrl(sourcePath, name),
     mimeType: mime.getType(name),
     path: relativeUrl(sourcePath, join("_file", name)),
-    lastModified: maybeLastModified(join(root, resolvePath(sourcePath, name)))
+    lastModified: maybeLastModified(join(root, resolvePath(sourcePath, "/" + name)))
   };
 }
 

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -78,7 +78,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
         mimeType: "image/png",
         name: "./test.png",
         path: "./_file/test.png",
-        lastModified: undefined
+        lastModified: 1704963723000
       }
     ]);
   });
@@ -106,13 +106,13 @@ describe("normalizePieceHtml adds local file attachments", () => {
         mimeType: "image/jpeg",
         name: "./large.jpg",
         path: "./_file/large.jpg",
-        lastModified: undefined
+        lastModified: 1704963723000
       },
       {
         mimeType: "image/jpeg",
         name: "./small.jpg",
         path: "./_file/small.jpg",
-        lastModified: undefined
+        lastModified: 1704963723000
       }
     ]);
   });
@@ -133,7 +133,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
         mimeType: "video/quicktime",
         name: "./observable.mov",
         path: "./_file/observable.mov",
-        lastModified: undefined
+        lastModified: 1704963723000
       }
     ]);
   });
@@ -160,13 +160,13 @@ describe("normalizePieceHtml adds local file attachments", () => {
         mimeType: "video/mp4",
         name: "./observable.mp4",
         path: "./_file/observable.mp4",
-        lastModified: undefined
+        lastModified: 1704963723000
       },
       {
         mimeType: "video/quicktime",
         name: "./observable.mov",
         path: "./_file/observable.mov",
-        lastModified: undefined
+        lastModified: 1704963723000
       }
     ]);
   });
@@ -191,13 +191,13 @@ describe("normalizePieceHtml adds local file attachments", () => {
         mimeType: "image/png",
         name: "./observable-logo-narrow.png",
         path: "./_file/observable-logo-narrow.png",
-        lastModified: undefined
+        lastModified: 1704963723000
       },
       {
         mimeType: "image/png",
         name: "./observable-logo-wide.png",
         path: "./_file/observable-logo-wide.png",
-        lastModified: undefined
+        lastModified: 1704963723000
       }
     ]);
   });
@@ -238,7 +238,7 @@ describe("normalizePieceHtml only adds local files", () => {
         mimeType: "image/jpeg",
         name: "./small.jpg",
         path: "./_file/small.jpg",
-        lastModified: undefined
+        lastModified: 1704963723000
       }
     ]);
   });
@@ -265,7 +265,7 @@ describe("normalizePieceHtml only adds local files", () => {
         mimeType: "video/quicktime",
         name: "./observable.mov",
         path: "./_file/observable.mov",
-        lastModified: undefined
+        lastModified: 1704963723000
       }
     ]);
   });

--- a/test/output/build/archives/tar.html
+++ b/test/output/build/archives/tar.html
@@ -14,43 +14,43 @@
 
 import {define} from "./_observablehq/client.js";
 
-define({id: "d5134368", inputs: ["FileAttachment","display"], files: [{"name":"./static-tar/file.txt","mimeType":"text/plain","path":"./_file/static-tar/file.txt"}], body: async (FileAttachment,display) => {
+define({id: "d5134368", inputs: ["FileAttachment","display"], files: [{"name":"./static-tar/file.txt","mimeType":"text/plain","path":"./_file/static-tar/file.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("static-tar/file.txt").text()
 ))
 }});
 
-define({id: "a0c06958", inputs: ["FileAttachment","display"], files: [{"name":"./static-tgz/file.txt","mimeType":"text/plain","path":"./_file/static-tgz/file.txt"}], body: async (FileAttachment,display) => {
+define({id: "a0c06958", inputs: ["FileAttachment","display"], files: [{"name":"./static-tgz/file.txt","mimeType":"text/plain","path":"./_file/static-tgz/file.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("static-tgz/file.txt").text()
 ))
 }});
 
-define({id: "d84cd7fb", inputs: ["FileAttachment","display"], files: [{"name":"./static-tar/does-not-exist.txt","mimeType":"text/plain","path":"./_file/static-tar/does-not-exist.txt"}], body: async (FileAttachment,display) => {
+define({id: "d84cd7fb", inputs: ["FileAttachment","display"], files: [{"name":"./static-tar/does-not-exist.txt","mimeType":"text/plain","path":"./_file/static-tar/does-not-exist.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("static-tar/does-not-exist.txt").text()
 ))
 }});
 
-define({id: "86bd51aa", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic-tar/file.txt","mimeType":"text/plain","path":"./_file/dynamic-tar/file.txt"}], body: async (FileAttachment,display) => {
+define({id: "86bd51aa", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic-tar/file.txt","mimeType":"text/plain","path":"./_file/dynamic-tar/file.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("dynamic-tar/file.txt").text()
 ))
 }});
 
-define({id: "95938c22", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic-tar/does-not-exist.txt","mimeType":"text/plain","path":"./_file/dynamic-tar/does-not-exist.txt"}], body: async (FileAttachment,display) => {
+define({id: "95938c22", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic-tar/does-not-exist.txt","mimeType":"text/plain","path":"./_file/dynamic-tar/does-not-exist.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("dynamic-tar/does-not-exist.txt").text()
 ))
 }});
 
-define({id: "7e5740fd", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic-tar-gz/file.txt","mimeType":"text/plain","path":"./_file/dynamic-tar-gz/file.txt"}], body: async (FileAttachment,display) => {
+define({id: "7e5740fd", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic-tar-gz/file.txt","mimeType":"text/plain","path":"./_file/dynamic-tar-gz/file.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("dynamic-tar-gz/file.txt").text()
 ))
 }});
 
-define({id: "d0a58efd", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic-tar-gz/does-not-exist.txt","mimeType":"text/plain","path":"./_file/dynamic-tar-gz/does-not-exist.txt"}], body: async (FileAttachment,display) => {
+define({id: "d0a58efd", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic-tar-gz/does-not-exist.txt","mimeType":"text/plain","path":"./_file/dynamic-tar-gz/does-not-exist.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("dynamic-tar-gz/does-not-exist.txt").text()
 ))

--- a/test/output/build/archives/zip.html
+++ b/test/output/build/archives/zip.html
@@ -14,25 +14,25 @@
 
 import {define} from "./_observablehq/client.js";
 
-define({id: "d3b9d0ee", inputs: ["FileAttachment","display"], files: [{"name":"./static/file.txt","mimeType":"text/plain","path":"./_file/static/file.txt"}], body: async (FileAttachment,display) => {
+define({id: "d3b9d0ee", inputs: ["FileAttachment","display"], files: [{"name":"./static/file.txt","mimeType":"text/plain","path":"./_file/static/file.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("static/file.txt").text()
 ))
 }});
 
-define({id: "bab54217", inputs: ["FileAttachment","display"], files: [{"name":"./static/not-found.txt","mimeType":"text/plain","path":"./_file/static/not-found.txt"}], body: async (FileAttachment,display) => {
+define({id: "bab54217", inputs: ["FileAttachment","display"], files: [{"name":"./static/not-found.txt","mimeType":"text/plain","path":"./_file/static/not-found.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("static/not-found.txt").text()
 ))
 }});
 
-define({id: "11eec300", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic/file.txt","mimeType":"text/plain","path":"./_file/dynamic/file.txt"}], body: async (FileAttachment,display) => {
+define({id: "11eec300", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic/file.txt","mimeType":"text/plain","path":"./_file/dynamic/file.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("dynamic/file.txt").text()
 ))
 }});
 
-define({id: "ee2310f3", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic/not-found.txt","mimeType":"text/plain","path":"./_file/dynamic/not-found.txt"}], body: async (FileAttachment,display) => {
+define({id: "ee2310f3", inputs: ["FileAttachment","display"], files: [{"name":"./dynamic/not-found.txt","mimeType":"text/plain","path":"./_file/dynamic/not-found.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 await FileAttachment("dynamic/not-found.txt").text()
 ))

--- a/test/output/build/files/subsection/subfiles.html
+++ b/test/output/build/files/subsection/subfiles.html
@@ -13,13 +13,13 @@
 
 import {define} from "../_observablehq/client.js";
 
-define({id: "ef9a31ef", inputs: ["FileAttachment","display"], files: [{"name":"../file-top.csv","mimeType":"text/csv","path":"../_file/file-top.csv"}], body: async (FileAttachment,display) => {
+define({id: "ef9a31ef", inputs: ["FileAttachment","display"], files: [{"name":"../file-top.csv","mimeType":"text/csv","path":"../_file/file-top.csv","lastModified":1729072800000}], body: async (FileAttachment,display) => {
 display(await(
 FileAttachment("../file-top.csv")
 ))
 }});
 
-define({id: "834ecf9f", inputs: ["FileAttachment","display"], files: [{"name":"./file-sub.csv","mimeType":"text/csv","path":"../_file/subsection/file-sub.csv"}], body: async (FileAttachment,display) => {
+define({id: "834ecf9f", inputs: ["FileAttachment","display"], files: [{"name":"./file-sub.csv","mimeType":"text/csv","path":"../_file/subsection/file-sub.csv","lastModified":1729072800000}], body: async (FileAttachment,display) => {
 display(await(
 FileAttachment("file-sub.csv")
 ))

--- a/test/output/build/imports/foo/foo.html
+++ b/test/output/build/imports/foo/foo.html
@@ -20,7 +20,7 @@
 
 import {define} from "../_observablehq/client.js";
 
-define({id: "261e010e", inputs: ["display","FileAttachment"], outputs: ["d3","bar","top"], files: [{"name":"../top.js","mimeType":"application/javascript","path":"../_file/top.js"}], body: async (display,FileAttachment) => {
+define({id: "261e010e", inputs: ["display","FileAttachment"], outputs: ["d3","bar","top"], files: [{"name":"../top.js","mimeType":"application/javascript","path":"../_file/top.js","lastModified":1729072800000}], body: async (display,FileAttachment) => {
 const [d3, {bar}, {top}] = await Promise.all([import("https://cdn.jsdelivr.net/npm/d3@7.8.5/+esm"), import("../_import/bar/bar.js?sha=2e71da6918681d51fd9e7ed79b03aed514771c2e1583af42783665aff3f5ef5e"), import("../_import/top.js?sha=43e37c2a4fe9ca94e62d0d8acd5dbd8bdd5f0ec845503964f465979c4c82c2a3")]);
 
 display(bar);

--- a/test/output/build/missing-file/index.html
+++ b/test/output/build/missing-file/index.html
@@ -14,7 +14,7 @@
 
 import {define} from "./_observablehq/client.js";
 
-define({id: "5760fd93", inputs: ["FileAttachment","display"], files: [{"name":"./does-not-exist.txt","mimeType":"text/plain","path":"./_file/does-not-exist.txt"}], body: async (FileAttachment,display) => {
+define({id: "5760fd93", inputs: ["FileAttachment","display"], files: [{"name":"./does-not-exist.txt","mimeType":"text/plain","path":"./_file/does-not-exist.txt","lastModified":1704931200000}], body: async (FileAttachment,display) => {
 display(await(
 FileAttachment("does-not-exist.txt")
 ))

--- a/test/output/build/simple/simple.html
+++ b/test/output/build/simple/simple.html
@@ -14,7 +14,7 @@
 
 import {define} from "./_observablehq/client.js";
 
-define({id: "115586ff", inputs: ["FileAttachment"], outputs: ["result"], files: [{"name":"./data.txt","mimeType":"text/plain","path":"./_file/data.txt"}], body: (FileAttachment) => {
+define({id: "115586ff", inputs: ["FileAttachment"], outputs: ["result"], files: [{"name":"./data.txt","mimeType":"text/plain","path":"./_file/data.txt","lastModified":1704931200000}], body: (FileAttachment) => {
 let result = FileAttachment("data.txt").text();
 return {result};
 }});

--- a/test/output/fetch-parent-dir.json
+++ b/test/output/fetch-parent-dir.json
@@ -5,7 +5,8 @@
     {
       "name": "./NOENT.md",
       "mimeType": "text/markdown",
-      "path": "./_file/NOENT.md"
+      "path": "./_file/NOENT.md",
+      "lastModified": 1704963723000
     },
     {
       "name": "./tex-expression.md",
@@ -88,7 +89,8 @@
         {
           "name": "./NOENT.md",
           "mimeType": "text/markdown",
-          "path": "./_file/NOENT.md"
+          "path": "./_file/NOENT.md",
+          "lastModified": 1704963723000
         }
       ],
       "body": "(FileAttachment) => {\nconst fail3 = FileAttachment(\"./NOENT.md\").text()\nreturn {fail3};\n}"

--- a/test/output/template-file-attachment.js
+++ b/test/output/template-file-attachment.js
@@ -1,3 +1,3 @@
-define({id: "0", inputs: ["FileAttachment"], files: [{"name":"./test.js","mimeType":"application/javascript","path":"./_file/test.js"}], body: (FileAttachment) => {
+define({id: "0", inputs: ["FileAttachment"], files: [{"name":"./test.js","mimeType":"application/javascript","path":"./_file/test.js","lastModified":1704963723000}], body: (FileAttachment) => {
 FileAttachment(`test.js`);
 }});


### PR DESCRIPTION
Addresses two issues with #697 :

1. fix for files called from subfolders (_e.g._ `FileAttachment("volcano.json")` in [javascript/files](http://127.0.0.1:3000/javascript/files). The only change for this issue is to add "/" to the path (and fix relevant tests).
2. support lastModified for data loaders

Point 2 is more tricky and might need a bit more thought. At the time when we compute the file reference, the data loaders may have already run or not. We can't look into the future and know when they'll finish running—nor for that matter be sure they'll ever run successfully. If there is a cached filed already, we can't be sure it's going to be fresh or not.

So, this uses a best guess: if the file already has a cached version, lastModified is the date of that cached file. If not, lastModified is _currentDate_ (which is a mock date for unit tests, and the time the process was started for preview and for build).

This best guess is, I think, good enough for preview. However it means that we'll report a `file.lastModified` that in some cases will be optimistic, because the file might be actually built a few moments (minutes) later. This could be considered as a bug when you build the project and you see that the lastModified time reported in a file is _before_ the time returned by, say, an API call made by the data loader.

I don't worry about that too much, but if we wanted to use the true filemtime of the built assets, we'd need to re-run the build of those pages after all the data loaders have run (if any of them was not fresh), so that on the second run they use the cache and get the correct filemtime. I'm not sure it's worth adding that complexity, in the sense that, if that really matters for your application, you can run `yarn build` twice. But we could do that, if we decide it's important, or alternatively do some bookkeeping with a list of files where the actual file dates will need to be updated post-data loaders.

Another way of “fixing” this would be to name this property in a more generic way that doesn't imply a contract about the "last modification date". If we called it `time`, `timestamp`, `ts`, or `date` we could define the contract on our own terms: “`ts` represents the last time this file was modified or, in the case of data loaders, the last time they ran or were scheduled to run” (or something less verbose).