### PR TITLE
ignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .DS_Store
 **/.observablehq/cache/
 coverage/


### PR DESCRIPTION
This moves the `.env` ignore up to the top level of the repo to mitigate against accidental commits in the future.