### PR TITLE
fix FileAttachment resolution in imports

### DIFF
--- a/src/client/stdlib/fileAttachment.js
+++ b/src/client/stdlib/fileAttachment.js
@@ -12,7 +12,7 @@ export function FileAttachment(name, base = location.href) {
   const file = files.get(url);
   if (!file) throw new Error(`File not found: ${name}`);
   const {path, mimeType} = file;
-  return new FileAttachmentImpl(new URL(path, base).href, name.split("/").pop(), mimeType);
+  return new FileAttachmentImpl(new URL(path, location).href, name.split("/").pop(), mimeType);
 }
 
 async function remote_fetch(file) {

--- a/test/client/stdlib/fileAttachment-test.ts
+++ b/test/client/stdlib/fileAttachment-test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert";
+import {FileAttachment, registerFile} from "../../../src/client/stdlib/fileAttachment.js";
+
+describe("FileAttachment(name)", () => {
+  before(() => {
+    globalThis.location = new URL("http://localhost:3000/test") as any;
+    registerFile("./test.csv", {"name":"./test.csv","mimeType":"text/csv","path":"./_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6"}); // prettier-ignore
+  });
+  after(() => {
+    delete (globalThis as any).location;
+  });
+  it("returns the file at the specified path", async () => {
+    const f = FileAttachment("./test.csv");
+    assert.strictEqual(f.name, "test.csv");
+    assert.strictEqual(f.mimeType, "text/csv");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+  });
+  it("normalizes the specified file path", async () => {
+    const f = FileAttachment("test.csv");
+    assert.strictEqual(f.name, "test.csv");
+    assert.strictEqual(f.mimeType, "text/csv");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+  });
+  it("resolves the specified path relative to the current location", async () => {
+    const f = FileAttachment("/test.csv");
+    assert.strictEqual(f.name, "test.csv");
+    assert.strictEqual(f.mimeType, "text/csv");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+  });
+  it("resolves the specified path relative to the specified location (1)", async () => {
+    const f = FileAttachment("/test.csv", "http://localhost:3000/sub/path");
+    assert.strictEqual(f.name, "test.csv");
+    assert.strictEqual(f.mimeType, "text/csv");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+  });
+  it("resolves the specified path relative to the specified location (2)", async () => {
+    const f = FileAttachment("../test.csv", "http://localhost:3000/sub/path");
+    assert.strictEqual(f.name, "test.csv");
+    assert.strictEqual(f.mimeType, "text/csv");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+  });
+  it("throws an error if the file does not exist", async () => {
+    assert.throws(() => FileAttachment("does-not-exist.csv"), /file not found/i);
+    assert.throws(() => FileAttachment("test.csv?found=not"), /file not found/i);
+    assert.throws(() => FileAttachment("test.csv", "http://localhost:3000/sub/path"), /file not found/i);
+  });
+  it("throws an error if used as a constructor", async () => {
+    assert.throws(() => new FileAttachment("test.csv"), /not a constructor/i);
+  });
+});

--- a/test/client/stdlib/fileAttachment-test.ts
+++ b/test/client/stdlib/fileAttachment-test.ts
@@ -13,31 +13,31 @@ describe("FileAttachment(name)", () => {
     const f = FileAttachment("./test.csv");
     assert.strictEqual(f.name, "test.csv");
     assert.strictEqual(f.mimeType, "text/csv");
-    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6"); // prettier-ignore
   });
   it("normalizes the specified file path", async () => {
     const f = FileAttachment("test.csv");
     assert.strictEqual(f.name, "test.csv");
     assert.strictEqual(f.mimeType, "text/csv");
-    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6"); // prettier-ignore
   });
   it("resolves the specified path relative to the current location", async () => {
     const f = FileAttachment("/test.csv");
     assert.strictEqual(f.name, "test.csv");
     assert.strictEqual(f.mimeType, "text/csv");
-    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6"); // prettier-ignore
   });
   it("resolves the specified path relative to the specified location (1)", async () => {
     const f = FileAttachment("/test.csv", "http://localhost:3000/sub/path");
     assert.strictEqual(f.name, "test.csv");
     assert.strictEqual(f.mimeType, "text/csv");
-    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6"); // prettier-ignore
   });
   it("resolves the specified path relative to the specified location (2)", async () => {
     const f = FileAttachment("../test.csv", "http://localhost:3000/sub/path");
     assert.strictEqual(f.name, "test.csv");
     assert.strictEqual(f.mimeType, "text/csv");
-    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6");
+    assert.strictEqual(await f.url(), "http://localhost:3000/_file/test.csv?sha=edd06c0d902e9ce083a9a5d8d0e655732c72e8129d3c60bfe69d228265e892d6"); // prettier-ignore
   });
   it("throws an error if the file does not exist", async () => {
     assert.throws(() => FileAttachment("does-not-exist.csv"), /file not found/i);


### PR DESCRIPTION
Fixes #989. The file name is resolved against `import.meta.url`, but the file path is resolved against the serving page. I’ll see if I can write some tests for this. (We don’t have many tests yet for client-side code.)