### PR TITLE
resolve script[src]

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -18,7 +18,9 @@ const ASSET_PROPERTIES: readonly [selector: string, src: string][] = [
 ];
 
 export function isJavaScript({type}: HTMLScriptElement): boolean {
-  return !type || type === "text/javascript" || type === "application/javascript" || type === "module";
+  if (!type) return true;
+  type = type.toLowerCase();
+  return type === "text/javascript" || type === "application/javascript" || type === "module";
 }
 
 export function parseHtml(html: string): DOMWindow {

--- a/src/html.ts
+++ b/src/html.ts
@@ -3,7 +3,7 @@ import he from "he";
 import hljs from "highlight.js";
 import type {DOMWindow} from "jsdom";
 import {JSDOM, VirtualConsole} from "jsdom";
-import {relativePath, resolveLocalPath} from "./path.js";
+import {isAssetPath, relativePath, resolveLocalPath} from "./path.js";
 
 const ASSET_PROPERTIES: readonly [selector: string, src: string][] = [
   ["a[href][download]", "href"],
@@ -17,53 +17,89 @@ const ASSET_PROPERTIES: readonly [selector: string, src: string][] = [
   ["video[src]", "src"]
 ];
 
-export function isAssetPath(specifier: string): boolean {
-  return !/^(\w+:|#)/.test(specifier);
+export function isJavaScript({type}: HTMLScriptElement): boolean {
+  return !type || type === "text/javascript" || type === "application/javascript" || type === "module";
 }
 
 export function parseHtml(html: string): DOMWindow {
   return new JSDOM(`<!DOCTYPE html><body>${html}`, {virtualConsole: new VirtualConsole()}).window;
 }
 
-export function findAssets(html: string, path: string): Set<string> {
-  const {document} = parseHtml(html);
-  const assets = new Set<string>();
+interface Assets {
+  files: Set<string>;
+  localImports: Set<string>;
+  globalImports: Set<string>;
+}
 
-  const maybeAsset = (specifier: string): void => {
+export function findAssets(html: string, path: string): Assets {
+  const {document} = parseHtml(html);
+  const files = new Set<string>();
+  const localImports = new Set<string>();
+  const globalImports = new Set<string>();
+
+  const maybeFile = (specifier: string): void => {
     if (!isAssetPath(specifier)) return;
     const localPath = resolveLocalPath(path, specifier);
     if (!localPath) return console.warn(`non-local asset path: ${specifier}`);
-    assets.add(relativePath(path, localPath));
+    files.add(relativePath(path, localPath));
   };
 
   for (const [selector, src] of ASSET_PROPERTIES) {
     for (const element of document.querySelectorAll(selector)) {
-      const source = decodeURIComponent(element.getAttribute(src)!);
+      const source = decodeURI(element.getAttribute(src)!);
       if (src === "srcset") {
         for (const s of parseSrcset(source)) {
-          maybeAsset(s);
+          maybeFile(s);
         }
       } else {
-        maybeAsset(source);
+        maybeFile(source);
       }
     }
   }
 
-  return assets;
+  for (const script of document.querySelectorAll<HTMLScriptElement>("script[src]")) {
+    const src = script.getAttribute("src")!;
+    if (isJavaScript(script)) {
+      if (isAssetPath(src)) {
+        const localPath = resolveLocalPath(path, src);
+        if (!localPath) {
+          console.warn(`non-local asset path: ${src}`);
+          continue;
+        }
+        localImports.add(relativePath(path, localPath));
+      } else {
+        globalImports.add(src);
+      }
+    } else {
+      maybeFile(src);
+    }
+  }
+
+  return {files, localImports, globalImports};
 }
 
-export function rewriteHtml(html: string, resolve: (specifier: string) => string = String): string {
+interface HtmlResolvers {
+  resolveFile?: (specifier: string) => string;
+  resolveScript?: (specifier: string) => string;
+}
+
+export function rewriteHtml(html: string, {resolveFile = String, resolveScript = String}: HtmlResolvers): string {
   const {document} = parseHtml(html);
 
-  const maybeResolve = (specifier: string): string => {
-    return isAssetPath(specifier) ? resolve(specifier) : specifier;
+  const maybeResolveFile = (specifier: string): string => {
+    return isAssetPath(specifier) ? resolveFile(specifier) : specifier;
   };
 
   for (const [selector, src] of ASSET_PROPERTIES) {
     for (const element of document.querySelectorAll(selector)) {
-      const source = decodeURIComponent(element.getAttribute(src)!);
-      element.setAttribute(src, src === "srcset" ? resolveSrcset(source, maybeResolve) : maybeResolve(source));
+      const source = decodeURI(element.getAttribute(src)!);
+      element.setAttribute(src, src === "srcset" ? resolveSrcset(source, maybeResolveFile) : maybeResolveFile(source));
     }
+  }
+
+  for (const script of document.querySelectorAll<HTMLScriptElement>("script[src]")) {
+    const src = decodeURI(script.getAttribute("src")!);
+    script.setAttribute("src", (isJavaScript(script) ? resolveScript : maybeResolveFile)(src));
   }
 
   // Syntax highlighting for <code> elements. The code could contain an inline

--- a/src/javascript/imports.ts
+++ b/src/javascript/imports.ts
@@ -71,7 +71,7 @@ export function findImports(body: Node, path: string, input: string): ImportRefe
   function findImport(node: ImportNode | ExportNode) {
     const source = node.source;
     if (!source || !isStringLiteral(source)) return;
-    const name = decodeURIComponent(getStringLiteralValue(source));
+    const name = decodeURI(getStringLiteralValue(source));
     const method = node.type === "ImportExpression" ? "dynamic" : "static";
     if (isPathImport(name)) {
       const localPath = resolveLocalPath(path, name);
@@ -85,7 +85,7 @@ export function findImports(body: Node, path: string, input: string): ImportRefe
   function findImportMetaResolve(node: CallExpression) {
     const source = node.arguments[0];
     if (!isImportMetaResolve(node) || !isStringLiteral(source)) return;
-    const name = decodeURIComponent(getStringLiteralValue(source));
+    const name = decodeURI(getStringLiteralValue(source));
     if (isPathImport(name)) {
       const localPath = resolveLocalPath(path, name);
       if (!localPath) throw syntaxError(`non-local import: ${name}`, node, input); // prettier-ignore

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -334,7 +334,7 @@ export function parseMarkdown(input: string, {md, path, style: configStyle}: Par
   const code: MarkdownCode[] = [];
   const context: ParseContext = {code, startLine: 0, currentLine: 0, path};
   const tokens = md.parse(content, context);
-  const html = md.renderer.render(tokens, md.options, context); // Note: mutates code, assets!
+  const html = md.renderer.render(tokens, md.options, context); // Note: mutates code!
   const style = getStylesheet(path, data, configStyle);
   return {
     html,

--- a/src/path.ts
+++ b/src/path.ts
@@ -48,6 +48,20 @@ export function resolveLocalPath(source: string, target: string): string | null 
   return path;
 }
 
+/**
+ * Returns true if the specified specifier refers to a local path, as opposed to
+ * a global import from npm or a URL. Local paths start with ./, ../, or /.
+ */
 export function isPathImport(specifier: string): boolean {
   return ["./", "../", "/"].some((prefix) => specifier.startsWith(prefix));
+}
+
+/**
+ * Like isPathImport, but more lax; this is used to detect when an HTML element
+ * such as an image refers to a local asset. Whereas isPathImport requires a
+ * local path to start with ./, ../, or /, isAssetPath only requires that a
+ * local path not start with a protocol (e.g., http: or https:) or a hash (#).
+ */
+export function isAssetPath(specifier: string): boolean {
+  return !/^(\w+:|#)/.test(specifier);
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -92,7 +92,7 @@ export class PreviewServer {
     if (this._verbose) console.log(faint(req.method!), req.url);
     try {
       const url = new URL(req.url!, "http://localhost");
-      let pathname = decodeURIComponent(url.pathname);
+      let pathname = decodeURI(url.pathname);
       let match: RegExpExecArray | null;
       if (pathname === "/_observablehq/client.js") {
         end(req, res, await rollupClient(getClientPath("preview.js"), root, pathname), "text/javascript");
@@ -334,7 +334,7 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, config: Config) {
 
   async function hello({path: initialPath, hash: initialHash}: {path: string; hash: string}): Promise<void> {
     if (markdownWatcher || attachmentWatcher) throw new Error("already watching");
-    path = decodeURIComponent(initialPath);
+    path = decodeURI(initialPath);
     if (!(path = normalize(path)).startsWith("/")) throw new Error("Invalid path: " + initialPath);
     if (path.endsWith("/")) path += "index";
     path = join(dirname(path), basename(path, ".html") + ".md");
@@ -390,8 +390,8 @@ function handleWatch(socket: WebSocket, req: IncomingMessage, config: Config) {
   }
 }
 
-function getHtml({html}: MarkdownPage, {resolveFile}: Resolvers): string[] {
-  return Array.from(parseHtml(rewriteHtml(html, resolveFile)).document.body.children, (d) => d.outerHTML);
+function getHtml({html}: MarkdownPage, resolvers: Resolvers): string[] {
+  return Array.from(parseHtml(rewriteHtml(html, resolvers)).document.body.children, (d) => d.outerHTML);
 }
 
 function getCode({code}: MarkdownPage, resolvers: Resolvers): Map<string, string> {

--- a/src/render.ts
+++ b/src/render.ts
@@ -79,7 +79,7 @@ ${preview ? `\nopen({hash: ${JSON.stringify(resolvers.hash)}, eval: (body) => ev
   }
 <div id="observablehq-center">${renderHeader(options, data)}
 <main id="observablehq-main" class="observablehq${draft ? " observablehq--draft" : ""}">
-${html.unsafe(rewriteHtml(page.html, resolvers.resolveFile))}</main>${renderFooter(path, options, data, normalizeLink)}
+${html.unsafe(rewriteHtml(page.html, resolvers))}</main>${renderFooter(path, options, data, normalizeLink)}
 </div>
 `);
 }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -9,19 +9,20 @@ import {getImplicitFileImports, getImplicitInputImports} from "./libraries.js";
 import {getImplicitStylesheets} from "./libraries.js";
 import type {MarkdownPage} from "./markdown.js";
 import {extractNpmSpecifier, populateNpmCache, resolveNpmImport, resolveNpmImports} from "./npm.js";
-import {isPathImport, relativePath, resolvePath} from "./path.js";
+import {isAssetPath, isPathImport, relativePath, resolveLocalPath, resolvePath} from "./path.js";
 
 export interface Resolvers {
   hash: string;
-  assets: Set<string>;
+  assets: Set<string>; // like files, but not registered for FileAttachment
   files: Set<string>;
   localImports: Set<string>;
   globalImports: Set<string>;
   staticImports: Set<string>;
-  stylesheets: Set<string>;
+  stylesheets: Set<string>; // stylesheets to be added by render
   resolveFile(specifier: string): string;
   resolveImport(specifier: string): string;
   resolveStylesheet(specifier: string): string;
+  resolveScript(specifier: string): string;
 }
 
 const defaultImports = [
@@ -73,7 +74,7 @@ export async function getResolvers(
   {root, path, loaders}: {root: string; path: string; loaders: LoaderResolver}
 ): Promise<Resolvers> {
   const hash = createHash("sha256").update(page.html).update(JSON.stringify(page.data));
-  const assets = findAssets(page.html, path);
+  const assets = new Set<string>();
   const files = new Set<string>();
   const fileMethods = new Set<string>();
   const localImports = new Set<string>();
@@ -81,6 +82,12 @@ export async function getResolvers(
   const staticImports = new Set<string>(defaultImports);
   const stylesheets = new Set<string>();
   const resolutions = new Map<string, string>();
+
+  // Add assets.
+  const info = findAssets(page.html, path);
+  for (const f of info.files) assets.add(f);
+  for (const i of info.localImports) localImports.add(i), staticImports.add(i);
+  for (const i of info.globalImports) globalImports.add(i), staticImports.add(i);
 
   // Add stylesheets. TODO Instead of hard-coding Source Serif Pro, parse the
   // page’s stylesheet to look for external imports.
@@ -242,6 +249,15 @@ export async function getResolvers(
       : specifier;
   }
 
+  function resolveScript(src: string): string {
+    if (isAssetPath(src)) {
+      const localPath = resolveLocalPath(path, src);
+      return localPath ? resolveImport(relativePath(path, localPath)) : src;
+    } else {
+      return resolveImport(src);
+    }
+  }
+
   return {
     hash: hash.digest("hex"),
     assets,
@@ -252,6 +268,7 @@ export async function getResolvers(
     stylesheets,
     resolveFile,
     resolveImport,
+    resolveScript,
     resolveStylesheet
   };
 }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -86,8 +86,9 @@ export async function getResolvers(
   // Add assets.
   const info = findAssets(page.html, path);
   for (const f of info.files) assets.add(f);
-  for (const i of info.localImports) localImports.add(i), staticImports.add(i);
-  for (const i of info.globalImports) globalImports.add(i), staticImports.add(i);
+  for (const i of info.localImports) localImports.add(i);
+  for (const i of info.globalImports) globalImports.add(i);
+  for (const i of info.staticImports) staticImports.add(i);
 
   // Add stylesheets. TODO Instead of hard-coding Source Serif Pro, parse the
   // page’s stylesheet to look for external imports.

--- a/test/html-test.ts
+++ b/test/html-test.ts
@@ -42,78 +42,107 @@ describe("html(strings, ...values)", () => {
 describe("findAssets(html, path)", () => {
   it("finds local files from img[src]", () => {
     const html = '<img src="./test.png">';
-    assert.deepStrictEqual(findAssets(html, "foo"), new Set(["./test.png"]));
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set(["./test.png"]));
   });
   it("finds local files from img[srcset]", () => {
     const html = '<img srcset="small.jpg 480w, large.jpg 800w" sizes="(max-width: 600px) 480px, 800px" src="large.jpg" alt="Image for testing">'; // prettier-ignore
-    assert.deepStrictEqual(findAssets(html, "foo"), new Set(["./large.jpg", "./small.jpg"]));
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set(["./large.jpg", "./small.jpg"]));
   });
   it("finds local files from video[src]", () => {
     const html = '<video src="observable.mov" controls></video>'; // prettier-ignore
-    assert.deepStrictEqual(findAssets(html, "foo"), new Set(["./observable.mov"]));
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set(["./observable.mov"]));
   });
   it("finds local files from video source[src]", () => {
     const html = '<video width="320" height="240" controls><source src="observable.mp4" type="video/mp4"><source src="observable.mov" type="video/mov"></video>'; // prettier-ignore
-    assert.deepStrictEqual(findAssets(html, "foo"), new Set(["./observable.mp4", "./observable.mov"]));
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set(["./observable.mp4", "./observable.mov"]));
   });
   it("finds local files from picture source[srcset]", () => {
     const html = '<picture><source srcset="observable-logo-wide.png" media="(min-width: 600px)"><img src="observable-logo-narrow.png"></picture>'; // prettier-ignore
-    assert.deepStrictEqual(findAssets(html, "foo"), new Set(["./observable-logo-narrow.png", "./observable-logo-wide.png"])); // prettier-ignore
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set(["./observable-logo-narrow.png", "./observable-logo-wide.png"])); // prettier-ignore
   });
   it("ignores non-local files from img[src]", () => {
     const html = '<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">'; // prettier-ignore
-    assert.deepStrictEqual(findAssets(html, "foo"), new Set());
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set());
   });
   it("ignores non-local files from img[srcset]", () => {
     const html = '<img srcset="small.jpg 480w, https://upload.wikimedia.org/900px-American_Shorthair.jpg 900w" sizes="(max-width: 600px) 480px, 900px" src="https://upload.wikimedia.org/900px-American_Shorthair.jpg" alt="Cat image for testing">'; // prettier-ignore
-    assert.deepStrictEqual(findAssets(html, "foo"), new Set(["./small.jpg"]));
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set(["./small.jpg"]));
   });
   it("ignores non-local files from video source[src]", () => {
     const html = '<video width="320" height="240" controls><source src="https://www.youtube.com/watch?v=SsFyayu5csc" type="video/youtube"><source src="observable.mov" type="video/mov"></video>'; // prettier-ignore
-    assert.deepStrictEqual(findAssets(html, "foo"), new Set(["./observable.mov"]));
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set(["./observable.mov"]));
+  });
+  it("finds local imports from script[src]", () => {
+    const html = '<script src="./test.js">';
+    assert.deepStrictEqual(findAssets(html, "foo").localImports, new Set(["./test.js"]));
+  });
+  it("does not require a ./ for local script[src]", () => {
+    const html = '<script src="test.js">';
+    assert.deepStrictEqual(findAssets(html, "foo").localImports, new Set(["./test.js"]));
+  });
+  it("resolves leading slash for script[src]", () => {
+    const html = '<script src="/test.js">';
+    assert.deepStrictEqual(findAssets(html, "foo/bar").localImports, new Set(["../test.js"]));
+  });
+  it("finds local imports from script[src][type=module]", () => {
+    const html = '<script src="test.js" type="module">';
+    assert.deepStrictEqual(findAssets(html, "foo").localImports, new Set(["./test.js"]));
+  });
+  it("finds local imports from script[src][type=text/javascript]", () => {
+    const html = '<script src="test.js" type="text/javascript">';
+    assert.deepStrictEqual(findAssets(html, "foo").localImports, new Set(["./test.js"]));
+  });
+  it("finds local imports from script[src][type=]", () => {
+    const html = '<script src="test.js" type="">';
+    assert.deepStrictEqual(findAssets(html, "foo").localImports, new Set(["./test.js"]));
+  });
+  it("finds assets from script[src][type=other]", () => {
+    const html = '<script src="test.js" type="other">';
+    assert.deepStrictEqual(findAssets(html, "foo").files, new Set(["./test.js"]));
   });
 });
 
 describe("rewriteHtml(html, resolve)", () => {
   const resolve = (s: string) => (/^\w+:/.test(s) ? s : `${s}?sha=${createHash("sha256").update(s).digest("hex")}`);
+  const resolvers = {resolveFile: resolve, resolveImport: resolve};
   it("rewrites local files from img[src]", () => {
     const html = '<img src="./test.png">';
     const expected = '<img src="./test.png?sha=6189e1c84e5c3a2ccbc916f3d1d6fef48db7a1bec53153b3d3725ca49cd62436">';
-    assert.strictEqual(rewriteHtml(html, resolve), expected);
+    assert.strictEqual(rewriteHtml(html, resolvers), expected);
   });
   it("rewrites local files from img[srcset]", () => {
     const html = '<img srcset="small.jpg 480w, large.jpg 800w" sizes="(max-width: 600px) 480px, 800px" src="large.jpg" alt="Image for testing">'; // prettier-ignore
     const expected = '<img srcset="small.jpg?sha=2885b3e6b0b5bb5699bbe54c1e7ee3284bba74312af5f63b51cfdf43535b19e8 480w, large.jpg?sha=22c3cf923c354764ad1a1bc0aa8e5f9b52829c525145c266c9127a5fdd30091e 800w" sizes="(max-width: 600px) 480px, 800px" src="large.jpg?sha=22c3cf923c354764ad1a1bc0aa8e5f9b52829c525145c266c9127a5fdd30091e" alt="Image for testing">'; // prettier-ignore
-    assert.strictEqual(rewriteHtml(html, resolve), expected);
+    assert.strictEqual(rewriteHtml(html, resolvers), expected);
   });
   it("rewrites local files from video[src]", () => {
     const html = '<video src="observable.mov" controls></video>'; // prettier-ignore
     const expected = '<video src="observable.mov?sha=e9864d5e85a350487f7283e3b82deb9253ea67bb93f3155a0c45f4988ad1c674" controls=""></video>'; // prettier-ignore
-    assert.strictEqual(rewriteHtml(html, resolve), expected);
+    assert.strictEqual(rewriteHtml(html, resolvers), expected);
   });
   it("rewrites local files from video source[src]", () => {
     const html = '<video width="320" height="240" controls><source src="observable.mp4" type="video/mp4"><source src="observable.mov" type="video/mov"></video>'; // prettier-ignore
     const expected = '<video width="320" height="240" controls=""><source src="observable.mp4?sha=fc2705f5cf20b095dcdf7a98735d1fc1f6204efac98c6d97dbe2d0b9eb6d8bb7" type="video/mp4"><source src="observable.mov?sha=e9864d5e85a350487f7283e3b82deb9253ea67bb93f3155a0c45f4988ad1c674" type="video/mov"></video>'; // prettier-ignore
-    assert.strictEqual(rewriteHtml(html, resolve), expected);
+    assert.strictEqual(rewriteHtml(html, resolvers), expected);
   });
   it("rewrites local files from picture source[srcset]", () => {
     const html = '<picture><source srcset="observable-logo-wide.png" media="(min-width: 600px)"><img src="observable-logo-narrow.png"></picture>'; // prettier-ignore
     const expected = '<picture><source srcset="observable-logo-wide.png?sha=7ff2bc1caec7fee511b629d788853b92ef8c0d5d06a758c28785591555a25b20" media="(min-width: 600px)"><img src="observable-logo-narrow.png?sha=cc8f8b74a03412a19db51b56a04c832c6bf5e723e644924b766c39261578dc80"></picture>'; // prettier-ignore
-    assert.strictEqual(rewriteHtml(html, resolve), expected);
+    assert.strictEqual(rewriteHtml(html, resolvers), expected);
   });
   it("ignores non-local files from img[src]", () => {
     const html = '<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/American_Shorthair.jpg/900px-American_Shorthair.jpg">'; // prettier-ignore
     const expected = html;
-    assert.strictEqual(rewriteHtml(html, resolve), expected);
+    assert.strictEqual(rewriteHtml(html, resolvers), expected);
   });
   it("ignores non-local files from img[srcset]", () => {
     const html = '<img srcset="small.jpg 480w, https://upload.wikimedia.org/900px-American_Shorthair.jpg 900w" sizes="(max-width: 600px) 480px, 900px" src="https://upload.wikimedia.org/900px-American_Shorthair.jpg" alt="Cat image for testing">'; // prettier-ignore
     const expected = '<img srcset="small.jpg?sha=2885b3e6b0b5bb5699bbe54c1e7ee3284bba74312af5f63b51cfdf43535b19e8 480w, https://upload.wikimedia.org/900px-American_Shorthair.jpg 900w" sizes="(max-width: 600px) 480px, 900px" src="https://upload.wikimedia.org/900px-American_Shorthair.jpg" alt="Cat image for testing">'; // prettier-ignore
-    assert.strictEqual(rewriteHtml(html, resolve), expected);
+    assert.strictEqual(rewriteHtml(html, resolvers), expected);
   });
   it("ignores non-local files from video source[src]", () => {
     const html = '<video width="320" height="240" controls><source src="https://www.youtube.com/watch?v=SsFyayu5csc" type="video/youtube"><source src="observable.mov" type="video/mov"></video>'; // prettier-ignore
     const expected = '<video width="320" height="240" controls=""><source src="https://www.youtube.com/watch?v=SsFyayu5csc" type="video/youtube"><source src="observable.mov?sha=e9864d5e85a350487f7283e3b82deb9253ea67bb93f3155a0c45f4988ad1c674" type="video/mov"></video>'; // prettier-ignore
-    assert.strictEqual(rewriteHtml(html, resolve), expected);
+    assert.strictEqual(rewriteHtml(html, resolvers), expected);
   });
 });

--- a/test/input/build/imports/script.md
+++ b/test/input/build/imports/script.md
@@ -1,0 +1,4 @@
+# Scripts
+
+<script src="top.js" type="module"></script>
+<script src="top.js" type="other"></script>

--- a/test/output/build/imports/foo/foo.html
+++ b/test/output/build/imports/foo/foo.html
@@ -47,6 +47,7 @@ return {foobar};
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <ol>
+    <li class="observablehq-link"><a href="../script">Scripts</a></li>
     <li class="observablehq-link observablehq-link-active"><a href="./foo">Foo</a></li>
   </ol>
 </nav>
@@ -62,7 +63,7 @@ return {foobar};
 <div id="cell-ec24b17a" class="observablehq observablehq--block"></div>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="../"><span>Home</span></a></nav>
+<nav><a rel="prev" href="../script"><span>Scripts</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/imports/script.html
+++ b/test/output/build/imports/script.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>Scripts</title>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Source+Serif+Pro:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&amp;display=swap" crossorigin>
+<link rel="preload" as="style" href="./_observablehq/theme-air,near-midnight.css">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Source+Serif+Pro:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&amp;display=swap" crossorigin>
+<link rel="stylesheet" type="text/css" href="./_observablehq/theme-air,near-midnight.css">
+<link rel="modulepreload" href="./_observablehq/client.js">
+<link rel="modulepreload" href="./_observablehq/runtime.js">
+<link rel="modulepreload" href="./_observablehq/stdlib.js">
+<link rel="modulepreload" href="./_import/top.160847a6.js">
+<script type="module">
+
+import "./_observablehq/client.js";
+
+</script>
+<input id="observablehq-sidebar-toggle" type="checkbox" title="Toggle sidebar">
+<label id="observablehq-sidebar-backdrop" for="observablehq-sidebar-toggle"></label>
+<nav id="observablehq-sidebar">
+  <ol>
+    <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
+    <li class="observablehq-link"><a href="./">Home</a></li>
+  </ol>
+  <ol>
+    <li class="observablehq-link observablehq-link-active"><a href="./script">Scripts</a></li>
+    <li class="observablehq-link"><a href="./foo/foo">Foo</a></li>
+  </ol>
+</nav>
+<script>{/* redacted init script */}</script>
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<nav>
+</nav>
+</aside>
+<div id="observablehq-center">
+<main id="observablehq-main" class="observablehq">
+<h1 id="scripts" tabindex="-1"><a class="observablehq-header-anchor" href="#scripts">Scripts</a></h1>
+<script src="./_import/top.js?sha=160847a6b4890d59f8e8862911bfbe3b8066955d31f2708cafbe51945c3c57b6" type="module"></script>
+<script src="./_file/top.a53c5d5b.js" type="other"></script>
+</main>
+<footer id="observablehq-footer">
+<nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./foo/foo"><span>Foo</span></a></nav>
+<div>Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
+</footer>
+</div>


### PR DESCRIPTION
For JavaScript scripts (see [script[type]](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#type)), the `src` attribute is resolved as an import; for non-JavaScript scripts, it is resolved as a file. This means you can now load vanilla JavaScript scripts (or modules), and it “just works”. For module scripts, the module is also preloaded.