### PR TITLE
normalize pages

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ import {LoaderResolver} from "./dataloader.js";
 import {visitMarkdownFiles} from "./files.js";
 import {formatIsoDate, formatLocaleDate} from "./format.js";
 import {createMarkdownIt, parseMarkdown} from "./markdown.js";
-import {resolvePath} from "./path.js";
+import {isAssetPath, parseRelativeUrl, resolvePath} from "./path.js";
 import {resolveTheme} from "./theme.js";
 
 export interface Page {
@@ -197,7 +197,13 @@ function normalizePage(spec: any): Page {
   let {name, path} = spec;
   name = String(name);
   path = String(path);
-  if (path.endsWith("/")) path = `${path}index`;
+  if (isAssetPath(path)) {
+    const u = parseRelativeUrl(join("/", path)); // add leading slash
+    let {pathname} = u;
+    pathname = pathname.replace(/\.html$/i, ""); // remove trailing .html
+    pathname = pathname.replace(/\/$/, "/index"); // add trailing index
+    path = pathname + u.search + u.hash;
+  }
   return {name, path};
 }
 

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -14,7 +14,7 @@ import {rewriteHtmlPaths} from "./html.js";
 import {parseInfo} from "./info.js";
 import type {JavaScriptNode} from "./javascript/parse.js";
 import {parseJavaScript} from "./javascript/parse.js";
-import {relativePath} from "./path.js";
+import {isAssetPath, parseRelativeUrl, relativePath} from "./path.js";
 import {transpileSql} from "./sql.js";
 import {transpileTag} from "./tag.js";
 import {InvalidThemeError} from "./theme.js";
@@ -280,22 +280,10 @@ function makeSoftbreakRenderer(baseRenderer: RenderRule): RenderRule {
   };
 }
 
