### PR TITLE
re-resolve npm imports; apache-arrow 15

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -159,8 +159,8 @@ export async function getDependencyResolver(
     for (const dependency of dependencies) {
       const {name: depName, path: depPath = "+esm"} = parseNpmSpecifier(dependency.slice("/npm/".length));
       const range =
-        (name === "arquero" || name === "@uwdata/mosaic-core") && depName === "apache-arrow"
-          ? "latest" // force Arquero & Mosaic to use the latest version of Arrow
+        (name === "arquero" || name === "@uwdata/mosaic-core" || name === "@duckdb/duckdb-wasm") && depName === "apache-arrow" // prettier-ignore
+          ? "latest" // force Arquero, Mosaic & DuckDB-Wasm to use the (same) latest version of Arrow
           : name === "@uwdata/mosaic-core" && depName === "@duckdb/duckdb-wasm"
           ? "1.28.0" // force Mosaic to use the latest (stable) version of DuckDB-Wasm
           : pkg.dependencies?.[depName] ?? pkg.devDependencies?.[depName] ?? pkg.peerDependencies?.[depName];

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -144,9 +144,8 @@ export async function getDependencyResolver(
   // If there are dependencies to resolve, load the package.json and use the semver
   // range there instead of the (stale) resolution that jsDelivr provides.
   if (dependencies.size > 0) {
-    await populateNpmCache(root, `/_npm/${name}@${range}/package.json`);
-    const pkgRoot = join(root, ".observablehq", "cache", "_npm", `${name}@${range}`);
-    const pkg = JSON.parse(await readFile(join(pkgRoot, "package.json"), "utf-8"));
+    const pkgPath = await populateNpmCache(root, `/_npm/${name}@${range}/package.json`);
+    const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));
     for (const dependency of dependencies) {
       const {name: depName, path: depPath = "+esm"} = parseNpmSpecifier(dependency.slice("/npm/".length));
       const range =

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -101,6 +101,15 @@ export async function populateNpmCache(root: string, path: string): Promise<stri
   return promise;
 }
 
+/**
+ * Returns an import resolver for rewriting an npm module from jsDelivr,
+ * replacing /npm/ import specifiers with relative paths, and re-resolving
+ * versions against the module’s package.json file. (jsDeliver bakes-in the
+ * exact version the first time a module is built and doesn’t update it when a
+ * new version of a dependency is published; we always want to import the latest
+ * version to ensure that we don’t load duplicate copies of transitive
+ * dependencies at different versions.)
+ */
 export async function getDependencyResolver(
   root: string,
   path: string,

--- a/test/javascript/npm-test.ts
+++ b/test/javascript/npm-test.ts
@@ -1,6 +1,17 @@
 import assert from "node:assert";
-import {rewriteNpmImports} from "../../src/npm.js";
+import {getDependencyResolver, rewriteNpmImports} from "../../src/npm.js";
 import {relativePath} from "../../src/path.js";
+import {mockJsDelivr} from "../mocks/jsdelivr.js";
+
+describe("getDependencyResolver(root, path, input)", () => {
+  mockJsDelivr();
+  it("finds /npm/ imports and re-resolves their versions", async () => {
+    const root = "test/input/build/simple-public";
+    const specifier = "/npm/d3-array@3.2.3/dist/d3-array.js";
+    const resolver = await getDependencyResolver(root, "/_npm/d3@7.8.5/+esm.js", `import '${specifier}';\n`);
+    assert.strictEqual(resolver(specifier), "../d3-array@3.2.4/dist/d3-array.js");
+  });
+});
 
 // prettier-ignore
 describe("rewriteNpmImports(input, resolve)", () => {

--- a/test/javascript/npm-test.ts
+++ b/test/javascript/npm-test.ts
@@ -11,6 +11,12 @@ describe("getDependencyResolver(root, path, input)", () => {
     const resolver = await getDependencyResolver(root, "/_npm/d3@7.8.5/+esm.js", `import '${specifier}';\n`);
     assert.strictEqual(resolver(specifier), "../d3-array@3.2.4/dist/d3-array.js");
   });
+  it("finds /npm/ import resolutions and re-resolves their versions", async () => {
+    const root = "test/input/build/simple-public";
+    const specifier = "/npm/d3-array@3.2.3/dist/d3-array.js";
+    const resolver = await getDependencyResolver(root, "/_npm/d3@7.8.5/+esm.js", `import.meta.resolve('${specifier}');\n`);
+    assert.strictEqual(resolver(specifier), "../d3-array@3.2.4/dist/d3-array.js");
+  });
 });
 
 // prettier-ignore

--- a/test/javascript/npm-test.ts
+++ b/test/javascript/npm-test.ts
@@ -1,49 +1,57 @@
 import assert from "node:assert";
 import {rewriteNpmImports} from "../../src/npm.js";
+import {relativePath} from "../../src/path.js";
 
 // prettier-ignore
-describe("rewriteNpmImports(input, path)", () => {
+describe("rewriteNpmImports(input, resolve)", () => {
   it("rewrites /npm/ imports to /_npm/", () => {
-    assert.strictEqual(rewriteNpmImports('export * from "/npm/d3-array@3.2.4/dist/d3-array.js";\n', "/_npm/d3@7.8.5/dist/d3.js"), 'export * from "../../d3-array@3.2.4/dist/d3-array.js";\n');
+    assert.strictEqual(rewriteNpmImports('export * from "/npm/d3-array@3.2.4/dist/d3-array.js";\n', (v) => resolve("/_npm/d3@7.8.5/dist/d3.js", v)), 'export * from "../../d3-array@3.2.4/dist/d3-array.js";\n');
   });
   it("rewrites /npm/…+esm imports to +esm.js", () => {
-    assert.strictEqual(rewriteNpmImports('export * from "/npm/d3-array@3.2.4/+esm";\n', "/_npm/d3@7.8.5/+esm.js"), 'export * from "../d3-array@3.2.4/+esm.js";\n');
+    assert.strictEqual(rewriteNpmImports('export * from "/npm/d3-array@3.2.4/+esm";\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'export * from "../d3-array@3.2.4/+esm.js";\n');
   });
   it("rewrites /npm/ imports to a relative path", () => {
-    assert.strictEqual(rewriteNpmImports('import "/npm/d3-array@3.2.4/dist/d3-array.js";\n', "/_npm/d3@7.8.5/dist/d3.js"), 'import "../../d3-array@3.2.4/dist/d3-array.js";\n');
-    assert.strictEqual(rewriteNpmImports('import "/npm/d3-array@3.2.4/dist/d3-array.js";\n', "/_npm/d3@7.8.5/d3.js"), 'import "../d3-array@3.2.4/dist/d3-array.js";\n');
+    assert.strictEqual(rewriteNpmImports('import "/npm/d3-array@3.2.4/dist/d3-array.js";\n', (v) => resolve("/_npm/d3@7.8.5/dist/d3.js", v)), 'import "../../d3-array@3.2.4/dist/d3-array.js";\n');
+    assert.strictEqual(rewriteNpmImports('import "/npm/d3-array@3.2.4/dist/d3-array.js";\n', (v) => resolve("/_npm/d3@7.8.5/d3.js", v)), 'import "../d3-array@3.2.4/dist/d3-array.js";\n');
   });
   it("rewrites named imports", () => {
-    assert.strictEqual(rewriteNpmImports('import {sort} from "/npm/d3-array@3.2.4/+esm";\n', "/_npm/d3@7.8.5/+esm.js"), 'import {sort} from "../d3-array@3.2.4/+esm.js";\n');
+    assert.strictEqual(rewriteNpmImports('import {sort} from "/npm/d3-array@3.2.4/+esm";\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import {sort} from "../d3-array@3.2.4/+esm.js";\n');
   });
   it("rewrites empty imports", () => {
-    assert.strictEqual(rewriteNpmImports('import "/npm/d3-array@3.2.4/+esm";\n', "/_npm/d3@7.8.5/+esm.js"), 'import "../d3-array@3.2.4/+esm.js";\n');
+    assert.strictEqual(rewriteNpmImports('import "/npm/d3-array@3.2.4/+esm";\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import "../d3-array@3.2.4/+esm.js";\n');
   });
   it("rewrites default imports", () => {
-    assert.strictEqual(rewriteNpmImports('import d3 from "/npm/d3-array@3.2.4/+esm";\n', "/_npm/d3@7.8.5/+esm.js"), 'import d3 from "../d3-array@3.2.4/+esm.js";\n');
+    assert.strictEqual(rewriteNpmImports('import d3 from "/npm/d3-array@3.2.4/+esm";\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import d3 from "../d3-array@3.2.4/+esm.js";\n');
   });
   it("rewrites namespace imports", () => {
-    assert.strictEqual(rewriteNpmImports('import * as d3 from "/npm/d3-array@3.2.4/+esm";\n', "/_npm/d3@7.8.5/+esm.js"), 'import * as d3 from "../d3-array@3.2.4/+esm.js";\n');
+    assert.strictEqual(rewriteNpmImports('import * as d3 from "/npm/d3-array@3.2.4/+esm";\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import * as d3 from "../d3-array@3.2.4/+esm.js";\n');
   });
   it("rewrites named exports", () => {
-    assert.strictEqual(rewriteNpmImports('export {sort} from "/npm/d3-array@3.2.4/+esm";\n', "/_npm/d3@7.8.5/+esm.js"), 'export {sort} from "../d3-array@3.2.4/+esm.js";\n');
+    assert.strictEqual(rewriteNpmImports('export {sort} from "/npm/d3-array@3.2.4/+esm";\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'export {sort} from "../d3-array@3.2.4/+esm.js";\n');
   });
   it("rewrites namespace exports", () => {
-    assert.strictEqual(rewriteNpmImports('export * from "/npm/d3-array@3.2.4/+esm";\n', "/_npm/d3@7.8.5/+esm.js"), 'export * from "../d3-array@3.2.4/+esm.js";\n');
+    assert.strictEqual(rewriteNpmImports('export * from "/npm/d3-array@3.2.4/+esm";\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'export * from "../d3-array@3.2.4/+esm.js";\n');
   });
   it("rewrites dynamic imports with static module specifiers", () => {
-    assert.strictEqual(rewriteNpmImports('import("/npm/d3-array@3.2.4/+esm");\n', "/_npm/d3@7.8.5/+esm.js"), 'import("../d3-array@3.2.4/+esm.js");\n');
-    assert.strictEqual(rewriteNpmImports("import(`/npm/d3-array@3.2.4/+esm`);\n", "/_npm/d3@7.8.5/+esm.js"), 'import("../d3-array@3.2.4/+esm.js");\n');
-    assert.strictEqual(rewriteNpmImports("import('/npm/d3-array@3.2.4/+esm');\n", "/_npm/d3@7.8.5/+esm.js"), 'import("../d3-array@3.2.4/+esm.js");\n');
+    assert.strictEqual(rewriteNpmImports('import("/npm/d3-array@3.2.4/+esm");\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import("../d3-array@3.2.4/+esm.js");\n');
+    assert.strictEqual(rewriteNpmImports("import(`/npm/d3-array@3.2.4/+esm`);\n", (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import("../d3-array@3.2.4/+esm.js");\n');
+    assert.strictEqual(rewriteNpmImports("import('/npm/d3-array@3.2.4/+esm');\n", (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import("../d3-array@3.2.4/+esm.js");\n');
   });
   it("ignores dynamic imports with dynamic module specifiers", () => {
-    assert.strictEqual(rewriteNpmImports('import(`/npm/d3-array@${"3.2.4"}/+esm`);\n', "/_npm/d3@7.8.5/+esm.js"), 'import(`/npm/d3-array@${"3.2.4"}/+esm`);\n');
+    assert.strictEqual(rewriteNpmImports('import(`/npm/d3-array@${"3.2.4"}/+esm`);\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import(`/npm/d3-array@${"3.2.4"}/+esm`);\n');
   });
   it("ignores dynamic imports with dynamic module specifiers", () => {
-    assert.strictEqual(rewriteNpmImports('import(`/npm/d3-array@${"3.2.4"}/+esm`);\n', "/_npm/d3@7.8.5/+esm.js"), 'import(`/npm/d3-array@${"3.2.4"}/+esm`);\n');
+    assert.strictEqual(rewriteNpmImports('import(`/npm/d3-array@${"3.2.4"}/+esm`);\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import(`/npm/d3-array@${"3.2.4"}/+esm`);\n');
   });
   it("strips the sourceMappingURL declaration", () => {
-    assert.strictEqual(rewriteNpmImports('import(`/npm/d3-array@${"3.2.4"}/+esm`);\n//# sourceMappingURL=index.js.map', "/_npm/d3@7.8.5/+esm.js"), 'import(`/npm/d3-array@${"3.2.4"}/+esm`);\n');
-    assert.strictEqual(rewriteNpmImports('import(`/npm/d3-array@${"3.2.4"}/+esm`);\n//# sourceMappingURL=index.js.map\n', "/_npm/d3@7.8.5/+esm.js"), 'import(`/npm/d3-array@${"3.2.4"}/+esm`);\n');
+    assert.strictEqual(rewriteNpmImports('import(`/npm/d3-array@${"3.2.4"}/+esm`);\n//# sourceMappingURL=index.js.map', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import(`/npm/d3-array@${"3.2.4"}/+esm`);\n');
+    assert.strictEqual(rewriteNpmImports('import(`/npm/d3-array@${"3.2.4"}/+esm`);\n//# sourceMappingURL=index.js.map\n', (v) => resolve("/_npm/d3@7.8.5/+esm.js", v)), 'import(`/npm/d3-array@${"3.2.4"}/+esm`);\n');
   });
 });
+
+function resolve(path: string, specifier: string): string {
+  if (!specifier.startsWith("/npm/")) return specifier;
+  specifier = `/_npm/${specifier.slice("/npm/".length)}`;
+  if (specifier.endsWith("/+esm")) specifier += ".js";
+  return relativePath(path, specifier);
+}

--- a/test/mocks/jsdelivr.ts
+++ b/test/mocks/jsdelivr.ts
@@ -39,6 +39,10 @@ export function mockJsDelivr() {
         .intercept({path: new RegExp(`^/npm/${name}@${version}/`), method: "GET"})
         .reply(200, "", {headers: {"cache-control": "public, immutable", "content-type": "text/javascript; charset=utf-8"}})
         .persist(); // prettier-ignore
+      cdnClient
+        .intercept({path: new RegExp(`^/npm/${name}@${version}/package.json`), method: "GET"})
+        .reply(200, "", {headers: {"cache-control": "public, immutable", "content-type": "application/json; charset=utf-8"}})
+        .persist(); // prettier-ignore
     }
   });
 }

--- a/test/mocks/jsdelivr.ts
+++ b/test/mocks/jsdelivr.ts
@@ -5,7 +5,7 @@ const packages: [name: string, {version: string; dependencies?: Record<string, s
   ["@observablehq/inputs", {version: "0.10.6"}],
   ["@observablehq/plot", {version: "0.6.11"}],
   ["@viz-js/viz", {version: "3.2.3"}],
-  ["apache-arrow", {version: "14.0.1"}],
+  ["apache-arrow", {version: "15.0.1"}],
   ["arquero", {version: "5.3.0"}],
   ["canvas-confetti", {version: "1.9.2"}],
   ["d3-array", {version: "3.2.4"}],

--- a/test/mocks/jsdelivr.ts
+++ b/test/mocks/jsdelivr.ts
@@ -1,27 +1,28 @@
 import {getCurrentAgent, mockAgent} from "./undici.js";
 
-const packages: [name: string, version: string][] = [
-  ["@duckdb/duckdb-wasm", "1.28.0"],
-  ["@observablehq/inputs", "0.10.6"],
-  ["@observablehq/plot", "0.6.11"],
-  ["@viz-js/viz", "3.2.3"],
-  ["apache-arrow", "14.0.1"],
-  ["arquero", "5.3.0"],
-  ["canvas-confetti", "1.9.2"],
-  ["d3-dsv", "3.0.1"],
-  ["d3", "7.8.5"],
-  ["echarts", "5.5.0"],
-  ["exceljs", "4.4.0"],
-  ["htl", "0.3.1"],
-  ["jszip", "3.10.1"],
-  ["katex", "0.16.9"],
-  ["leaflet", "1.9.4"],
-  ["lodash", "4.17.21"],
-  ["mapbox-gl", "3.1.2"],
-  ["mermaid", "10.6.1"],
-  ["parquet-wasm", "0.6.0-beta.1"],
-  ["sql.js", "1.9.0"],
-  ["topojson-client", "3.1.0"]
+const packages: [name: string, {version: string; dependencies?: Record<string, string>}][] = [
+  ["@duckdb/duckdb-wasm", {version: "1.28.0"}],
+  ["@observablehq/inputs", {version: "0.10.6"}],
+  ["@observablehq/plot", {version: "0.6.11"}],
+  ["@viz-js/viz", {version: "3.2.3"}],
+  ["apache-arrow", {version: "14.0.1"}],
+  ["arquero", {version: "5.3.0"}],
+  ["canvas-confetti", {version: "1.9.2"}],
+  ["d3-array", {version: "3.2.4"}],
+  ["d3-dsv", {version: "3.0.1"}],
+  ["d3", {version: "7.8.5", dependencies: {"d3-array": "3"}}],
+  ["echarts", {version: "5.5.0"}],
+  ["exceljs", {version: "4.4.0"}],
+  ["htl", {version: "0.3.1"}],
+  ["jszip", {version: "3.10.1"}],
+  ["katex", {version: "0.16.9"}],
+  ["leaflet", {version: "1.9.4"}],
+  ["lodash", {version: "4.17.21"}],
+  ["mapbox-gl", {version: "3.1.2"}],
+  ["mermaid", {version: "10.6.1"}],
+  ["parquet-wasm", {version: "0.6.0-beta.1"}],
+  ["sql.js", {version: "1.9.0"}],
+  ["topojson-client", {version: "3.1.0"}]
 ];
 
 export function mockJsDelivr() {
@@ -30,18 +31,18 @@ export function mockJsDelivr() {
     const agent = getCurrentAgent();
     const dataClient = agent.get("https://data.jsdelivr.com");
     const cdnClient = agent.get("https://cdn.jsdelivr.net");
-    for (const [name, version] of packages) {
+    for (const [name, pkg] of packages) {
       dataClient
-        .intercept({path: `/v1/packages/npm/${name}/resolved`, method: "GET"})
-        .reply(200, {version}, {headers: {"content-type": "application/json; charset=utf-8"}})
+        .intercept({path: new RegExp(`^/v1/packages/npm/${name}/resolved(\\?specifier=|$)`), method: "GET"})
+        .reply(200, {version: pkg.version}, {headers: {"content-type": "application/json; charset=utf-8"}})
         .persist();
       cdnClient
-        .intercept({path: new RegExp(`^/npm/${name}@${version}/`), method: "GET"})
-        .reply(200, "", {headers: {"cache-control": "public, immutable", "content-type": "text/javascript; charset=utf-8"}})
+        .intercept({path: `/npm/${name}@${pkg.version}/package.json`, method: "GET"})
+        .reply(200, pkg, {headers: {"content-type": "application/json; charset=utf-8"}})
         .persist(); // prettier-ignore
       cdnClient
-        .intercept({path: new RegExp(`^/npm/${name}@${version}/package.json`), method: "GET"})
-        .reply(200, "", {headers: {"cache-control": "public, immutable", "content-type": "application/json; charset=utf-8"}})
+        .intercept({path: new RegExp(`^/npm/${name}@${pkg.version}/`), method: "GET"})
+        .reply(200, "", {headers: {"cache-control": "public, immutable", "content-type": "text/javascript; charset=utf-8"}})
         .persist(); // prettier-ignore
     }
   });


### PR DESCRIPTION
Fixes #1019. Rather than relying on the versions baked-in to jsDelivr, we now download the `package.json` and re-resolve the versions of transitive dependencies. This ensures that you get consistent versions, when possible, of transitive dependencies. In addition, we override @uwdata/mosaic-core’s dependencies on @duckdb/duckdb-wasm and apache-arrow to match Framework’s pinned versions.

Loading the `package.json` is a bit slow, but I can’t think of a faster way to do this. Perhaps we could have an `observable install` command that you can run from the command-line to populate the npm cache for all known pages. We could then run that command as part of `observable create` so you don’t experience slow page loads.