### PR TITLE
linkify carefully

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -279,12 +279,11 @@ export interface ParseOptions {
   style?: Config["style"];
 }
 
-export function parseMarkdown(
-  input: string,
-  {root, path, markdownIt = (md) => md, style: configStyle}: ParseOptions
-): MarkdownPage {
+export function parseMarkdown(input: string, {root, path, markdownIt, style: configStyle}: ParseOptions): MarkdownPage {
   const parts = matter(input, {});
-  const md = markdownIt(MarkdownIt({html: true}));
+  let md = MarkdownIt({html: true, linkify: true});
+  md.linkify.set({fuzzyLink: false, fuzzyEmail: false});
+  if (typeof markdownIt === "function") md = markdownIt(md);
   md.use(MarkdownItAnchor, {permalink: MarkdownItAnchor.permalink.headerLink({class: "observablehq-header-anchor"})});
   md.inline.ruler.push("placeholder", transformPlaceholderInline);
   md.core.ruler.before("linkify", "placeholder", transformPlaceholderCore);

--- a/test/input/linkify.md
+++ b/test/input/linkify.md
@@ -1,0 +1,8 @@
+# Linkify
+
+https://observablehq.com/ is a link to https://observablehq.com.
+
+mailto:support@observablehq.com is a link too.
+
+Observablehq.com and support@observablehq.com are not links, since by default we disable fuzzy links.
+

--- a/test/output/linkify.html
+++ b/test/output/linkify.html
@@ -1,0 +1,4 @@
+<h1 id="linkify" tabindex="-1"><a class="observablehq-header-anchor" href="#linkify">Linkify</a></h1>
+<p><a href="https://observablehq.com/">https://observablehq.com/</a> is a link to <a href="https://observablehq.com">https://observablehq.com</a>.</p>
+<p><a href="mailto:support@observablehq.com">mailto:support@observablehq.com</a> is a link too.</p>
+<p>Observablehq.com and support@observablehq.com are not links, since by default we disable fuzzy links.</p>

--- a/test/output/linkify.md.json
+++ b/test/output/linkify.md.json
@@ -1,0 +1,6 @@
+{
+  "data": null,
+  "title": "Linkify",
+  "style": null,
+  "code": []
+}


### PR DESCRIPTION
I know this can be done with markdownit plugins, but I feel that it is a basic requirement and I'm surprised each time I type a URL and it doesn't link.

However I disable so-called "fuzzy links", because 1. they're too invasive and risk matching on false positive text and 2. they're wrong (e.g. they use http:// when we'd most of the time want https:// anyway).

Relevant API documentation: https://markdown-it.github.io/linkify-it/doc/