-export function parseRelativeUrl(url: string): {pathname: string; search: string; hash: string} {
-  let search: string;
-  let hash: string;
-  const i = url.indexOf("#");
-  if (i < 0) hash = "";
-  else (hash = url.slice(i)), (url = url.slice(0, i));
-  const j = url.indexOf("?");
-  if (j < 0) search = "";
-  else (search = url.slice(j)), (url = url.slice(0, j));
-  return {pathname: url, search, hash};
-}
-
 export function makeLinkNormalizer(baseNormalize: (url: string) => string, clean: boolean): (url: string) => string {
   return (url) => {
-    // Only clean relative links; ignore e.g. "https:" links.
-    if (!/^\w+:/.test(url)) {
+    // Only clean local links (and ignore e.g. "https:" links).
+    if (isAssetPath(url)) {
       const u = parseRelativeUrl(url);
       let {pathname} = u;
       if (pathname && !pathname.endsWith("/") && !extname(pathname)) pathname += ".html";

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,4 +1,4 @@
-import {dirname, extname, join} from "node:path/posix";
+import {dirname, join} from "node:path/posix";
 
 /**
  * Returns the normalized relative path from "/file/path/to/a" to

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,4 +1,4 @@
-import {dirname, join} from "node:path/posix";
+import {dirname, extname, join} from "node:path/posix";
 
 /**
  * Returns the normalized relative path from "/file/path/to/a" to
@@ -71,4 +71,16 @@ export function isAssetPath(specifier: string): boolean {
  */
 export function resolveRelativePath(source: string, target: string): string {
   return relativePath(source, resolvePath(source, target));
+}
+
+export function parseRelativeUrl(url: string): {pathname: string; search: string; hash: string} {
+  let search: string;
+  let hash: string;
+  const i = url.indexOf("#");
+  if (i < 0) hash = "";
+  else (hash = url.slice(i)), (url = url.slice(0, i));
+  const j = url.indexOf("?");
+  if (j < 0) search = "";
+  else (search = url.slice(j)), (url = url.slice(0, j));
+  return {pathname: url, search, hash};
 }

--- a/test/config-test.ts
+++ b/test/config-test.ts
@@ -83,20 +83,57 @@ describe("normalizeConfig(spec, root)", () => {
   it("coerces pages to an array", async () => {
     assert.deepStrictEqual((await config({pages: new Set()}, root)).pages, []);
   });
-  it("coerces pages", async () => {
+  it("coerces and normalizes page paths", async () => {
     const inpages = [
       {name: 42, path: true},
-      {name: null, path: {toString: () => "yes"}}
+      {name: null, path: {toString: () => "yes"}},
+      {name: "Index", path: "/foo/index"},
+      {name: "Index.html", path: "/foo/index.html"},
+      {name: "Page.html", path: "/foo.html"}
     ];
     const outpages = [
-      {name: "42", path: "true"},
-      {name: "null", path: "yes"}
+      {name: "42", path: "/true"},
+      {name: "null", path: "/yes"},
+      {name: "Index", path: "/foo/index"},
+      {name: "Index.html", path: "/foo/index"},
+      {name: "Page.html", path: "/foo"}
+    ];
+    assert.deepStrictEqual((await config({pages: inpages}, root)).pages, outpages);
+  });
+  it("allows external page paths", async () => {
+    const pages = [{name: "Example.com", path: "https://example.com"}];
+    assert.deepStrictEqual((await config({pages}, root)).pages, pages);
+  });
+  it("allows page paths to have query strings and anchor fragments", async () => {
+    const inpages = [
+      {name: "Anchor fragment on index", path: "/test/index#foo=bar"},
+      {name: "Anchor fragment on index.html", path: "/test/index.html#foo=bar"},
+      {name: "Anchor fragment on page.html", path: "/test.html#foo=bar"},
+      {name: "Anchor fragment on slash", path: "/test/#foo=bar"},
+      {name: "Anchor fragment", path: "/test#foo=bar"},
+      {name: "Query string on index", path: "/test/index?foo=bar"},
+      {name: "Query string on index.html", path: "/test/index.html?foo=bar"},
+      {name: "Query string on page.html", path: "/test.html?foo=bar"},
+      {name: "Query string on slash", path: "/test/?foo=bar"},
+      {name: "Query string", path: "/test?foo=bar"}
+    ];
+    const outpages = [
+      {name: "Anchor fragment on index", path: "/test/index#foo=bar"},
+      {name: "Anchor fragment on index.html", path: "/test/index#foo=bar"},
+      {name: "Anchor fragment on page.html", path: "/test#foo=bar"},
+      {name: "Anchor fragment on slash", path: "/test/index#foo=bar"},
+      {name: "Anchor fragment", path: "/test#foo=bar"},
+      {name: "Query string on index", path: "/test/index?foo=bar"},
+      {name: "Query string on index.html", path: "/test/index?foo=bar"},
+      {name: "Query string on page.html", path: "/test?foo=bar"},
+      {name: "Query string on slash", path: "/test/index?foo=bar"},
+      {name: "Query string", path: "/test?foo=bar"}
     ];
     assert.deepStrictEqual((await config({pages: inpages}, root)).pages, outpages);
   });
   it("coerces sections", async () => {
     const inpages = [{name: 42, pages: new Set([{name: null, path: {toString: () => "yes"}}])}];
-    const outpages = [{name: "42", open: true, pages: [{name: "null", path: "yes"}]}];
+    const outpages = [{name: "42", open: true, pages: [{name: "null", path: "/yes"}]}];
     assert.deepStrictEqual((await config({pages: inpages}, root)).pages, outpages);
   });
   it("coerces toc", async () => {

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -6,7 +6,7 @@ import deepEqual from "fast-deep-equal";
 import {normalizeConfig} from "../src/config.js";
 import {isEnoent} from "../src/error.js";
 import type {MarkdownPage} from "../src/markdown.js";
-import {makeLinkNormalizer, parseMarkdown, parseRelativeUrl} from "../src/markdown.js";
+import {makeLinkNormalizer, parseMarkdown} from "../src/markdown.js";
 
 const {md} = await normalizeConfig();
 
@@ -61,27 +61,6 @@ describe("parseMarkdown(input)", () => {
       assert.ok(allequal, `${name} must match snapshot`);
     });
   }
-});
-
-describe("parseRelativeUrl(url)", () => {
-  it("handles paths", () => {
-    assert.deepStrictEqual(parseRelativeUrl("foo"), {pathname: "foo", search: "", hash: ""});
-    assert.deepStrictEqual(parseRelativeUrl("foo.html"), {pathname: "foo.html", search: "", hash: ""});
-    assert.deepStrictEqual(parseRelativeUrl("../foo"), {pathname: "../foo", search: "", hash: ""});
-    assert.deepStrictEqual(parseRelativeUrl("./foo"), {pathname: "./foo", search: "", hash: ""});
-    assert.deepStrictEqual(parseRelativeUrl("/foo"), {pathname: "/foo", search: "", hash: ""});
-    assert.deepStrictEqual(parseRelativeUrl("/foo%3Fbar"), {pathname: "/foo%3Fbar", search: "", hash: ""});
-  });
-  it("handles queries", () => {
-    assert.deepStrictEqual(parseRelativeUrl("foo?bar"), {pathname: "foo", search: "?bar", hash: ""});
-  });
-  it("handles hashes", () => {
-    assert.deepStrictEqual(parseRelativeUrl("foo#bar"), {pathname: "foo", search: "", hash: "#bar"});
-    assert.deepStrictEqual(parseRelativeUrl("foo#bar?baz"), {pathname: "foo", search: "", hash: "#bar?baz"});
-  });
-  it("handles queries and hashes", () => {
-    assert.deepStrictEqual(parseRelativeUrl("foo?bar#baz"), {pathname: "foo", search: "?bar", hash: "#baz"});
-  });
 });
 
 describe("makeLinkNormalizer(normalize, false)", () => {

--- a/test/path-test.ts
+++ b/test/path-test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import {isPathImport, relativePath, resolveLocalPath, resolvePath} from "../src/path.js";
+import {isPathImport, parseRelativeUrl, relativePath, resolveLocalPath, resolvePath} from "../src/path.js";
 
 describe("resolvePath(source, target)", () => {
   it("returns the path to the specified target within the source root", () => {
@@ -125,5 +125,26 @@ describe("isPathImport(specifier)", () => {
     assert.strictEqual(isPathImport("foo"), false);
     assert.strictEqual(isPathImport("foo:bar"), false);
     assert.strictEqual(isPathImport("foo://bar"), false);
+  });
+});
+
+describe("parseRelativeUrl(url)", () => {
+  it("handles paths", () => {
+    assert.deepStrictEqual(parseRelativeUrl("foo"), {pathname: "foo", search: "", hash: ""});
+    assert.deepStrictEqual(parseRelativeUrl("foo.html"), {pathname: "foo.html", search: "", hash: ""});
+    assert.deepStrictEqual(parseRelativeUrl("../foo"), {pathname: "../foo", search: "", hash: ""});
+    assert.deepStrictEqual(parseRelativeUrl("./foo"), {pathname: "./foo", search: "", hash: ""});
+    assert.deepStrictEqual(parseRelativeUrl("/foo"), {pathname: "/foo", search: "", hash: ""});
+    assert.deepStrictEqual(parseRelativeUrl("/foo%3Fbar"), {pathname: "/foo%3Fbar", search: "", hash: ""});
+  });
+  it("handles queries", () => {
+    assert.deepStrictEqual(parseRelativeUrl("foo?bar"), {pathname: "foo", search: "?bar", hash: ""});
+  });
+  it("handles hashes", () => {
+    assert.deepStrictEqual(parseRelativeUrl("foo#bar"), {pathname: "foo", search: "", hash: "#bar"});
+    assert.deepStrictEqual(parseRelativeUrl("foo#bar?baz"), {pathname: "foo", search: "", hash: "#bar?baz"});
+  });
+  it("handles queries and hashes", () => {
+    assert.deepStrictEqual(parseRelativeUrl("foo?bar#baz"), {pathname: "foo", search: "?bar", hash: "#baz"});
   });
 });


### PR DESCRIPTION
Fixes #1110. Ref. #1100. Preserves query strings, anchor fragment, and absolute URLs; drops trailing `.html` from the path; adds leading slash (`/`) if needed; adds trailing `/index` if needed.