### PR TITLE
prql

### DIFF
--- a/docs/sql.md
+++ b/docs/sql.md
@@ -174,3 +174,25 @@ The `sql` tag is available by default in Markdown. You can also import it explic
 ```js echo
 import {sql} from "npm:@observablehq/duckdb";
 ```
+
+## PRQL
+
+[PRQL](https://prql-lang.org/) (pronounced “prequel”) is a “modern language for transforming data — a simple, powerful, pipelined SQL replacement.” To use PRQL instead of SQL, create a PRQL fenced code block (<code>```prql</code>). For example:
+
+````md
+```prql
+from gaia
+sort {phot_g_mean_mag}
+take 10
+```
+````
+
+This produces:
+
+```prql
+from gaia
+sort {phot_g_mean_mag}
+take 10
+```
+
+Because PRQL is compiled to SQL during build, Framework does not support a `prql` tagged template literal; PRQL can only be used in PRQL code blocks.

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "mime": "^4.0.0",
     "minisearch": "^6.3.0",
     "open": "^10.1.0",
+    "prql-js": "^0.11.3",
     "rollup": "^4.6.0",
     "rollup-plugin-esbuild": "^6.1.0",
     "semver": "^7.5.4",

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -14,7 +14,7 @@ import {parseInfo} from "./info.js";
 import type {JavaScriptNode} from "./javascript/parse.js";
 import {parseJavaScript} from "./javascript/parse.js";
 import {relativePath} from "./path.js";
-import {transpileSql} from "./sql.js";
+import {transpilePrql, transpileSql} from "./sql.js";
 import {transpileTag} from "./tag.js";
 import {InvalidThemeError} from "./theme.js";
 import {red} from "./tty.js";
@@ -60,6 +60,8 @@ function getLiveSource(content: string, tag: string, attributes: Record<string, 
     ? transpileTag(content, "html.fragment", true)
     : tag === "sql"
     ? transpileSql(content, attributes)
+    : tag === "prql"
+    ? transpilePrql(content, attributes)
     : tag === "svg"
     ? transpileTag(content, "svg.fragment", true)
     : tag === "dot"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,6 +2965,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+prql-js@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/prql-js/-/prql-js-0.11.3.tgz#17e6799144874003135a2d207d61368f3c07b719"
+  integrity sha512-Od8Glg/m2KaaQyeu9/xpZvHi/tUW5S6sp3pozDzhht+R6+JqAfLW0VUDT30nfNBQ9guuEABs1t5w+0CemUJC6A==
+
 psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"


### PR DESCRIPTION
Fixes #1075.

Doesn’t work with interpolated expressions, e.g.,

```prql
from gaia
filter phot_g_mean_mag < ${min}
sort {phot_g_mean_mag}
take 10
```

I’m not sure how we’d implement that… we’d need some way to represent placeholder values (such as `?`) that are appropriately substituted during the transformation.

I’m also not sure if we also want to support a `prql` tagged template literal, since that would mean loading `prql-js` in the browser (importing it dynamically, presumably?).