### PR TITLE
default to npm

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -80,7 +80,7 @@ export async function create(options = {}, effects: CreateEffects = defaultEffec
             {value: "yarn", label: "Yes, via yarn", hint: "recommended"},
             {value: null, label: "No"}
           ],
-          initialValue: inferPackageManager()
+          initialValue: inferPackageManager("npm")
         }),
       initializeGit: () =>
         clack.confirm({
@@ -205,12 +205,12 @@ async function recursiveCopyTemplate(
   }
 }
 
-function inferPackageManager(): string | null {
+function inferPackageManager(defaultValue: string | null): string | null {
   const userAgent = process.env["npm_config_user_agent"];
-  if (!userAgent) return null;
+  if (!userAgent) return defaultValue;
   const pkgSpec = userAgent.split(" ")[0]!; // userAgent is non-empty, so this is always defined
-  if (!pkgSpec) return null;
+  if (!pkgSpec) return defaultValue;
   const [name, version] = pkgSpec.split("/");
-  if (!name || !version) return null;
+  if (!name || !version) return defaultValue;
   return name;
 }


### PR DESCRIPTION
Running a bare `observable create` currently defaults to not installing dependencies, which is not recommended. This changes the default to npm instead.