### PR TITLE
no process.env.{HOSTNAME,PORT}

### DIFF
--- a/bin/observable.ts
+++ b/bin/observable.ts
@@ -128,11 +128,10 @@ try {
           ...CONFIG_OPTION,
           host: {
             type: "string",
-            default: process.env.HOSTNAME ?? "127.0.0.1"
+            default: "127.0.0.1"
           },
           port: {
-            type: "string",
-            default: process.env.PORT
+            type: "string"
           },
           open: {
             type: "boolean",

--- a/test/preview/preview-test.ts
+++ b/test/preview/preview-test.ts
@@ -6,8 +6,8 @@ import type {PreviewOptions, PreviewServer} from "../../src/preview.js";
 import {mockJsDelivr} from "../mocks/jsdelivr.js";
 
 const testHostRoot = "test/preview/dashboard";
-const testHostName = process.env.TEST_HOSTNAME ?? "127.0.0.1";
-const testPort = +(process.env.TEST_PORT ?? 8080);
+const testHostName = "127.0.0.1";
+const testPort = 3000;
 
 const testServerOptions: PreviewOptions = {
   config: await normalizeConfig({root: testHostRoot}),


### PR DESCRIPTION
Ref. https://github.com/observablehq/framework/issues/90#issuecomment-1950294898