### PR TITLE
adopt text-wrap: balance for all headers

### DIFF
--- a/src/style/global.css
+++ b/src/style/global.css
@@ -40,6 +40,7 @@ h6 {
   margin-top: 0;
   margin-bottom: 0.25rem;
   scroll-margin-top: 1rem;
+  text-wrap: balance;
 }
 
 h2 + p,


### PR DESCRIPTION
It just looks better in general.

example:

![Capture d’écran 2024-03-03 à 17 53 03](https://github.com/observablehq/framework/assets/7001/cf1ffa23-cfc2-4cbf-a25b-fd86f58f26fc)
