### PR TITLE
fix implicit display documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -385,7 +385,11 @@ This looks like:
   <figcaption>Using <code>FileAttachment</code> to load data.</figcaption>
 </figure>
 
-The built-in [`display`](./javascript/display) function displays the specified value, a bit like `console.log` in the browser’s console. As you may have noticed above with <code class="language-js">1 + 2</code>, `display` is called implicitly when a code block contains an expression.
+The built-in [`display`](./javascript/display) function displays the specified value, a bit like `console.log` in the browser’s console. As you can see below, `display` is called [implicitly](./javascript/display#implicit-display) when a code block contains an expression:
+
+```js echo
+1 + 2
+```
 
 For convenience, here’s a copy of the data so you can explore it here:
 


### PR DESCRIPTION
closes #864
![f](https://github.com/observablehq/framework/assets/7001/4e173fc7-e89e-4dd3-9978-d93cc28e110f)
