### PR TITLE
add leaflet images

### DIFF
--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -69,6 +69,13 @@ export function getImplicitDownloads(imports: Iterable<string>): Set<string> {
     implicits.add("npm:sql.js/dist/sql-wasm.js");
     implicits.add("npm:sql.js/dist/sql-wasm.wasm");
   }
+  if (set.has("npm:leaflet")) {
+    implicits.add("npm:leaflet/dist/images/layers.png");
+    implicits.add("npm:leaflet/dist/images/layers-2x.png");
+    implicits.add("npm:leaflet/dist/images/marker-icon.png");
+    implicits.add("npm:leaflet/dist/images/marker-icon-2x.png");
+    implicits.add("npm:leaflet/dist/images/marker-shadow.png");
+  }
   if (set.has("npm:katex")) {
     implicits.add("npm:katex/dist/fonts/KaTeX_AMS-Regular.ttf");
     implicits.add("npm:katex/dist/fonts/KaTeX_AMS-Regular.woff");

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -194,6 +194,7 @@ export async function resolveNpmImports(root: string, path: string): Promise<Imp
   promise = (async function () {
     try {
       const filePath = await populateNpmCache(root, path);
+      if (!/\.(m|c)?js$/i.test(path)) return []; // not JavaScript; TODO traverse CSS, too
       const source = await readFile(filePath, "utf-8");
       const body = Parser.parse(source, parseOptions);
       return findImports(body, path, source);


### PR DESCRIPTION
Some of these would be statically discoverable by parsing the CSS, but some of them are only referenced in the code (and without using `import.meta.resolve`), so we’ll need to enumerate these anyway if we want it to work out of the box.