### PR TITLE
unpin echarts

### DIFF
--- a/docs/lib/echarts.md
+++ b/docs/lib/echarts.md
@@ -4,7 +4,7 @@ index: true
 
 # Apache ECharts
 
-[Apache ECharts](https://echarts.apache.org), an open source JavaScript visualization library, is available by default as `echarts` in Markdown. You can also import it explicitly like so:
+[Apache ECharts](https://echarts.apache.org), an open-source JavaScript visualization library, is available by default as `echarts` in Markdown. You can also import it explicitly like so:
 
 ```js run=false
 import * as echarts from "npm:echarts";

--- a/docs/lib/echarts.md
+++ b/docs/lib/echarts.md
@@ -7,7 +7,7 @@ index: true
 Apache ECharts is available by default as `echarts` in Markdown. You can also import it explicitly like so:
 
 ```js run=false
-import * as echarts from "npm:echarts/dist/echarts.esm.js";
+import * as echarts from "npm:echarts";
 ```
 
 To use ECharts, declare a container element with the desired dimensions, [display it](../javascript/display), and then call `echarts.init`.

--- a/docs/lib/echarts.md
+++ b/docs/lib/echarts.md
@@ -4,7 +4,7 @@ index: true
 
 # Apache ECharts
 
-Apache ECharts is available by default as `echarts` in Markdown. You can also import it explicitly like so:
+[Apache ECharts](https://echarts.apache.org), an open source JavaScript visualization library, is available by default as `echarts` in Markdown. You can also import it explicitly like so:
 
 ```js run=false
 import * as echarts from "npm:echarts";

--- a/src/client/stdlib/recommendedLibraries.js
+++ b/src/client/stdlib/recommendedLibraries.js
@@ -5,7 +5,7 @@ export const d3 = () => import("npm:d3");
 export const dot = () => import("observablehq:stdlib/dot").then((dot) => dot.default);
 export const duckdb = () => import("npm:@duckdb/duckdb-wasm");
 export const DuckDBClient = () => import("observablehq:stdlib/duckdb").then((duckdb) => duckdb.DuckDBClient);
-export const echarts = () => import("npm:echarts/dist/echarts.esm.min.js");
+export const echarts = () => import("npm:echarts");
 export const htl = () => import("npm:htl");
 export const html = () => import("npm:htl").then((htl) => htl.html);
 export const svg = () => import("npm:htl").then((htl) => htl.svg);

--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -20,7 +20,7 @@ export function getImplicitInputImports(inputs: Iterable<string>): Set<string> {
   if (set.has("dot")) implicits.add("npm:@observablehq/dot");
   if (set.has("duckdb")) implicits.add("npm:@duckdb/duckdb-wasm");
   if (set.has("DuckDBClient")) implicits.add("npm:@observablehq/duckdb");
-  if (set.has("echarts")) implicits.add("npm:echarts/dist/echarts.esm.min.js");
+  if (set.has("echarts")) implicits.add("npm:echarts");
   if (set.has("htl") || set.has("html") || set.has("svg")) implicits.add("npm:htl");
   if (set.has("Inputs")) implicits.add("npm:@observablehq/inputs");
   if (set.has("L")) implicits.add("npm:leaflet");

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -171,11 +171,11 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
       ? "13.0.0" // https://github.com/observablehq/framework/issues/750
       : name === "parquet-wasm"
       ? "0.5.0" // https://github.com/observablehq/framework/issues/733
-      : name === "echarts"
-      ? "5.4.3" // https://github.com/observablehq/framework/pull/811
       : undefined,
     path = name === "mermaid"
-      ? "dist/mermaid.esm.min.mjs/+esm" // TODO
+      ? "dist/mermaid.esm.min.mjs/+esm"
+      : name === "echarts"
+      ? "dist/echarts.esm.min.js"
       : "+esm"
   } = parseNpmSpecifier(specifier);
   return `/_npm/${name}@${await resolveNpmVersion(root, {name, range})}/${path.replace(/\+esm$/, "+esm.js")}`;

--- a/test/mocks/jsdelivr.ts
+++ b/test/mocks/jsdelivr.ts
@@ -10,6 +10,7 @@ const packages: [name: string, version: string][] = [
   ["canvas-confetti", "1.9.2"],
   ["d3-dsv", "3.0.1"],
   ["d3", "7.8.5"],
+  ["echarts", "5.5.0"],
   ["exceljs", "4.4.0"],
   ["htl", "0.3.1"],
   ["jszip", "3.10.1"],


### PR DESCRIPTION
Seems like the latest version works, as long as you use the correct entry (`dist/echarts.esm.min.js`).