### PR TITLE
bug fixes for search

### DIFF
--- a/src/client/search.js
+++ b/src/client/search.js
@@ -43,7 +43,7 @@ input.addEventListener("input", () => {
 function renderResult({id, score, title}, i) {
   return `<li data-score="${Math.min(5, Math.round(0.6 * score))}" class="observablehq-link${
     i === 0 ? ` ${activeClass}` : ""
-  }"><a href="${escapeDoubleQuote(import.meta.resolve(`../${id}`))}">${escapeText(title ?? "—")}</a></li>`;
+  }"><a href="${escapeDoubleQuote(import.meta.resolve(`../${id}`))}">${escapeText(String(title ?? "—"))}</a></li>`;
 }
 
 function escapeDoubleQuote(text) {

--- a/src/client/search.js
+++ b/src/client/search.js
@@ -43,7 +43,7 @@ input.addEventListener("input", () => {
 function renderResult({id, score, title}, i) {
   return `<li data-score="${Math.min(5, Math.round(0.6 * score))}" class="observablehq-link${
     i === 0 ? ` ${activeClass}` : ""
-  }"><a href="${escapeDoubleQuote(import.meta.resolve(`../${id}`))}">${escapeText(title)}</a></li>`;
+  }"><a href="${escapeDoubleQuote(import.meta.resolve(`../${id}`))}">${escapeText(title ?? "—")}</a></li>`;
 }
 
 function escapeDoubleQuote(text) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -30,7 +30,7 @@ export async function searchIndex(config: Config, effects = defaultEffects): Pro
   if (indexCache.has(config) && indexCache.get(config).freshUntil > +new Date()) return indexCache.get(config).json;
 
   // Get all the listed pages (which are indexed by default)
-  const pagePaths = new Set();
+  const pagePaths = new Set(["/index"]);
   for (const p of pages) {
     if ("path" in p) pagePaths.add(p.path);
     else for (const {path} of p.pages) pagePaths.add(path);


### PR DESCRIPTION
- add the home page to the default list of indexable pages
  - even though it's not in pages, it's not ‘unlisted’
  - one can still opt out with index: false, as we do for this documentation

closes #815


- support empty titles (replaced with a emdash), and titles such as numbers



you can test this by adding this to a listed and indexed page:

```
---
title: 3.141592
---

# Happi as π


```

then if you searched for "happi" you would see the client error in the console (and no result was displayed) as it was trying to apply the escaping code to a Number.
