### PR TITLE
initialize cache on create

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -88,7 +88,7 @@ export async function create(effects: CreateEffects = defaultEffects): Promise<v
         const templateDir = op.resolve(fileURLToPath(import.meta.url), "..", "..", "templates", template);
         const runCommand = packageManager === "yarn" ? "yarn" : `${packageManager ?? "npm"} run`;
         const installCommand = `${packageManager ?? "npm"} install`;
-        await effects.sleep(1000);
+        await effects.sleep(1000); // this step is fast; give the spinner a chance to show
         await recursiveCopyTemplate(
           templateDir,
           rootPath!,
@@ -103,19 +103,17 @@ export async function create(effects: CreateEffects = defaultEffects): Promise<v
         );
         if (packageManager) {
           s.message(`Installing dependencies via ${packageManager}`);
-          await effects.sleep(1000);
           if (packageManager === "yarn") await writeFile(join(rootPath, "yarn.lock"), "");
           await promisify(exec)(installCommand, {cwd: rootPath});
         }
         if (initializeGit) {
           s.message("Initializing git repository");
-          await effects.sleep(1000);
+          await effects.sleep(1000); // this step is fast; give the spinner a chance to show
           await promisify(exec)("git init", {cwd: rootPath});
           await promisify(exec)("git add -A", {cwd: rootPath});
         }
         if (packageManager) {
           s.message("Initializing Framework cache");
-          await effects.sleep(1000);
           await promisify(exec)(`${runCommand} build`, {cwd: rootPath});
         }
         s.stop("Installed! 🎉");

--- a/src/create.ts
+++ b/src/create.ts
@@ -37,13 +37,7 @@ const defaultEffects: CreateEffects = {
   }
 };
 
-// TODO Do we want to accept the output path as a command-line argument,
-// still? It’s not sufficient to run observable create non-interactively,
-// though we could just apply all the defaults in that case, and then expose
-// command-line arguments for the other prompts. In any case, our immediate
-// priority is supporting the interactive case, not the automated one.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function create(options = {}, effects: CreateEffects = defaultEffects): Promise<void> {
+export async function create(effects: CreateEffects = defaultEffects): Promise<void> {
   const {clack} = effects;
   clack.intro(`${inverse(" observable create ")} ${faint(`v${process.env.npm_package_version}`)}`);
   const defaultRootPath = "hello-framework";
@@ -118,6 +112,11 @@ export async function create(options = {}, effects: CreateEffects = defaultEffec
           await effects.sleep(1000);
           await promisify(exec)("git init", {cwd: rootPath});
           await promisify(exec)("git add -A", {cwd: rootPath});
+        }
+        if (packageManager) {
+          s.message("Initializing Framework cache");
+          await effects.sleep(1000);
+          await promisify(exec)(`${runCommand} build`, {cwd: rootPath});
         }
         s.stop("Installed! 🎉");
         const instructions = [`cd ${rootPath}`, ...(packageManager ? [] : [installCommand]), `${runCommand} dev`];

--- a/test/create-test.ts
+++ b/test/create-test.ts
@@ -14,7 +14,7 @@ describe("create", () => {
       null, // Install dependencies?
       false // Initialize git repository?
     );
-    await create(undefined, effects);
+    await create(effects);
     assert.deepStrictEqual(
       new Set(effects.outputs.keys()),
       new Set([
@@ -42,7 +42,7 @@ describe("create", () => {
       null, // Install dependencies?
       false // Initialize git repository?
     );
-    await create(undefined, effects);
+    await create(effects);
     assert.deepStrictEqual(
       new Set(effects.outputs.keys()),
       new Set([


### PR DESCRIPTION
Fixes #1064. By running build during create, the initial loads of Framework in the preview server are instant because the npm and data loader cache are already populated. I think this is a better user experience — you’re expecting to wait during install anyway, and it means your first experience seeing pages load in Framework is representative of the (instant) experience of the cached and built project.