### PR TITLE
add support for java data loaders

### DIFF
--- a/docs/HelloJava.txt.java
+++ b/docs/HelloJava.txt.java
@@ -1,0 +1,5 @@
+public class HelloJava {
+  public static void main(String[] args) {
+    System.out.println("Hello, world!");
+  }
+}

--- a/docs/data/ForecastJava.json.java
+++ b/docs/data/ForecastJava.json.java
@@ -1,0 +1,43 @@
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+// requires gson in the classpath. For instance, have the following env var set:
+// export CLASSPATH=/Users/<YOUR_USER_NAME>/.m2/repository/com/google/code/gson/gson/2.8.6/gson-2.8.6.jar
+public class ForecastJava {
+
+  public static void main(String[] args) {
+    double latitude = 37.80;
+    double longitude = -122.47;
+
+    try {
+      JsonObject station = getJson("https://api.weather.gov/points/" + latitude + "," + longitude);
+      JsonObject properties = station.getAsJsonObject("properties");
+      String forecastUrl = properties.getAsJsonPrimitive("forecastHourly").getAsString();
+      JsonObject forecast = getJson(forecastUrl);
+
+      System.out.println(forecast);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static JsonObject getJson(String url) throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    connection.setRequestMethod("GET");
+    connection.setRequestProperty("Accept", "application/json");
+
+    try (InputStream inputStream = connection.getInputStream();
+        InputStreamReader reader = new InputStreamReader(inputStream)) {
+
+      return JsonParser.parseReader(reader).getAsJsonObject();
+    } finally {
+      connection.disconnect();
+    }
+  }
+}

--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -134,6 +134,7 @@ Data loaders live in the source root (typically `docs`) alongside your other sou
 - `.R` - R (`Rscript`)
 - `.rs` - Rust (`rust-script`)
 - `.go` - Go (`go run`)
+- `.java` - Java >=11 (`java`)
 - `.sh` - shell script (`sh`)
 - `.exe` - arbitrary executable
 
@@ -145,12 +146,13 @@ For example, for the file `quakes.csv`, the following data loaders are considere
 - `quakes.csv.R`
 - `quakes.csv.rs`
 - `quakes.csv.go`
+- `quakes.csv.java`
 - `quakes.csv.sh`
 - `quakes.csv.exe`
 
-If you use `.py`, `.R`, `.rs`, or `.go`, the corresponding interpreter (`python3`, `Rscript`, `rust-script`, or `go run`, respectively) must be installed and available on your `$PATH`. Any additional modules, packages, libraries, _etc._, must also be installed before you can use them.
+If you use `.py`, `.R`, `.rs`, `.go` or `java`, the corresponding interpreter (`python3`, `Rscript`, `rust-script`, `go run` or `java`, respectively) must be installed and available on your `$PATH`. Any additional modules, packages, libraries, _etc._, must also be installed before you can use them.
 
-Whereas `.js`, `.ts`, `.py`, `.R`, `.rs`, `.go`, and `.sh` data loaders are run via interpreters, `.exe` data loaders are run directly and must have the executable bit set. This is typically done via [`chmod`](https://en.wikipedia.org/wiki/Chmod). For example:
+Whereas `.js`, `.ts`, `.py`, `.R`, `.rs`, `.go`, `.java` and `.sh` data loaders are run via interpreters, `.exe` data loaders are run directly and must have the executable bit set. This is typically done via [`chmod`](https://en.wikipedia.org/wiki/Chmod). For example:
 
 ```sh
 chmod +x docs/quakes.csv.exe

--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -19,6 +19,7 @@ const languages = {
   ".R": ["Rscript"],
   ".rs": ["rust-script"],
   ".go": ["go", "run"],
+  ".java": ["java"],
   ".sh": ["sh"],
   ".exe": []
 };


### PR DESCRIPTION
Add support for java data loaders as discussed here:
https://github.com/observablehq/framework/issues/831

I put a [ForecastJava.json.java](https://github.com/observablehq/framework/compare/main...cyrilou242:framework:main#diff-e5a7882f72679fb0b6628ef66848b4597d6eeaa55e6793b2ab79897491c16df7) to have an example of how to load json in java. It's not used anywhere but it's easy to try be replacing in the getting started 
```
const forecast = FileAttachment("./data/forecast.json").json();
```

by 
```
const forecast = FileAttachment("./data/ForecastJava.json").json();
```
Can be removed if it's not helpful.