### PR TITLE
fix stale display

### DIFF
--- a/src/client/main.js
+++ b/src/client/main.js
@@ -26,37 +26,50 @@ export function define(cell) {
   cellsById.get(id)?.variables.forEach((v) => v.delete());
   cellsById.set(id, {cell, variables});
   const root = document.querySelector(`#cell-${id}`);
-  let reset = null;
-  const clear = () => ((root.innerHTML = ""), root.classList.remove("observablehq--loading"), (reset = null));
-  const display = inline
-    ? (v) => {
-        reset?.();
-        if (isNode(v) || typeof v === "string" || !v?.[Symbol.iterator]) root.append(v);
-        else root.append(...v);
-        return v;
+  const rejected = (error) => (clear(root), console.error(error), root.append(inspectError(error)));
+  const v = main.variable({_node: root, rejected}, {shadow: {}}); // _node for visibility promise
+  if (inputs.includes("display") || inputs.includes("view")) {
+    let displayVersion = -1; // the variable._version of currently-displayed values
+    const display = inline ? displayInline : displayBlock;
+    const vd = new v.constructor(2, v._module);
+    vd.define(
+      inputs.filter((i) => i !== "display" && i !== "view"),
+      () => {
+        let version = v._version; // capture version on input change
+        return (value) => {
+          if (version < displayVersion) throw new Error("stale display");
+          else if (version > displayVersion) clear(root);
+          displayVersion = version;
+          display(root, value);
+          return value;
+        };
       }
-    : (v) => {
-        reset?.();
-        root.append(isNode(v) ? v : inspect(v));
-        return v;
-      };
-  const v = main.variable(
-    {
-      _node: root, // for visibility promise
-      pending: () => (reset = clear),
-      fulfilled: () => reset?.(),
-      rejected: (error) => (reset?.(), console.error(error), root.append(inspectError(error)))
-    },
-    {
-      shadow: {
-        display: () => display,
-        view: () => (v) => Generators.input(display(v))
-      }
+    );
+    v._shadow.set("display", vd);
+    if (inputs.includes("view")) {
+      const vv = new v.constructor(2, v._module, null, {shadow: {}});
+      vv._shadow.set("display", vd);
+      vv.define(["display"], (display) => (v) => Generators.input(display(v)));
+      v._shadow.set("view", vv);
     }
-  );
+  }
   v.define(outputs.length ? `cell ${id}` : null, inputs, body);
   variables.push(v);
   for (const o of outputs) variables.push(main.variable(true).define(o, [`cell ${id}`], (exports) => exports[o]));
+}
+
+function clear(root) {
+  root.innerHTML = "";
+  root.classList.remove("observablehq--loading");
+}
+
+function displayInline(root, value) {
+  if (isNode(value) || typeof value === "string" || !value?.[Symbol.iterator]) root.append(value);
+  else root.append(...value);
+}
+
+function displayBlock(root, value) {
+  root.append(isNode(value) ? value : inspect(value));
 }
 
 export function undefine(id) {


### PR DESCRIPTION
The `display` function now captures the current version whenever the inputs (other than `display` and `view`) change, such that when a variable is invalidated, it gets a new `display` function capturing the new version. And, we now throw an error if `display` is called with a version that is older than the last-displayed content. Users should never see this error (unless they use developer tools to break on caught exceptions), but it also prevents downstream work for a variable that has been invalidated, which is nice.

I had to reach into the Runtime internals to get this to work, because I wanted shadow variables that depend on other variables. (Normally shadow variables aren’t allowed to have any inputs, but it’s really just a limitation of the **shadow** option, not the underlying implementation.)

Fixes #995.