### PR TITLE
ensure the Neighboring country interchange chart always has ticks

### DIFF
--- a/examples/eia/docs/components/charts.js
+++ b/examples/eia/docs/components/charts.js
@@ -52,8 +52,8 @@ export function countryInterchangeChart(width, height, usDemandGenForecast, coun
     height: height - 50,
     color: {legend: true, range: ["#B6B5B1", "#848890"]},
     grid: true,
-    y: {label: "GWh exported", labelOffset: 0, tickSize: 0},
     x: {type: "time", domain: extent(usDemandGenForecast.map((d) => d.date)), tickSize: 0, tickPadding: 3},
+    y: {label: "GWh exported", labelOffset: 0, tickSize: 0, tickSpacing: 20},
     marks: [
       Plot.ruleX([currentHour], {strokeOpacity: 0.5}),
       Plot.areaY(countryInterchangeSeries, {


### PR DESCRIPTION
At a certain width just before the responsive breakpoint we had this situation:

| before | after |
| --- | --- |
| ![before](https://github.com/observablehq/framework/assets/7001/2ef4fa25-3e50-4b9a-9d00-86d9c6ebb956) | ![after](https://github.com/observablehq/framework/assets/7001/1547c43b-5ae1-40b4-ac1f-a54fb42a7b27) |


filed as a generic Plot issue in https://github.com/observablehq/plot/issues/1988