### PR TITLE
custom builtins

### DIFF
--- a/docs/_builtins.js
+++ b/docs/_builtins.js
@@ -1,0 +1,3 @@
+export default {
+  confetti: () => import("npm:canvas-confetti").then((confetti) => confetti.default)
+};

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,5 +1,9 @@
 # Configuration
 
+```js
+confetti();
+```
+
 A `observablehq.config.js` (or `observablehq.config.ts`) file located in the project root allows configuration of your project. For example, a site might use a config file to set the project’s title and the sidebar contents:
 
 ```js run=false

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -1,3 +1,4 @@
+import builtins from "observablehq:builtins";
 import {Runtime} from "observablehq:runtime";
 import {FileAttachment, Generators, Mutable, resize} from "observablehq:stdlib";
 import {inspect, inspectError} from "./inspect.js";
@@ -13,7 +14,8 @@ const library = {
   Generators: () => Generators,
   Mutable: () => Mutable,
   ...recommendedLibraries,
-  ...sampleDatasets
+  ...sampleDatasets,
+  ...builtins
 };
 
 export const runtime = new Runtime(library);

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -1,4 +1,4 @@
-import {extname} from "node:path/posix";
+import {extname, join} from "node:path/posix";
 import {nodeResolve} from "@rollup/plugin-node-resolve";
 import {type CallExpression} from "acorn";
 import {simple} from "acorn-walk";
@@ -109,6 +109,8 @@ function importResolve(input: string, root: string, path: string): Plugin {
   async function resolve(specifier: string | AstNode): Promise<ResolveIdResult> {
     return typeof specifier !== "string" || specifier === input
       ? null
+      : specifier === "observablehq:builtins"
+      ? {id: join(root, "_builtins.js")}
       : specifier.startsWith("observablehq:")
       ? {id: relativePath(path, `/_observablehq/${specifier.slice("observablehq:".length)}${extname(specifier) ? "" : ".js"}`), external: true} // prettier-ignore
       : specifier === "npm:@observablehq/runtime"


### PR DESCRIPTION
Sketch at #928. The main thing missing is the equivalent of `getImplicitInputImports`, `getImplicitDownloads`, _etc._ Also, I’d rather have this live inside the config file, but I think it’s harder to express the builtins as code if we do that?