### PR TITLE
revert duckdb-wasm version pinning

### DIFF
--- a/src/javascript/imports.ts
+++ b/src/javascript/imports.ts
@@ -336,7 +336,6 @@ async function resolveNpmVersion(specifier: string): Promise<string> {
   const {name, range} = parseNpmSpecifier(specifier); // ignore path
   specifier = formatNpmSpecifier({name, range});
   const search = range ? `?specifier=${range}` : "";
-  if (name === "@duckdb/duckdb-wasm" && !range) return "1.28.0"; // https://github.com/duckdb/duckdb-wasm/issues/1561
   const {version} = (await cachedFetch(`https://data.jsdelivr.com/v1/packages/npm/${name}/resolved${search}`)).body;
   if (!version) throw new Error(`unable to resolve version: ${specifier}`);
   return version;


### PR DESCRIPTION
version 1.28.1 works again (and supports the spatial extension!)

reverts https://github.com/observablehq/framework/pull/519

test https://observablehq.observablehq.cloud/duckdb-spatial/