### PR TITLE
fix yarn dlx

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -221,7 +221,7 @@ Or with Yarn:
 
 You should see something like this:
 
-<pre data-copy="none"><b class="green">Observable Framework</b> v1.1.1
+<pre data-copy="none"><b class="green">Observable Framework</b> v1.1.2
 ↳ <u><a href="http://127.0.0.1:3000/" style="color: inherit;">http://127.0.0.1:3000/</a></u></pre>
 
 <div class="tip">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@observablehq/framework",
   "license": "ISC",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/src/create.ts
+++ b/src/create.ts
@@ -110,6 +110,7 @@ export async function create(options = {}, effects: CreateEffects = defaultEffec
         if (packageManager) {
           s.message(`Installing dependencies via ${packageManager}`);
           await effects.sleep(1000);
+          if (packageManager === "yarn") await writeFile(join(rootPath, "yarn.lock"), "");
           await promisify(exec)(installCommand, {cwd: rootPath});
         }
         if (initializeGit) {


### PR DESCRIPTION
yarn dlx needs an empty yarn.lock to indicate that it’s a new project, or it gets confused.