### PR TITLE
open the browser when running yarn dev — unless it's a tsx restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "observable": "bin/observable-init.js"
   },
   "scripts": {
-    "dev": "rm -f docs/themes.md docs/theme/*.md && (tsx watch docs/theme/generate-themes.ts & tsx watch --no-warnings=ExperimentalWarning ./bin/observable.ts preview)",
+    "dev": "export TS=`date +%s` && rm -f docs/themes.md docs/theme/*.md && (tsx watch docs/theme/generate-themes.ts & tsx watch --no-warnings=ExperimentalWarning ./bin/observable.ts preview)",
     "build": "yarn rebuild-themes && rm -rf dist && tsx --no-warnings=ExperimentalWarning ./bin/observable.ts build",
     "deploy": "yarn rebuild-themes && tsx --no-warnings=ExperimentalWarning ./bin/observable.ts deploy",
     "rebuild-themes": "rm -f docs/themes.md docs/theme/*.md && tsx docs/theme/generate-themes.ts",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -7,6 +7,7 @@ import type {IncomingMessage, RequestListener, Server, ServerResponse} from "nod
 import {basename, dirname, extname, join, normalize} from "node:path";
 import {fileURLToPath} from "node:url";
 import {difference} from "d3-array";
+import open from "open";
 import send from "send";
 import {type WebSocket, WebSocketServer} from "ws";
 import {version} from "../package.json";
@@ -72,11 +73,18 @@ export class PreviewServer {
     } else {
       await new Promise<void>((resolve) => server.listen(port, hostname, resolve));
     }
+    const url = `http://${hostname}:${port}/`;
     if (verbose) {
       console.log(`${green(bold("Observable Framework"))} ${faint(`v${version}`)}`);
-      console.log(`${faint("↳")} ${link(`http://${hostname}:${port}/`)}`);
+      console.log(`${faint("↳")} ${link(url)}`);
       console.log("");
+      // If the preview server has just been started, try to open the page in a
+      // browser. This relies on the TS environment variable being set by the dev
+      // script. Does not open for test or when TS is old (e.g. we've just
+      // restarted due to tsx watch).
+      if (process.env.TS && +new Date() - 1000 * +process.env.TS < 2000) open(url);
     }
+
     return new PreviewServer({server, verbose, ...options});
   }
 


### PR DESCRIPTION
closes #91
much simpler alternative to #499