### PR TITLE
don’t preload async

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -89,7 +89,7 @@ export function findAssets(html: string, path: string): Assets {
       } else {
         globalImports.add(src);
       }
-      if (script.getAttribute("type")?.toLowerCase() === "module") {
+      if (script.getAttribute("type")?.toLowerCase() === "module" && !script.hasAttribute("async")) {
         staticImports.add(src); // modulepreload
       }
     } else {


### PR DESCRIPTION
A `<script type="module" async>` probably shouldn’t be preloaded — the [`async` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async) implies that it’s lower priority. For example, we don’t want to preload our first-party analytics script on the Framework documentation.