### PR TITLE
quakes.csv.go was left out of the data loaders list

### DIFF
--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -144,6 +144,7 @@ For example, for the file `quakes.csv`, the following data loaders are considere
 - `quakes.csv.py`
 - `quakes.csv.R`
 - `quakes.csv.rs`
+- `quakes.csv.go`
 - `quakes.csv.sh`
 - `quakes.csv.exe`
 


### PR DESCRIPTION
Added the missing `quake.csv.go` entry to the list of data loaders.