### PR TITLE
Add OpenStreetMap attribution to Leaflet example

### DIFF
--- a/docs/lib/leaflet.md
+++ b/docs/lib/leaflet.md
@@ -21,7 +21,9 @@ div.style = "height: 400px;";
 const map = L.map(div)
   .setView([51.505, -0.09], 13);
 
-L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png")
+L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+})
   .addTo(map);
 
 L.marker([51.5, -0.09])


### PR DESCRIPTION
Use of OpenStreetMap data requires attribution. This is described on the [Copyright page](https://www.openstreetmap.org/copyright) and the [Tile Usage Guidelines](https://operations.osmfoundation.org/policies/tiles/). This PR adds attribution based on the example in the [Leaflet Quick Start](https://leafletjs.com/examples/quick-start/).