### PR TITLE
autorefresh linked images and style sheets

### DIFF
--- a/src/client/preview.js
+++ b/src/client/preview.js
@@ -97,8 +97,8 @@ export function open({hash, eval: compile} = {}) {
         break;
       }
       case "update-image": {
-        const image = document.querySelector(`img[src^="${message.path}"]`);
-        image.src = message.src;
+        const images = document.querySelectorAll(`img[src^="${message.path}"]`);
+        images.forEach(image => image.src = message.src);
         break;
       }
       case "add-stylesheet": {

--- a/src/client/preview.js
+++ b/src/client/preview.js
@@ -105,6 +105,11 @@ export function open({hash, eval: compile} = {}) {
         document.head.appendChild(link);
         break;
       }
+      case "update-stylesheet": {
+        const link = document.querySelector(`link[rel="stylesheet"][href^="${message.path}"]`);
+        link.href = message.href;
+        break;
+      }
       case "remove-stylesheet": {
         document.head.querySelector(`link[rel="stylesheet"][href="${message.href}"]`)?.remove();
         break;

--- a/src/client/preview.js
+++ b/src/client/preview.js
@@ -98,7 +98,7 @@ export function open({hash, eval: compile} = {}) {
       }
       case "update-image": {
         const images = document.querySelectorAll(`img[src^="${message.path}"]`);
-        images.forEach(image => image.src = message.src);
+        images.forEach((image) => (image.src = message.src));
         break;
       }
       case "add-stylesheet": {

--- a/src/client/preview.js
+++ b/src/client/preview.js
@@ -96,6 +96,11 @@ export function open({hash, eval: compile} = {}) {
         enableCopyButtons();
         break;
       }
+      case "update-image": {
+        const image = document.querySelector(`img[src^="${message.path}"]`);
+        image.src = message.src;
+        break;
+      }
       case "add-stylesheet": {
         const link = document.createElement("link");
         link.rel = "stylesheet";

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -371,7 +371,7 @@ export function normalizePieceHtml(html: string, root: string, sourcePath: strin
         const file = resolvePath(source);
 
         if (file) {
-          let url = file.mimeType === "text/css" ? constructStylesheetUrl(root, file) : file.path;
+          const url = file.mimeType === "text/css" ? constructStylesheetUrl(root, file) : file.path;
           element.setAttribute(src, url);
         }
       }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,6 +1,6 @@
 import {createHash} from "node:crypto";
 import {readFile} from "node:fs/promises";
-import {dirname, extname, join, normalize, relative} from "node:path";
+import {join} from "node:path";
 import {type Patch, type PatchItem, getPatch} from "fast-array-diff";
 import equal from "fast-deep-equal";
 import matter from "gray-matter";
@@ -297,7 +297,9 @@ function extendPiece(context: ParseContext, extend: Partial<RenderPiece>) {
   };
 }
 
-function renderIntoPieces(renderer: Renderer, root: string, sourcePath: string): Renderer["render"] {
+// function renderIntoPieces(renderer: Renderer, root: string, sourcePath: string): Renderer["render"] {
+function renderIntoPieces(renderer: Renderer, root: string, sourcePath: string):any {
+  console.log({ sourcePath });
   return async (tokens, options, context: ParseContext) => {
     const rules = renderer.rules;
     for (let i = 0, len = tokens.length; i < len; i++) {
@@ -368,12 +370,12 @@ export async function normalizePieceHtml(html: string, root: string, sourcePath:
       } else {
         const source = decodeURIComponent(element.getAttribute(src)!);
         const file = resolvePath(source);
-        console.log({ file });
+
         if (file) {
           let url = file.path;
           if (file.mimeType === "text/css") {
             try {
-              const hash = computeHash(await readFile(join(root, file.name), "utf-u"));
+              const hash = computeHash(await readFile(join(root, file.name), "utf-8"));
               url += `?hash=${hash}`;
             } catch (error) {
               // if file not found, it will be reported as 404 in client console
@@ -383,16 +385,6 @@ export async function normalizePieceHtml(html: string, root: string, sourcePath:
 
           element.setAttribute(src, url);
         }
-
-        // if (file) {
-        //   try {
-        //     file.hash = computeHash(await readFile(join(root, file.name), "utf-8"));
-        //     element.setAttribute(src, `${file.path}?hash=${file.hash}`);
-        //   } catch (error) {
-        //     // if file not found, it will be reported as 404 in client console
-        //     if (!isEnoent(error)) throw error;
-        //   }
-        // }
       }
     }
   }
@@ -456,7 +448,9 @@ export async function parseMarkdown(sourcePath: string, {root, path}: ParseOptio
   md.renderer.render = renderIntoPieces(md.renderer, root, path);
   const context: ParseContext = {files: [], imports: [], pieces: [], startLine: 0, currentLine: 0};
   const tokens = md.parse(parts.content, context);
+  console.log({ tokens });
   const html = await md.renderer.render(tokens, md.options, context); // Note: mutates context.pieces, context.files!
+  console.log({ html });
   return {
     html,
     data: isEmpty(parts.data) ? null : parts.data,

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -320,7 +320,6 @@ function renderIntoPieces(renderer: Renderer, root: string, sourcePath: string):
     for (const piece of context.pieces) {
       result += piece.html = normalizePieceHtml(piece.html, root, sourcePath, context);
     }
-
     return result;
   };
 }
@@ -369,7 +368,6 @@ export function normalizePieceHtml(html: string, root: string, sourcePath: strin
       } else {
         const source = decodeURIComponent(element.getAttribute(src)!);
         const file = resolvePath(source);
-
         if (file) {
           const url = file.mimeType === "text/css" ? constructStylesheetUrl(root, file) : file.path;
           element.setAttribute(src, url);

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -371,17 +371,7 @@ export function normalizePieceHtml(html: string, root: string, sourcePath: strin
         const file = resolvePath(source);
 
         if (file) {
-          let url = file.path;
-          if (file.mimeType === "text/css") {
-            try {
-              const hash = computeHash(readFileSync(join(root, file.name), "utf-8"));
-              url += `?hash=${hash}`;
-            } catch (error) {
-              // if file not found, it will be reported as 404 in client console
-              if (!isEnoent(error)) throw error;
-            }
-          }
-
+          let url = file.mimeType === "text/css" ? constructStylesheetUrl(root, file) : file.path;
           element.setAttribute(src, url);
         }
       }
@@ -479,6 +469,19 @@ async function computeMarkdownHash(
     }
   }
   return hash.digest("hex");
+}
+
+export function constructStylesheetUrl(root, file) {
+  let url = file.path;
+  try {
+    // use readFileSync as it is called from a context that does not permit async
+    const hash = computeHash(readFileSync(join(root, file.name), "utf-8"));
+    url += `?hash=${hash}`;
+  } catch (error) {
+    // if file not found, it will be reported as 404 in client console
+    if (!isEnoent(error)) throw error;
+  }
+  return url;
 }
 
 // TODO Use gray-matter’s parts.isEmpty, but only when it’s accurate.

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -370,7 +370,10 @@ export function normalizePieceHtml(html: string, sourcePath: string, context: Pa
         const source = decodeURIComponent(element.getAttribute(src)!);
         const file = resolvePath(source);
         if (file) {
-          const url = file.mimeType === "text/css" ? constructStylesheetUrl(context.root, file) : file.path;
+          const url =
+            file.mimeType === "text/css" || file.mimeType?.startsWith("image/")
+              ? constructAttachmentUrl(context.root, file)
+              : file.path;
           element.setAttribute(src, url);
         }
       }
@@ -470,7 +473,7 @@ async function computeMarkdownHash(
   return hash.digest("hex");
 }
 
-export function constructStylesheetUrl(root, file) {
+export function constructAttachmentUrl(root, file) {
   let url = file.path;
   try {
     // use readFileSync as it is called from a context that does not permit async

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -19,7 +19,7 @@ import {getClientPath} from "./files.js";
 import {FileWatchers} from "./fileWatchers.js";
 import {createImportResolver, rewriteModule} from "./javascript/imports.js";
 import {getImplicitSpecifiers, getImplicitStylesheets} from "./libraries.js";
-import {diffMarkdown, parseMarkdown} from "./markdown.js";
+import {constructStylesheetUrl, diffMarkdown, parseMarkdown} from "./markdown.js";
 import type {ParseResult} from "./markdown.js";
 import {renderPreview, resolveStylesheet} from "./render.js";
 import {bundleStyles, rollupClient} from "./rollup.js";
@@ -322,14 +322,11 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, {root, style: defa
     const stylesheet = files.find(({ mimeType, name: stylesheetName }) => mimeType === "text/css" && stylesheetName === name);
 
     if (stylesheet) {
-      let url = stylesheet.path;
-      try {
-        const hash = computeHash(readFileSync(join(root, stylesheet.name), "utf-8"));
-        url += `?hash=${hash}`;
-      } catch (error) {
-        console.log({ error });
-      }
-      send({type: "update-stylesheet", href: url, path: stylesheet.path });
+      send({
+        type: "update-stylesheet",
+        href: constructStylesheetUrl(root, stylesheet),
+        path: stylesheet.path
+      });
     }
   }
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,5 +1,5 @@
 import {createHash} from "node:crypto";
-import {readFileSync, watch} from "node:fs";
+import {watch} from "node:fs";
 import type {FSWatcher, WatchEventType} from "node:fs";
 import {access, constants, readFile, stat} from "node:fs/promises";
 import {createServer} from "node:http";
@@ -27,7 +27,6 @@ import {searchIndex} from "./search.js";
 import {Telemetry} from "./telemetry.js";
 import {bold, faint, green, link, red} from "./tty.js";
 import {relativeUrl} from "./url.js";
-import {computeHash} from "./hash.js";
 
 const publicRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "public");
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -19,7 +19,7 @@ import {getClientPath} from "./files.js";
 import {FileWatchers} from "./fileWatchers.js";
 import {createImportResolver, rewriteModule} from "./javascript/imports.js";
 import {getImplicitSpecifiers, getImplicitStylesheets} from "./libraries.js";
-import {constructStylesheetUrl, diffMarkdown, parseMarkdown} from "./markdown.js";
+import {constructAttachmentUrl, diffMarkdown, parseMarkdown} from "./markdown.js";
 import type {ParseResult} from "./markdown.js";
 import {renderPreview, resolveStylesheet} from "./render.js";
 import {bundleStyles, rollupClient} from "./rollup.js";
@@ -317,14 +317,23 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, {root, style: defa
       }
     }
 
+    const image = files.find(({mimeType, name: imageName}) => mimeType?.startsWith("image/") && imageName === name);
+    if (image) {
+      send({
+        type: "update-image",
+        src: constructAttachmentUrl(root, image),
+        path: image.path
+      });
+      return;
+    }
+
     const stylesheet = files.find(
       ({mimeType, name: stylesheetName}) => mimeType === "text/css" && stylesheetName === name
     );
-
     if (stylesheet) {
       send({
         type: "update-stylesheet",
-        href: constructStylesheetUrl(root, stylesheet),
+        href: constructAttachmentUrl(root, stylesheet),
         path: stylesheet.path
       });
     }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -308,7 +308,6 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, {root, style: defa
 
   function refreshAttachment(name: string) {
     const {cells, files} = current!;
-
     if (cells.some((cell) => cell.imports?.some((i) => i.name === name))) {
       watcher("change"); // trigger re-compilation of JavaScript to get new import hashes
     } else {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -318,7 +318,9 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, {root, style: defa
       }
     }
 
-    const stylesheet = files.find(({ mimeType, name: stylesheetName }) => mimeType === "text/css" && stylesheetName === name);
+    const stylesheet = files.find(
+      ({mimeType, name: stylesheetName}) => mimeType === "text/css" && stylesheetName === name
+    );
 
     if (stylesheet) {
       send({

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -21,7 +21,7 @@ describe("parseMarkdown(input)", () => {
     const skip = name.startsWith("skip.");
     const outname = only || skip ? name.slice(5) : name;
 
-    (only ? it.only : skip ? it.skip : it)(`test/input/${name}`, async () => {
+    (only ? it.only : skip ? it.skip : it)(`test/input/${name}`, () => {
       const snapshot = await parseMarkdown(path, {root: "test/input", path: name});
       let allequal = true;
       for (const ext of ["html", "json"]) {
@@ -65,7 +65,7 @@ describe("parseMarkdown(input)", () => {
 describe("normalizePieceHtml adds local file attachments", () => {
   const sourcePath = "/attachments.md";
 
-  it("img[src]", async () => {
+  it("img[src]", () => {
     const htmlStr = html`<img src="./test.png">`;
     const root = "/";
     const expected = html`<img src="./_file/test.png">`;
@@ -82,7 +82,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     ]);
   });
 
-  it("img[srcset]", async () => {
+  it("img[srcset]", () => {
     const htmlStr = html`
         <img
           srcset="small.jpg 480w, large.jpg 800w"
@@ -115,7 +115,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     ]);
   });
 
-  it("video[src]", async () => {
+  it("video[src]", () => {
     const htmlStr = html`<video src="observable.mov" controls>
       Your browser doesn't support HTML video.
       </video>`;
@@ -136,7 +136,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     ]);
   });
 
-  it("video source[src]", async () => {
+  it("video source[src]", () => {
     const htmlStr = html`<video width="320" height="240" controls>
       <source src="observable.mp4" type="video/mp4">
       <source src="observable.mov" type="video/mov">
@@ -168,7 +168,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     ]);
   });
 
-  it("picture source[srcset]", async () => {
+  it("picture source[srcset]", () => {
     const htmlStr = html`<picture>
       <source srcset="observable-logo-wide.png" media="(min-width: 600px)"/>
       <img src="observable-logo-narrow.png" />
@@ -202,7 +202,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
 describe("normalizePieceHtml only adds local files", () => {
   const sourcePath = "/attachments.md";
 
-  it("img[src] only adds local files", async () => {
+  it("img[src] only adds local files", () => {
     const htmlStr = html`<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">`;
     const root = "/";
     const expected = html`<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">`;
@@ -213,7 +213,7 @@ describe("normalizePieceHtml only adds local files", () => {
     assert.deepEqual(context.files, []);
   });
 
-  it("img[srcset] only adds local files", async () => {
+  it("img[srcset] only adds local files", () => {
     const htmlStr = html`
         <img
           srcset="small.jpg 480w, https://upload.wikimedia.org/900px-American_Shorthair.jpg 900w"

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -65,11 +65,12 @@ describe("parseMarkdown(input)", () => {
 describe("normalizePieceHtml adds local file attachments", () => {
   const sourcePath = "/attachments.md";
 
-  it("img[src]", () => {
+  it("img[src]", async () => {
     const htmlStr = html`<img src="./test.png">`;
+    const root = "/";
     const expected = html`<img src="./_file/test.png">`;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
+    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -81,7 +82,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     ]);
   });
 
-  it("img[srcset]", () => {
+  it("img[srcset]", async () => {
     const htmlStr = html`
         <img
           srcset="small.jpg 480w, large.jpg 800w"
@@ -91,12 +92,13 @@ describe("normalizePieceHtml adds local file attachments", () => {
           alt="Image for testing"
         />
       `;
+    const root = "/";
     const expected = html`
         <img srcset="./_file/small.jpg 480w, ./_file/large.jpg 800w" sizes="(max-width: 600px) 480px,
                 800px" src="./_file/large.jpg" alt="Image for testing">
       `;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
+    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -113,15 +115,16 @@ describe("normalizePieceHtml adds local file attachments", () => {
     ]);
   });
 
-  it("video[src]", () => {
+  it("video[src]", async () => {
     const htmlStr = html`<video src="observable.mov" controls>
       Your browser doesn't support HTML video.
       </video>`;
+    const root = "/";
     const expected = html`<video src="./_file/observable.mov" controls>
       Your browser doesn't support HTML video.
       </video>`;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
+    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -133,12 +136,13 @@ describe("normalizePieceHtml adds local file attachments", () => {
     ]);
   });
 
-  it("video source[src]", () => {
+  it("video source[src]", async () => {
     const htmlStr = html`<video width="320" height="240" controls>
       <source src="observable.mp4" type="video/mp4">
       <source src="observable.mov" type="video/mov">
       Your browser doesn't support HTML video.
       </video>`;
+    const root = "/";
 
     const expected = html`<video width="320" height="240" controls>
       <source src="./_file/observable.mp4" type="video/mp4">
@@ -147,7 +151,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
       </video>`;
 
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
+    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -164,11 +168,12 @@ describe("normalizePieceHtml adds local file attachments", () => {
     ]);
   });
 
-  it("picture source[srcset]", () => {
+  it("picture source[srcset]", async () => {
     const htmlStr = html`<picture>
       <source srcset="observable-logo-wide.png" media="(min-width: 600px)"/>
       <img src="observable-logo-narrow.png" />
     </picture>`;
+    const root = "/";
 
     const expected = html`<picture>
       <source srcset="./_file/observable-logo-wide.png" media="(min-width: 600px)">
@@ -176,7 +181,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     </picture>`;
 
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
+    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -197,17 +202,18 @@ describe("normalizePieceHtml adds local file attachments", () => {
 describe("normalizePieceHtml only adds local files", () => {
   const sourcePath = "/attachments.md";
 
-  it("img[src] only adds local files", () => {
+  it("img[src] only adds local files", async () => {
     const htmlStr = html`<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">`;
+    const root = "/";
     const expected = html`<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">`;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
+    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, []);
   });
 
-  it("img[srcset] only adds local files", () => {
+  it("img[srcset] only adds local files", async () => {
     const htmlStr = html`
         <img
           srcset="small.jpg 480w, https://upload.wikimedia.org/900px-American_Shorthair.jpg 900w"
@@ -216,11 +222,12 @@ describe("normalizePieceHtml only adds local files", () => {
           alt="Cat image for testing"
         />
       `;
+    const root = "/";
     const expected = html`
         <img srcset="./_file/small.jpg 480w, https://upload.wikimedia.org/900px-American_Shorthair.jpg 900w" sizes="(max-width: 600px) 480px, 900px" src="https://upload.wikimedia.org/900px-American_Shorthair.jpg" alt="Cat image for testing">
       `;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
+    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -232,12 +239,13 @@ describe("normalizePieceHtml only adds local files", () => {
     ]);
   });
 
-  it("video source[src] only adds local files", () => {
+  it("video source[src] only adds local files", async () => {
     const htmlStr = html`<video width="320" height="240" controls>
       <source src="https://www.youtube.com/watch?v=SsFyayu5csc" type="video/youtube"/>
       <source src="observable.mov" type="video/mov">
       Your browser doesn't support HTML video.
       </video>`;
+    const root = "/";
 
     const expected = html`<video width="320" height="240" controls>
       <source src="https://www.youtube.com/watch?v=SsFyayu5csc" type="video/youtube">
@@ -246,7 +254,7 @@ describe("normalizePieceHtml only adds local files", () => {
       </video>`;
 
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
+    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -8,7 +8,7 @@ import {type ParseResult, parseMarkdown} from "../src/markdown.js";
 import {normalizePieceHtml} from "../src/markdown.js";
 
 const html = (strings, ...values) => String.raw({raw: strings}, ...values);
-const mockContext = () => ({files: [], imports: [], pieces: [], startLine: 0, currentLine: 0});
+const mockContext = () => ({root: "/", files: [], imports: [], pieces: [], startLine: 0, currentLine: 0});
 
 describe("parseMarkdown(input)", () => {
   const inputRoot = "test/input";
@@ -67,10 +67,9 @@ describe("normalizePieceHtml adds local file attachments", () => {
 
   it("img[src]", () => {
     const htmlStr = html`<img src="./test.png">`;
-    const root = "/";
     const expected = html`<img src="./_file/test.png">`;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -92,13 +91,12 @@ describe("normalizePieceHtml adds local file attachments", () => {
           alt="Image for testing"
         />
       `;
-    const root = "/";
     const expected = html`
         <img srcset="./_file/small.jpg 480w, ./_file/large.jpg 800w" sizes="(max-width: 600px) 480px,
                 800px" src="./_file/large.jpg" alt="Image for testing">
       `;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -119,12 +117,11 @@ describe("normalizePieceHtml adds local file attachments", () => {
     const htmlStr = html`<video src="observable.mov" controls>
       Your browser doesn't support HTML video.
       </video>`;
-    const root = "/";
     const expected = html`<video src="./_file/observable.mov" controls>
       Your browser doesn't support HTML video.
       </video>`;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -142,7 +139,6 @@ describe("normalizePieceHtml adds local file attachments", () => {
       <source src="observable.mov" type="video/mov">
       Your browser doesn't support HTML video.
       </video>`;
-    const root = "/";
 
     const expected = html`<video width="320" height="240" controls>
       <source src="./_file/observable.mp4" type="video/mp4">
@@ -151,7 +147,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
       </video>`;
 
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -173,7 +169,6 @@ describe("normalizePieceHtml adds local file attachments", () => {
       <source srcset="observable-logo-wide.png" media="(min-width: 600px)"/>
       <img src="observable-logo-narrow.png" />
     </picture>`;
-    const root = "/";
 
     const expected = html`<picture>
       <source srcset="./_file/observable-logo-wide.png" media="(min-width: 600px)">
@@ -181,7 +176,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     </picture>`;
 
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -204,10 +199,9 @@ describe("normalizePieceHtml only adds local files", () => {
 
   it("img[src] only adds local files", () => {
     const htmlStr = html`<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">`;
-    const root = "/";
     const expected = html`<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">`;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, []);
@@ -222,12 +216,11 @@ describe("normalizePieceHtml only adds local files", () => {
           alt="Cat image for testing"
         />
       `;
-    const root = "/";
     const expected = html`
         <img srcset="./_file/small.jpg 480w, https://upload.wikimedia.org/900px-American_Shorthair.jpg 900w" sizes="(max-width: 600px) 480px, 900px" src="https://upload.wikimedia.org/900px-American_Shorthair.jpg" alt="Cat image for testing">
       `;
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -245,7 +238,6 @@ describe("normalizePieceHtml only adds local files", () => {
       <source src="observable.mov" type="video/mov">
       Your browser doesn't support HTML video.
       </video>`;
-    const root = "/";
 
     const expected = html`<video width="320" height="240" controls>
       <source src="https://www.youtube.com/watch?v=SsFyayu5csc" type="video/youtube">
@@ -254,7 +246,7 @@ describe("normalizePieceHtml only adds local files", () => {
       </video>`;
 
     const context = mockContext();
-    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -21,7 +21,7 @@ describe("parseMarkdown(input)", () => {
     const skip = name.startsWith("skip.");
     const outname = only || skip ? name.slice(5) : name;
 
-    (only ? it.only : skip ? it.skip : it)(`test/input/${name}`, () => {
+    (only ? it.only : skip ? it.skip : it)(`test/input/${name}`, async () => {
       const snapshot = await parseMarkdown(path, {root: "test/input", path: name});
       let allequal = true;
       for (const ext of ["html", "json"]) {
@@ -239,7 +239,7 @@ describe("normalizePieceHtml only adds local files", () => {
     ]);
   });
 
-  it("video source[src] only adds local files", async () => {
+  it("video source[src] only adds local files", () => {
     const htmlStr = html`<video width="320" height="240" controls>
       <source src="https://www.youtube.com/watch?v=SsFyayu5csc" type="video/youtube"/>
       <source src="observable.mov" type="video/mov">

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -70,7 +70,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     const root = "/";
     const expected = html`<img src="./_file/test.png">`;
     const context = mockContext();
-    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -98,7 +98,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
                 800px" src="./_file/large.jpg" alt="Image for testing">
       `;
     const context = mockContext();
-    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -124,7 +124,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
       Your browser doesn't support HTML video.
       </video>`;
     const context = mockContext();
-    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -151,7 +151,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
       </video>`;
 
     const context = mockContext();
-    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -181,7 +181,7 @@ describe("normalizePieceHtml adds local file attachments", () => {
     </picture>`;
 
     const context = mockContext();
-    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -207,7 +207,7 @@ describe("normalizePieceHtml only adds local files", () => {
     const root = "/";
     const expected = html`<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">`;
     const context = mockContext();
-    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, []);
@@ -227,7 +227,7 @@ describe("normalizePieceHtml only adds local files", () => {
         <img srcset="./_file/small.jpg 480w, https://upload.wikimedia.org/900px-American_Shorthair.jpg 900w" sizes="(max-width: 600px) 480px, 900px" src="https://upload.wikimedia.org/900px-American_Shorthair.jpg" alt="Cat image for testing">
       `;
     const context = mockContext();
-    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [
@@ -254,7 +254,7 @@ describe("normalizePieceHtml only adds local files", () => {
       </video>`;
 
     const context = mockContext();
-    const actual = await normalizePieceHtml(htmlStr, root, sourcePath, context);
+    const actual = normalizePieceHtml(htmlStr, root, sourcePath, context);
 
     assert.equal(actual, expected);
     assert.deepEqual(context.files, [

--- a/test/output/build/files/files.html
+++ b/test/output/build/files/files.html
@@ -51,8 +51,8 @@ FileAttachment("observable logo.png")
 </aside>
 <div id="observablehq-center">
 <main id="observablehq-main" class="observablehq">
-<span><link rel="stylesheet" href="./_file/custom-styles.css">
-<link rel="stylesheet" href="./_file/subsection/additional-styles.css">
+<span><link rel="stylesheet" href="./_file/custom-styles.css?hash=b072c9c8f20ed4e1530b0d339e885b857eefd6179fbae5162d2fbdc8332e0f24">
+<link rel="stylesheet" href="./_file/subsection/additional-styles.css?hash=3a854b3a5696005d76aea1207d0ab771f2d83b41459736d7e06c598cf4620213">
 <link rel="stylesheet" href="https://example.com/style.css">
 </span><div id="cell-10037545" class="observablehq observablehq--block observablehq--loading"></div>
 <div id="cell-453a8147" class="observablehq observablehq--block observablehq--loading"></div>

--- a/test/output/build/files/files.html
+++ b/test/output/build/files/files.html
@@ -57,7 +57,7 @@ FileAttachment("observable logo.png")
 </span><div id="cell-10037545" class="observablehq observablehq--block observablehq--loading"></div>
 <div id="cell-453a8147" class="observablehq observablehq--block observablehq--loading"></div>
 <div id="cell-444c421e" class="observablehq observablehq--block observablehq--loading"></div>
-<p><img src="./_file/observable logo small.png" alt=""></p>
+<p><img src="./_file/observable logo small.png?hash=a3fdd8b57c86d6e7b3b465a1b1f20231dab908d74cf3c17b75cf5c02995f6ad0" alt=""></p>
 </main>
 <footer id="observablehq-footer">
 <nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./subsection/subfiles"><span>Untitled</span></a></nav>


### PR DESCRIPTION
add logic to send a `update-stylesheet` message to the client when the stylesheet has changed.  the path & full url with new hash of the style sheet is passed to the client, which is used to update the `<link>` element.

currently, the url with the hash is sent on any file change action.  it would be nice to only send the `update-stylesheet` message only if the hash changed, and i can try to add logic to diff the hashes, but it adds complexity, so not sure if worth it.

fixes #415 and i think #908 now.