### PR TITLE
default mimeType to application/octet-stream

### DIFF
--- a/src/client/stdlib/fileAttachment.js
+++ b/src/client/stdlib/fileAttachment.js
@@ -28,9 +28,9 @@ async function dsv(file, delimiter, {array = false, typed = false} = {}) {
 }
 
 export class AbstractFile {
-  constructor(name, mimeType) {
-    Object.defineProperty(this, "name", {value: name, enumerable: true});
-    if (mimeType !== undefined) Object.defineProperty(this, "mimeType", {value: mimeType + "", enumerable: true});
+  constructor(name, mimeType = "application/octet-stream") {
+    Object.defineProperty(this, "name", {value: `${name}`, enumerable: true});
+    Object.defineProperty(this, "mimeType", {value: `${mimeType}`, enumerable: true});
   }
   async blob() {
     return (await remote_fetch(this)).blob();
@@ -100,7 +100,7 @@ class FileAttachmentImpl extends AbstractFile {
     Object.defineProperty(this, "_url", {value: url});
   }
   async url() {
-    return (await this._url) + "";
+    return `${await this._url}`;
   }
 }
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -451,7 +451,7 @@ function diffCode(oldCode: Map<string, string>, newCode: Map<string, string>): C
   return patch;
 }
 
-type FileDeclaration = {name: string; mimeType: string | null; path: string};
+type FileDeclaration = {name: string; mimeType?: string; path: string};
 type FilePatch = {removed: string[]; added: FileDeclaration[]};
 
 function diffFiles(oldFiles: Map<string, string>, newFiles: Map<string, string>): FilePatch {
@@ -463,7 +463,7 @@ function diffFiles(oldFiles: Map<string, string>, newFiles: Map<string, string>)
   }
   for (const [name, path] of newFiles) {
     if (oldFiles.get(name) !== path) {
-      patch.added.push({name, mimeType: mime.getType(name), path});
+      patch.added.push({name, mimeType: mime.getType(name) ?? undefined, path});
     }
   }
   return patch;

--- a/src/render.ts
+++ b/src/render.ts
@@ -83,7 +83,7 @@ function renderFiles(files: Iterable<string>, resolve: (name: string) => string)
 function renderFile(name: string, resolve: (name: string) => string): string {
   return `\nregisterFile(${JSON.stringify(name)}, ${JSON.stringify({
     name,
-    mimeType: mime.getType(name),
+    mimeType: mime.getType(name) ?? undefined,
     path: resolve(name)
   })});`;
 }


### PR DESCRIPTION
Fixes #874. I thought about just fixing this to null, and then I thought making it undefined, but then I figured we can reasonably assume what the default MIME type will be of the server in this case (application/octet-stream), so we might as well use that and then users don’t need to handle this field being unavailable.