### PR TITLE
adopt turbo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 test/output/**/*-changed.*
 test/output/build/**/*-changed/
 yarn-error.log
+.turbo

--- a/package.json
+++ b/package.json
@@ -22,16 +22,20 @@
     "observable": "bin/observable-init.js"
   },
   "scripts": {
-    "dev": "rm -f docs/themes.md docs/theme/*.md && (tsx watch docs/theme/generate-themes.ts & tsx watch --no-warnings=ExperimentalWarning ./bin/observable.ts preview --no-open)",
-    "build": "yarn rebuild-themes && rm -rf dist && tsx --no-warnings=ExperimentalWarning ./bin/observable.ts build",
-    "deploy": "yarn rebuild-themes && tsx --no-warnings=ExperimentalWarning ./bin/observable.ts deploy",
-    "rebuild-themes": "rm -f docs/themes.md docs/theme/*.md && tsx docs/theme/generate-themes.ts",
-    "test": "yarn test:mocha && yarn test:tsc && yarn test:lint && yarn test:prettier",
+    "dev": "turbo themes:rebuild preview",
+    "preview": "tsx watch --no-warnings=ExperimentalWarning ./bin/observable.ts preview --no-open",
+    "build": "turbo rebuild-themes && rm -rf dist && tsx --no-warnings=ExperimentalWarning ./bin/observable.ts build",
+    "deploy": "turbo rebuild-themes && tsx --no-warnings=ExperimentalWarning ./bin/observable.ts deploy",
+    "test": "turbo test:clean test:mocha1 test:mocha2 test:tsc test:lint test:prettier",
     "test:coverage": "c8 yarn test:mocha",
-    "test:mocha": "rm -rf test/.observablehq/cache test/input/build/*/.observablehq/cache && OBSERVABLE_TELEMETRY_DISABLE=1 TZ=America/Los_Angeles tsx --no-warnings=ExperimentalWarning ./node_modules/.bin/mocha 'test/**/*-test.*'",
+    "test:clean": "rm -rf test/.observablehq/cache test/input/build/*/.observablehq/cache",
+    "test:mocha": "OBSERVABLE_TELEMETRY_DISABLE=1 TZ=America/Los_Angeles tsx --no-warnings=ExperimentalWarning ./node_modules/.bin/mocha 'test/**/*-test.*'",
+    "test:mocha1": "OBSERVABLE_TELEMETRY_DISABLE=1 TZ=America/Los_Angeles tsx --no-warnings=ExperimentalWarning ./node_modules/.bin/mocha 'test/*/*-test.*'",
+    "test:mocha2": "OBSERVABLE_TELEMETRY_DISABLE=1 TZ=America/Los_Angeles tsx --no-warnings=ExperimentalWarning ./node_modules/.bin/mocha 'test/*-test.*'",
     "test:lint": "eslint src test --max-warnings=0",
     "test:prettier": "prettier --check src test",
     "test:tsc": "tsc --noEmit",
+    "themes:rebuild": "tsx docs/theme/generate-themes.ts",
     "observable": "tsx --no-warnings=ExperimentalWarning ./bin/observable.ts"
   },
   "c8": {
@@ -78,6 +82,7 @@
     "ws": "^8.14.2"
   },
   "devDependencies": {
+    "turbo": "1",
     "@types/d3-array": "^3.2.1",
     "@types/he": "^1.2.3",
     "@types/jsdom": "^21.1.6",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "test:mocha": {},
+    "test:mocha1": {},
+    "test:mocha2": {},
+    "test:tsc": {},
+    "test:lint": {},
+    "test:prettier": {},
+    "themes:rebuild": {
+      "outputs": ["./docs/theme/"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3496,6 +3496,48 @@ tsx@~4.2.1:
   optionalDependencies:
     fsevents "~2.3.3"
 
+turbo-darwin-64@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.12.4.tgz#c03061dcf3e9fb6e530b7c5be035e44627015af7"
+  integrity sha512-dBwFxhp9isTa9RS/fz2gDVk5wWhKQsPQMozYhjM7TT4jTrnYn0ZJMzr7V3B/M/T8QF65TbniW7w1gtgxQgX5Zg==
+
+turbo-darwin-arm64@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.12.4.tgz#5a10367004077fb7874717f4ddc47b2f66f74cfb"
+  integrity sha512-1Uo5iI6xsJ1j9ObsqxYRsa3W26mEbUe6fnj4rQYV6kDaqYD54oAMJ6hM53q9rB8JvFxwdrUXGp3PwTw9A0qqkA==
+
+turbo-linux-64@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.12.4.tgz#22af551b152634a162a13c4a14af28816b383fc9"
+  integrity sha512-ONg2aSqKP7LAQOg7ysmU5WpEQp4DGNxSlAiR7um+LKtbmC/UxogbR5+T+Uuq6zGuQ5kJyKjWJ4NhtvUswOqBsA==
+
+turbo-linux-arm64@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.12.4.tgz#f13fb4da0e9fd968ccc0b807df643913ee8fab50"
+  integrity sha512-9FPufkwdgfIKg/9jj87Cdtftw8o36y27/S2vLN7FTR2pp9c0MQiTBOLVYadUr1FlShupddmaMbTkXEhyt9SdrA==
+
+turbo-windows-64@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.12.4.tgz#9b72a5082f6db8f995f409226220982ee90661f7"
+  integrity sha512-2mOtxHW5Vjh/5rDVu/aFwsMzI+chs8XcEuJHlY1sYOpEymYTz+u6AXbnzRvwZFMrLKr7J7fQOGl+v96sLKbNdA==
+
+turbo-windows-arm64@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.12.4.tgz#e7058885e18705c625436acebcd66fda3dd506d5"
+  integrity sha512-nOY5wae9qnxPOpT1fRuYO0ks6dTwpKMPV6++VkDkamFDLFHUDVM/9kmD2UTeh1yyrKnrZksbb9zmShhmfj1wog==
+
+turbo@1:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.12.4.tgz#c3ba81871eba9ec87ac86af9e6270857726da9cb"
+  integrity sha512-yUJ7elEUSToiGwFZogXpYKJpQ0BvaMbkEuQECIWtkBLcmWzlMOt6bActsIm29oN83mRU0WbzGt4e8H1KHWedhg==
+  optionalDependencies:
+    turbo-darwin-64 "1.12.4"
+    turbo-darwin-arm64 "1.12.4"
+    turbo-linux-64 "1.12.4"
+    turbo-linux-arm64 "1.12.4"
+    turbo-windows-64 "1.12.4"
+    turbo-windows-arm64 "1.12.4"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"


### PR DESCRIPTION
With turbo, the unit tests are running faster (mostly because they get to be parallelized, I guess?). It should be possible to split the test suite into 5 or 10 buckets and get more speed.

ref. https://turbo.build/repo/docs/reference/configuration

It also seems to fix the pesky terminal bug!


todo:
- [ ] split tests into 4 or 8 buckets?
- [x] fix coverage (reported as 0%)