### PR TITLE
document data loaders' cwd and import.meta.url

### DIFF
--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -150,6 +150,16 @@ For example, for the file `quakes.csv`, the following data loaders are considere
 
 If you use `.py`, `.R`, `.rs`, or `.go`, the corresponding interpreter (`python3`, `Rscript`, `rust-script`, or `go run`, respectively) must be installed and available on your `$PATH`. Any additional modules, packages, libraries, _etc._, must also be installed before you can use them.
 
+Data loaders run from the same working directory as the `observable build` (or `preview`) command; in Node, you can access the current working directory by calling `process.cwd()`, and the script’s own location with [import.meta.url](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta). To compute the path of a file relative to the script location, use [import.meta.resolve](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve). For example, a data loader could read a file sitting next to it in the docs/ directory with the following command:
+
+```js run=false
+import {readFile} from "node:fs/promises";
+import {fileURLToPath} from "node:url";
+
+const table = await readFile(fileURLToPath(import.meta.resolve("./table.txt")), "utf-8");
+...
+```
+
 Whereas `.js`, `.ts`, `.py`, `.R`, `.rs`, `.go`, and `.sh` data loaders are run via interpreters, `.exe` data loaders are run directly and must have the executable bit set. This is typically done via [`chmod`](https://en.wikipedia.org/wiki/Chmod). For example:
 
 ```sh

--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -150,14 +150,13 @@ For example, for the file `quakes.csv`, the following data loaders are considere
 
 If you use `.py`, `.R`, `.rs`, or `.go`, the corresponding interpreter (`python3`, `Rscript`, `rust-script`, or `go run`, respectively) must be installed and available on your `$PATH`. Any additional modules, packages, libraries, _etc._, must also be installed before you can use them.
 
-Data loaders run from the same working directory as the `observable build` (or `preview`) command; in Node, you can access the current working directory by calling `process.cwd()`, and the script’s own location with [`import.meta.url`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta). To compute the path of a file relative to the script location, use [`import.meta.resolve`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve). For example, a data loader could read a file sitting next to it in the `docs/` directory with the following command:
+Data loaders are run in the same working directory in which you run the `observable build` or `observable preview` command, which is typically the project root. In Node, you can access the current working directory by calling `process.cwd()`, and the data loader’s source location with [`import.meta.url`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta). To compute the path of a file relative to the data loader source (rather than relative to the current working directory), use [`import.meta.resolve`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve). For example, a data loader in `docs/summary.txt.js` could read the file `docs/table.txt` as:
 
 ```js run=false
 import {readFile} from "node:fs/promises";
 import {fileURLToPath} from "node:url";
 
 const table = await readFile(fileURLToPath(import.meta.resolve("./table.txt")), "utf-8");
-...
 ```
 
 Whereas `.js`, `.ts`, `.py`, `.R`, `.rs`, `.go`, and `.sh` data loaders are run via interpreters, `.exe` data loaders are run directly and must have the executable bit set. This is typically done via [`chmod`](https://en.wikipedia.org/wiki/Chmod). For example:

--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -150,7 +150,7 @@ For example, for the file `quakes.csv`, the following data loaders are considere
 
 If you use `.py`, `.R`, `.rs`, or `.go`, the corresponding interpreter (`python3`, `Rscript`, `rust-script`, or `go run`, respectively) must be installed and available on your `$PATH`. Any additional modules, packages, libraries, _etc._, must also be installed before you can use them.
 
-Data loaders run from the same working directory as the `observable build` (or `preview`) command; in Node, you can access the current working directory by calling `process.cwd()`, and the script’s own location with [import.meta.url](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta). To compute the path of a file relative to the script location, use [import.meta.resolve](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve). For example, a data loader could read a file sitting next to it in the docs/ directory with the following command:
+Data loaders run from the same working directory as the `observable build` (or `preview`) command; in Node, you can access the current working directory by calling `process.cwd()`, and the script’s own location with [`import.meta.url`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta). To compute the path of a file relative to the script location, use [`import.meta.resolve`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve). For example, a data loader could read a file sitting next to it in the `docs/` directory with the following command:
 
 ```js run=false
 import {readFile} from "node:fs/promises";


### PR DESCRIPTION
it's possible that the example code might be too much or too convoluted… we can edit it down if it's not salvageable, and do a real-life complete example instead

closes #853

