### PR TITLE
separate docs:build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
       - if: steps.cache-data.outputs.cache-hit == 'true'
         run: find docs/.observablehq/cache examples/*/docs/.observablehq/cache -type f -exec touch {} +
       - run: yarn build
+      - run: yarn docs:build
       - name: Build example "api"
         run: yarn --frozen-lockfile && yarn build
         working-directory: examples/api

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,7 +11,7 @@ yarn
 Next start the local preview server:
 
 ```sh
-yarn dev
+yarn docs:dev
 ```
 
 Lastly visit <http://127.0.0.1:3000>.
@@ -21,7 +21,7 @@ The local preview server restarts automatically if you edit any of the TypeScrip
 To generate the static site:
 
 ```sh
-yarn build
+yarn docs:build
 ```
 
 This creates the `dist` folder. View the site using your preferred web server, such as:

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -54,7 +54,7 @@ We never collect identifying or sensitive information, such as environment varia
 Setting the `OBSERVABLE_TELEMETRY_DISABLE` environment variable to `true` disables telemetry collection entirely. For example:
 
 ```sh
-OBSERVABLE_TELEMETRY_DISABLE=true yarn build
+OBSERVABLE_TELEMETRY_DISABLE=true npm run build
 ```
 
 Setting the `OBSERVABLE_TELEMETRY_DEBUG` environment variable to `true` also disables telemetry collection, instead printing telemetry data to stderr. Use this to inspect what telemetry data would be collected.

--- a/package.json
+++ b/package.json
@@ -20,19 +20,20 @@
   },
   "scripts": {
     "dev": "rimraf --glob docs/themes.md docs/theme/*.md && (tsx watch docs/theme/generate-themes.ts & tsx watch --no-warnings=ExperimentalWarning ./src/bin/observable.ts preview --no-open)",
-    "build:mocha": "rimraf build.test && node build.js --sourcemap --outdir=build.test \"{src,test}/**/*.{ts,js,css}\" --ignore \"test/input/**\" --ignore \"test/output/**\" --ignore \"test/preview/dashboard/**\" --ignore \"**/*.d.ts\" && cp -r templates build.test",
-    "build": "yarn rebuild-themes && rimraf dist && tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts build",
-    "deploy": "yarn rebuild-themes && tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts deploy",
-    "rebuild-themes": "rimraf --glob docs/themes.md docs/theme/*.md && tsx docs/theme/generate-themes.ts",
+    "docs:themes": "rimraf --glob docs/themes.md docs/theme/*.md && tsx docs/theme/generate-themes.ts",
+    "docs:build": "yarn docs:themes && rimraf dist && tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts build",
+    "docs:deploy": "yarn docs:themes && tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts deploy",
+    "build": "rimraf build && node build.js --outdir=build --outbase=src \"src/**/*.{ts,js,css}\" --ignore \"**/*.d.ts\"",
     "test": "concurrently npm:test:mocha npm:test:tsc npm:test:lint npm:test:prettier",
     "test:coverage": "c8 --check-coverage --lines 80 --per-file yarn test:mocha",
-    "test:mocha": "yarn build:mocha && rimraf --glob test/.observablehq/cache test/input/build/*/.observablehq/cache && cross-env OBSERVABLE_TELEMETRY_DISABLE=1 TZ=America/Los_Angeles mocha -p \"build.test/test/**/*-test.js\"",
-    "test:mocha:serial": "yarn build:mocha && rimraf --glob test/.observablehq/cache test/input/build/*/.observablehq/cache && cross-env OBSERVABLE_TELEMETRY_DISABLE=1 TZ=America/Los_Angeles mocha \"build.test/test/**/*-test.js\"",
+    "test:build": "rimraf build.test && node build.js --sourcemap --outdir=build.test \"{src,test}/**/*.{ts,js,css}\" --ignore \"test/input/**\" --ignore \"test/output/**\" --ignore \"test/preview/dashboard/**\" --ignore \"**/*.d.ts\" && cp -r templates build.test",
+    "test:mocha": "yarn test:build && rimraf --glob test/.observablehq/cache test/input/build/*/.observablehq/cache && cross-env OBSERVABLE_TELEMETRY_DISABLE=1 TZ=America/Los_Angeles mocha -p \"build.test/test/**/*-test.js\"",
+    "test:mocha:serial": "yarn test:build && rimraf --glob test/.observablehq/cache test/input/build/*/.observablehq/cache && cross-env OBSERVABLE_TELEMETRY_DISABLE=1 TZ=America/Los_Angeles mocha \"build.test/test/**/*-test.js\"",
     "test:lint": "eslint src test --max-warnings=0",
     "test:prettier": "prettier --check src test",
     "test:tsc": "tsc --noEmit",
     "observable": "tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts",
-    "prepublishOnly": "rimraf build && node build.js --outdir=build --outbase=src \"src/**/*.{ts,js,css}\" --ignore \"**/*.d.ts\""
+    "prepublishOnly": "yarn build"
   },
   "c8": {
     "all": true,


### PR DESCRIPTION
Per https://github.com/observablehq/framework/pull/963#issuecomment-1976110292, and to fix the examples build, which needs both `yarn docs:build` to build the docs, and `yarn build` so that the examples can run `build/bin/observable.js`.