### PR TITLE
fix describe{Tables,Columns}

### DIFF
--- a/src/client/stdlib/duckdb.js
+++ b/src/client/stdlib/duckdb.js
@@ -146,18 +146,19 @@ export class DuckDBClient {
   }
 
   async describeTables() {
-    const tables = await this.query("SHOW TABLES");
-    return tables.map(({name}) => ({name}));
+    return Array.from(await this.query("SHOW TABLES"), ({name}) => ({name}));
   }
 
   async describeColumns({table} = {}) {
-    const columns = await this.query(`DESCRIBE ${this.escape(table)}`);
-    return columns.map(({column_name, column_type, null: nullable}) => ({
-      name: column_name,
-      type: getDuckDBType(column_type),
-      nullable: nullable !== "NO",
-      databaseType: column_type
-    }));
+    return Array.from(
+      await this.query(`DESCRIBE ${this.escape(table)}`),
+      ({column_name, column_type, null: nullable}) => ({
+        name: column_name,
+        type: getDuckDBType(column_type),
+        nullable: nullable !== "NO",
+        databaseType: column_type
+      })
+    );
   }
 
   static async of(sources = {}, config = {}) {


### PR DESCRIPTION
These methods broke because `db.query` now returns an Arrow table rather than an Array, and hence has no _array_.map method. (We’ve deviated from the DatabaseClient specification now, but that’s a good thing because Arrow tables are much, much faster.)

````md
```js echo
const arrowTable = Arrow.tableFromArrays({col1: [1, 2, 3], col2: ["one", "two", "three"]});
const db = await DuckDBClient.of({arrowTable});
```

```js echo
db.describeTables()
```

```js echo
db.query("SELECT * FROM arrowTable")
```
````