### PR TITLE
remove toc: false on the home page?

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-toc: false
 index: false
 ---
 


### PR DESCRIPTION
I think this was useful in earlier iterations, but since this page not "fullwidth" anymore, the only effect of the toc option on [the home page](https://observablehq.com/framework) now is to move the github link to the right; probably better to be consistent with other pages like https://observablehq.com/framework/css/note

| before | after |
| --- | --- |
| ![before](https://github.com/observablehq/framework/assets/7001/41ca64ce-b8c5-4251-afb3-4bd0b6aa0397) | ![after](https://github.com/observablehq/framework/assets/7001/fdaf0ded-4be1-4726-ab66-36ac744aca78) |
