### PR TITLE
Prompt for access level during project creation.

### DIFF
--- a/src/observableApiClient.ts
+++ b/src/observableApiClient.ts
@@ -101,16 +101,18 @@ export class ObservableApiClient {
   async postProject({
     title,
     slug,
-    workspaceId
+    workspaceId,
+    accessLevel
   }: {
     title: string;
     slug: string;
     workspaceId: string;
+    accessLevel: string;
   }): Promise<PostProjectResponse> {
     return await this._fetch<PostProjectResponse>(new URL("/cli/project", this._apiOrigin), {
       method: "POST",
       headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({title, slug, workspace: workspaceId})
+      body: JSON.stringify({title, slug, workspace: workspaceId, accessLevel})
     });
   }
 
@@ -225,6 +227,7 @@ export interface WorkspaceResponse {
 export type PostProjectResponse = GetProjectResponse;
 
 export interface GetProjectResponse {
+  accessLevel: string;
   id: string;
   slug: string;
   title: string;

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -213,7 +213,7 @@ describe("deploy", () => {
       .start();
 
     const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG, isTty: true});
-    effects.clack.inputs.push(null, DEPLOY_CONFIG.projectSlug, "fix some bugs");
+    effects.clack.inputs.push(null, DEPLOY_CONFIG.projectSlug, "private", "fix some bugs");
 
     await deploy(TEST_OPTIONS, effects);
 
@@ -484,6 +484,7 @@ describe("deploy", () => {
     const effects = new MockDeployEffects();
     effects.clack.inputs.push(null); // which project do you want to use?
     effects.clack.inputs.push("test-project"); // which slug do you want to use?
+    effects.clack.inputs.push("private"); // who is allowed to access your project?
 
     try {
       await deploy(TEST_OPTIONS, effects);
@@ -687,15 +688,18 @@ describe("promptDeployTarget", () => {
     const effects = new MockDeployEffects();
     const workspace = userWithTwoWorkspaces.workspaces[1];
     const projectSlug = "new-project";
+    const accessLevel = "private";
     effects.clack.inputs = [
       workspace, // which workspace do you want to use?
       true, //
-      projectSlug // what slug do you want to use
+      projectSlug, // what slug do you want to use
+      accessLevel // who is allowed to access your project?
     ];
     const api = new ObservableApiClient({apiKey: {key: validApiKey, source: "test"}});
     getCurrentObservableApi().handleGetWorkspaceProjects({workspaceLogin: workspace.login, projects: []}).start();
     const result = await promptDeployTarget(effects, api, TEST_CONFIG, userWithTwoWorkspaces);
     assert.deepEqual(result, {
+      accessLevel,
       create: true,
       projectSlug,
       title: "Mock BI",

--- a/test/mocks/observableApi.ts
+++ b/test/mocks/observableApi.ts
@@ -95,17 +95,20 @@ class ObservableApiMock {
     projectSlug,
     projectId = "project123",
     title = "Mock BI",
+    accessLevel = "private",
     status = 200
   }: {
     workspaceLogin: string;
     projectSlug: string;
     projectId?: string;
     title?: string;
+    accessLevel?: string;
     status?: number;
   }): ObservableApiMock {
     const response =
       status === 200
         ? JSON.stringify({
+            accessLevel,
             id: projectId,
             slug: projectSlug,
             title,
@@ -126,12 +129,14 @@ class ObservableApiMock {
     projectId = "project123",
     workspaceId = workspaces[0].id,
     slug = "mock-project",
+    accessLevel = "private",
     status = 200
   }: {
     projectId?: string;
     title?: string;
     slug?: string;
     workspaceId?: string;
+    accessLevel?: string;
     status?: number;
   } = {}): ObservableApiMock {
     const owner = workspaces.find((w) => w.id === workspaceId);
@@ -140,6 +145,7 @@ class ObservableApiMock {
     const response =
       status == 200
         ? JSON.stringify({
+            accessLevel,
             id: projectId,
             slug,
             title: "Mock Project",
@@ -181,7 +187,7 @@ class ObservableApiMock {
     status = 200
   }: {
     workspaceLogin: string;
-    projects: {slug: string; id: string; title?: string}[];
+    projects: {slug: string; id: string; title?: string; accessLevel?: string}[];
     status?: number;
   }): ObservableApiMock {
     const owner = workspaces.find((w) => w.login === workspaceLogin);
@@ -190,7 +196,13 @@ class ObservableApiMock {
     const response =
       status === 200
         ? JSON.stringify({
-            results: projects.map((p) => ({...p, creator, owner, title: p.title ?? "Mock Title"}))
+            results: projects.map((p) => ({
+              ...p,
+              creator,
+              owner,
+              title: p.title ?? "Mock Title",
+              accessLevel: p.accessLevel ?? "private"
+            }))
           } satisfies PaginatedList<GetProjectResponse>)
         : emptyErrorBody;
     const headers = authorizationHeader(status !== 403);


### PR DESCRIPTION
Resolves https://github.com/observablehq/framework/issues/879

The Observable API postProject endpoint already supports an access level (private/public), so expose that as a selection during project creation. Defaults to private.

Looks like:

```
│
◆  Who is allowed to access your project?
│  ● Private (only allow workspace members)
│  ○ Public
└
```

```
│
◆  Who is allowed to access your project?
│  ○ Private
│  ● Public (allow anyone)
└
```