### PR TITLE
fix transitive static imports

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -72,7 +72,8 @@ export async function build(
     const options = {path, ...config};
     effects.output.write(`${faint("parse")} ${sourcePath} `);
     const start = performance.now();
-    const page = await parseMarkdown(sourcePath, options);
+    const source = await readFile(sourcePath, "utf8");
+    const page = parseMarkdown(source, options);
     if (page?.data?.draft) {
       effects.logger.log(faint("(skipped)"));
       continue;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import {existsSync} from "node:fs";
+import {readFile} from "node:fs/promises";
 import op from "node:path";
 import {basename, dirname, join} from "node:path/posix";
 import {cwd} from "node:process";
@@ -82,7 +83,8 @@ async function readPages(root: string): Promise<Page[]> {
   const pages: Page[] = [];
   for await (const file of visitMarkdownFiles(root)) {
     if (file === "index.md" || file === "404.md") continue;
-    const parsed = await parseMarkdown(join(root, file), {root, path: file});
+    const source = await readFile(join(root, file), "utf8");
+    const parsed = parseMarkdown(source, {root, path: file});
     if (parsed?.data?.draft) continue;
     const name = basename(file, ".md");
     const page = {path: join("/", dirname(file), name), name: parsed.title ?? "Untitled"};

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-named-as-default-member */
 import {createHash} from "node:crypto";
-import {readFile} from "node:fs/promises";
 import matter from "gray-matter";
 import he from "he";
 import MarkdownIt from "markdown-it";
@@ -276,12 +275,11 @@ export interface ParseOptions {
   style?: Config["style"];
 }
 
-export async function parseMarkdown(
-  sourcePath: string,
+export function parseMarkdown(
+  input: string,
   {root, path, markdownIt = (md) => md, style: configStyle}: ParseOptions
-): Promise<MarkdownPage> {
-  const source = await readFile(sourcePath, "utf-8");
-  const parts = matter(source, {});
+): MarkdownPage {
+  const parts = matter(input, {});
   const md = markdownIt(MarkdownIt({html: true}));
   md.use(MarkdownItAnchor, {permalink: MarkdownItAnchor.permalink.headerLink({class: "observablehq-header-anchor"})});
   md.inline.ruler.push("placeholder", transformPlaceholderInline);

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -200,7 +200,8 @@ export class PreviewServer {
         // Anything else should 404; static files should be matched above.
         try {
           const options = {path: pathname, ...config, preview: true};
-          const parse = await parseMarkdown(path + ".md", options);
+          const source = await readFile(path + ".md", "utf8");
+          const parse = parseMarkdown(source, options);
           const html = await renderPage(parse, options);
           end(req, res, html, "text/html");
         } catch (error) {
@@ -218,7 +219,8 @@ export class PreviewServer {
       if (req.method === "GET" && res.statusCode === 404) {
         try {
           const options = {path: "/404", ...config, preview: true};
-          const parse = await parseMarkdown(join(root, "404.md"), options);
+          const source = await readFile(join(root, "404.md"), "utf8");
+          const parse = parseMarkdown(source, options);
           const html = await renderPage(parse, options);
           end(req, res, html, "text/html");
           return;
@@ -312,7 +314,8 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, config: Config) {
         break;
       }
       case "change": {
-        const page = await parseMarkdown(join(root, path), {path, ...config});
+        const source = await readFile(join(root, path), "utf8");
+        const page = parseMarkdown(source, {path, ...config});
         // delay to avoid a possibly-empty file
         if (!force && page.html === "") {
           if (!emptyTimeout) {
@@ -361,7 +364,8 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, config: Config) {
     if (!(path = normalize(path)).startsWith("/")) throw new Error("Invalid path: " + initialPath);
     if (path.endsWith("/")) path += "index";
     path += ".md";
-    const page = await parseMarkdown(join(root, path), {path, ...config});
+    const source = await readFile(join(root, path), "utf8");
+    const page = parseMarkdown(source, {path, ...config});
     const resolvers = await getResolvers(page, {root, path});
     if (resolvers.hash !== initialHash) return void send({type: "reload"});
     hash = resolvers.hash;

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -102,32 +102,27 @@ export async function getResolvers(page: MarkdownPage, {root, path}: {root: stri
   for (const i of localImports) hash.update(getModuleHash(root, resolvePath(path, i)));
   if (page.style && isPathImport(page.style)) hash.update(getFileHash(root, resolvePath(path, page.style)));
 
-  // Collect transitively-attached files and imports.
+  // Collect transitively-attached files and local imports.
   for (const i of localImports) {
     const p = resolvePath(path, i);
     const info = getModuleInfo(root, p);
     if (!info) continue;
-    for (const f of info.files) {
-      files.add(relativePath(path, resolvePath(p, f)));
-    }
-    for (const m of info.fileMethods) {
-      fileMethods.add(m);
-    }
-    for (const o of info.localStaticImports) {
-      const r = relativePath(path, resolvePath(p, o));
-      localImports.add(r);
-      staticImports.add(r);
-    }
-    for (const o of info.localDynamicImports) {
-      localImports.add(relativePath(path, resolvePath(p, o)));
-    }
-    for (const o of info.globalStaticImports) {
-      staticImports.add(o);
-      globalImports.add(o);
-    }
-    for (const o of info.globalDynamicImports) {
-      globalImports.add(o);
-    }
+    for (const f of info.files) files.add(relativePath(path, resolvePath(p, f)));
+    for (const m of info.fileMethods) fileMethods.add(m);
+    for (const o of info.localStaticImports) localImports.add(relativePath(path, resolvePath(p, o)));
+    for (const o of info.localDynamicImports) localImports.add(relativePath(path, resolvePath(p, o)));
+    for (const o of info.globalStaticImports) globalImports.add(o);
+    for (const o of info.globalDynamicImports) globalImports.add(o);
+  }
+
+  // Collect static imports from transitive local imports.
+  for (const i of staticImports) {
+    if (!localImports.has(i)) continue;
+    const p = resolvePath(path, i);
+    const info = getModuleInfo(root, p);
+    if (!info) continue;
+    for (const o of info.localStaticImports) staticImports.add(relativePath(path, resolvePath(p, o)));
+    for (const o of info.globalStaticImports) staticImports.add(o);
   }
 
   // Add implicit imports for files. These are technically implemented as
@@ -219,8 +214,6 @@ export async function getResolvers(page: MarkdownPage, {root, path}: {root: stri
       ? relativePath(path, `/_observablehq/${specifier.slice("observablehq:".length)}${extname(specifier) ? "" : ".js"}`) // prettier-ignore
       : resolutions.has(specifier)
       ? relativePath(path, resolutions.get(specifier)!)
-      : specifier.startsWith("npm:")
-      ? `https://cdn.jsdelivr.net/npm/${specifier.slice("npm:".length)}`
       : specifier;
   }
 
@@ -235,8 +228,6 @@ export async function getResolvers(page: MarkdownPage, {root, path}: {root: stri
       ? relativePath(path, `/_observablehq/${specifier.slice("observablehq:".length)}`)
       : resolutions.has(specifier)
       ? relativePath(path, resolutions.get(specifier)!)
-      : specifier.startsWith("npm:")
-      ? `https://cdn.jsdelivr.net/npm/${specifier.slice("npm:".length)}`
       : specifier;
   }
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,3 +1,4 @@
+import {readFile} from "node:fs/promises";
 import {basename, join} from "node:path/posix";
 import he from "he";
 import MiniSearch from "minisearch";
@@ -41,7 +42,8 @@ export async function searchIndex(config: Config, effects = defaultEffects): Pro
   const index = new MiniSearch(indexOptions);
   for await (const file of visitMarkdownFiles(root)) {
     const path = join(root, file);
-    const {html, title, data} = await parseMarkdown(path, {root, path: "/" + file.slice(0, -3)});
+    const source = await readFile(path, "utf8");
+    const {html, title, data} = parseMarkdown(source, {root, path: "/" + file.slice(0, -3)});
 
     // Skip pages that opt-out of indexing, and skip unlisted pages unless
     // opted-in. We only log the first case.

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -19,7 +19,8 @@ describe("parseMarkdown(input)", () => {
     const outname = only || skip ? name.slice(5) : name;
 
     (only ? it.only : skip ? it.skip : it)(`test/input/${name}`, async () => {
-      const snapshot = await parseMarkdown(path, {root: "test/input", path: name});
+      const source = await readFile(path, "utf8");
+      const snapshot = parseMarkdown(source, {root: "test/input", path: name});
       let allequal = true;
       for (const ext of ["html", "json"]) {
         const actual = ext === "json" ? jsonMeta(snapshot) : snapshot[ext];

--- a/test/resolvers-test.ts
+++ b/test/resolvers-test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert";
+import {parseMarkdown} from "../src/markdown.js";
+import {getResolvers} from "../src/resolvers.js";
+
+describe("getResolvers(page, {root, path})", () => {
+  const builtins = ["npm:@observablehq/runtime", "npm:@observablehq/stdlib", "observablehq:client"];
+  it("resolves directly-attached files", async () => {
+    const options = {root: "test/input", path: "attached.md"};
+    const page = parseMarkdown("${FileAttachment('foo.csv')}", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.files, new Set(["./foo.csv"]));
+  });
+  it("ignores files that are outside of the source root", async () => {
+    const options = {root: "test/input", path: "attached.md"};
+    const page = parseMarkdown("${FileAttachment('../foo.csv')}", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.files, new Set([]));
+  });
+  it("detects file methods", async () => {
+    const options = {root: "test/input", path: "attached.md"};
+    const page = parseMarkdown("${FileAttachment('foo.csv').csv}", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(["npm:d3-dsv", ...builtins]));
+  });
+  it("detects local static imports", async () => {
+    const options = {root: "test/input/imports", path: "attached.md"};
+    const page = parseMarkdown("```js\nimport './bar.js';\n```", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(["./bar.js", ...builtins]));
+    assert.deepStrictEqual(resolvers.localImports, new Set(["./bar.js"]));
+  });
+  it("detects local transitive static imports", async () => {
+    const options = {root: "test/input/imports", path: "attached.md"};
+    const page = parseMarkdown("```js\nimport './other/foo.js';\n```", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(["./other/foo.js", "./bar.js", ...builtins]));
+    assert.deepStrictEqual(resolvers.localImports, new Set(["./other/foo.js", "./bar.js"]));
+  });
+  it("detects local transitive static imports (2)", async () => {
+    const options = {root: "test/input/imports", path: "attached.md"};
+    const page = parseMarkdown("```js\nimport './transitive-static-import.js';\n```", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(["./transitive-static-import.js", "./other/foo.js", "./bar.js", ...builtins])); // prettier-ignore
+    assert.deepStrictEqual(resolvers.localImports, new Set(["./transitive-static-import.js", "./other/foo.js", "./bar.js"])); // prettier-ignore
+  });
+  it("detects local transitive dynamic imports", async () => {
+    const options = {root: "test/input/imports", path: "attached.md"};
+    const page = parseMarkdown("```js\nimport './dynamic-import.js';\n```", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(["./dynamic-import.js", ...builtins]));
+    assert.deepStrictEqual(resolvers.localImports, new Set(["./dynamic-import.js", "./bar.js"]));
+  });
+  it("detects local transitive dynamic imports (2)", async () => {
+    const options = {root: "test/input/imports", path: "attached.md"};
+    const page = parseMarkdown("```js\nimport('./dynamic-import.js');\n```", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(builtins));
+    assert.deepStrictEqual(resolvers.localImports, new Set(["./dynamic-import.js", "./bar.js"]));
+  });
+  it("detects local transitive dynamic imports (3)", async () => {
+    const options = {root: "test/input/imports", path: "attached.md"};
+    const page = parseMarkdown("```js\nimport('./transitive-dynamic-import.js');\n```", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(builtins));
+    assert.deepStrictEqual(resolvers.localImports, new Set(["./transitive-dynamic-import.js", "./other/foo.js", "./bar.js"])); // prettier-ignore
+  });
+  it("detects local transitive dynamic imports (4)", async () => {
+    const options = {root: "test/input/imports", path: "attached.md"};
+    const page = parseMarkdown("```js\nimport('./transitive-static-import.js');\n```", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(builtins));
+    assert.deepStrictEqual(resolvers.localImports, new Set(["./transitive-static-import.js", "./other/foo.js", "./bar.js"])); // prettier-ignore
+  });
+  it("detects local dynamic imports", async () => {
+    const options = {root: "test/input", path: "attached.md"};
+    const page = parseMarkdown("${import('./foo.js')}", options);
+    const resolvers = await getResolvers(page, options);
+    assert.deepStrictEqual(resolvers.staticImports, new Set(builtins));
+    assert.deepStrictEqual(resolvers.localImports, new Set(["./foo.js"]));
+  });
+});


### PR DESCRIPTION
There was a bug where a transitive static import from a dynamic import was considered a static import, but it should be considered a dynamic import. Adds more tests for `getResolvers` to increase coverage.