### PR TITLE
save search query, and restore on cmd-K

### DIFF
--- a/src/client/search-init.ts
+++ b/src/client/search-init.ts
@@ -23,6 +23,7 @@ addEventListener("keydown", (event) => {
     // persistently after you blur the search input.)
     toggle.classList.add("observablehq-sidebar-open");
     input.focus();
+    input.value = sessionStorage.getItem("search-query") ?? "";
     input.select();
     event.preventDefault();
   }

--- a/src/client/search.js
+++ b/src/client/search.js
@@ -28,6 +28,7 @@ const index = await fetch(import.meta.resolve("./minisearch.json"))
 input.addEventListener("input", () => {
   if (currentValue === input.value) return;
   currentValue = input.value;
+  sessionStorage.setItem("search-query", currentValue);
   if (!currentValue.length) {
     container.setAttribute("data-shortcut", shortcut);
     sidebar.classList.remove("observablehq-search-results");


### PR DESCRIPTION
as I'm working on a project with ~300 pages, I find that not having this feature is _very_ annoying, since when I'm working on maps (say…), I have to re-type the same search query again and again (I'll test a bit with the feature on, I hope that it's not annoying in a different way :-) )

closes #889

https://github.com/observablehq/framework/assets/7001/c1e75d2e-746f-4ce8-8a78-dbd1639d802c

