### PR TITLE
Decode Markdown filename URIs in preview (allow spaces)

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -357,7 +357,7 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, {root, style}: Con
 
   async function hello({path: initialPath, hash: initialHash}: {path: string; hash: string}): Promise<void> {
     if (markdownWatcher || attachmentWatcher) throw new Error("already watching");
-    path = initialPath;
+    path = decodeURIComponent(initialPath);
     if (!(path = normalize(path)).startsWith("/")) throw new Error("Invalid path: " + initialPath);
     if (path.endsWith("/")) path += "index";
     path += ".md";


### PR DESCRIPTION
While running Framework with a Markdown file with spaces in its name (`Test File.md`), I encountered:

```
Protocol error Error: ENOENT: no such file or directory, open 'Test%20File.md'
    at open (node:internal/fs/promises:633:25)
    at readFile (node:internal/fs/promises:1242:14)
    at parseMarkdown (file:///Users/huw/Library/Mobile Documents/iCloud~md~obsidian/Documents/node_modules/.pnpm/@observablehq+framework@1.0.0_@types+markdown-it@13.0.7/node_modules/@observablehq/framework/src/markdown.ts:421:18)
    at hello (file:///Users/huw/Library/Mobile Documents/iCloud~md~obsidian/Documents/node_modules/.pnpm/@observablehq+framework@1.0.0_@types+markdown-it@13.0.7/node_modules/@observablehq/framework/src/preview.ts:373:15)
    at WebSocket.<anonymous> (file:///Users/huw/Library/Mobile Documents/iCloud~md~obsidian/Documents/node_modules/.pnpm/@observablehq+framework@1.0.0_@types+markdown-it@13.0.7/node_modules/@observablehq/framework/src/preview.ts:386:11) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'Test%20File.md'
}
socket close /_observablehq
```

This prevented all live reloads. I investigated the cause and noticed that we weren't ever decoding the filename in the preview watcher. I fixed it and tested locally, and also ran `yarn test`. FWIW I got 596 passing tests, but a couple of data loader tests failed (I assume this is irrelevant).

 Please let me know what else I need to do to contribute—and thank you for all your work, I love Observable ^_^