### PR TITLE
fix head, header, footer front matter

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -15,12 +15,21 @@ toc: false
 
 The front matter supports the following options:
 
-- **title** — the page title; defaults to the (first) first-level heading of the page, if any
-- **toc** — if false, disables the [table of contents](./config#toc)
-- **index** — whether to index this page if [search](./search) is enabled; defaults to true for listed pages
+- **title** - the page title; defaults to the (first) first-level heading of the page, if any
+- **index** - whether to index this page if [search](./search) is enabled; defaults to true for listed pages
 - **keywords** <a href="https://github.com/observablehq/framework/releases/tag/v1.1.0" class="observablehq-version-badge" data-version="^1.1.0" title="Added in v1.1.0"></a> - additional words to index for [search](./search); boosted at the same weight as the title
-- **draft** <a href="https://github.com/observablehq/framework/releases/tag/v1.1.0" class="observablehq-version-badge" data-version="^1.1.0" title="Added in v1.1.0"></a> — whether to skip this page during build; drafts are also not listed in the default sidebar
-- **sql** <a href="https://github.com/observablehq/framework/releases/tag/v1.2.0" class="observablehq-version-badge" data-version="^1.2.0" title="Added in v1.2.0"></a> — table definitions for [SQL code blocks](./sql)
+- **draft** <a href="https://github.com/observablehq/framework/releases/tag/v1.1.0" class="observablehq-version-badge" data-version="^1.1.0" title="Added in v1.1.0"></a> - whether to skip this page during build; drafts are also not listed in the default sidebar
+- **sql** <a href="https://github.com/observablehq/framework/releases/tag/v1.2.0" class="observablehq-version-badge" data-version="^1.2.0" title="Added in v1.2.0"></a> - table definitions for [SQL code blocks](./sql)
+
+The front matter can also override the following [project configuration](./config) options:
+
+- **toc** - the [table of contents](./config#toc)
+- **style** - the [custom stylesheet](./config#style)
+- **theme** - the [theme](./config#theme)
+- **head** - the [head](./config#head)
+- **header** - the [header](./config#header)
+- **footer** - the [footer](./config#footer)
+- **sidebar** - whether to show the [sidebar](./config#sidebar)
 
 ## Headings
 

--- a/src/frontMatter.ts
+++ b/src/frontMatter.ts
@@ -7,6 +7,9 @@ export interface FrontMatter {
   toc?: {show?: boolean; label?: string};
   style?: string | null;
   theme?: string[];
+  head?: string | null;
+  header?: string | null;
+  footer?: string | null;
   index?: boolean;
   keywords?: string[];
   draft?: boolean;
@@ -30,7 +33,7 @@ export function readFrontMatter(input: string): {content: string; data: FrontMat
 export function normalizeFrontMatter(spec: any = {}): FrontMatter {
   const frontMatter: FrontMatter = {};
   if (spec == null || typeof spec !== "object") return frontMatter;
-  const {title, sidebar, toc, index, keywords, draft, sql, style, theme} = spec;
+  const {title, sidebar, toc, index, keywords, draft, sql, head, header, footer, style, theme} = spec;
   if (title !== undefined) frontMatter.title = stringOrNull(title);
   if (sidebar !== undefined) frontMatter.sidebar = Boolean(sidebar);
   if (toc !== undefined) frontMatter.toc = normalizeToc(toc);
@@ -38,13 +41,16 @@ export function normalizeFrontMatter(spec: any = {}): FrontMatter {
   if (keywords !== undefined) frontMatter.keywords = normalizeKeywords(keywords);
   if (draft !== undefined) frontMatter.draft = Boolean(draft);
   if (sql !== undefined) frontMatter.sql = normalizeSql(sql);
+  if (head !== undefined) frontMatter.head = stringOrNull(head);
+  if (header !== undefined) frontMatter.header = stringOrNull(header);
+  if (footer !== undefined) frontMatter.footer = stringOrNull(footer);
   if (style !== undefined) frontMatter.style = stringOrNull(style);
   if (theme !== undefined) frontMatter.theme = normalizeTheme(theme);
   return frontMatter;
 }
 
 function stringOrNull(spec: unknown): string | null {
-  return spec == null ? null : String(spec);
+  return spec == null || spec === false ? null : String(spec);
 }
 
 function normalizeToc(spec: unknown): {show?: boolean; label?: string} {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -359,7 +359,7 @@ export function parseMarkdownMetadata(input: string, options: ParseOptions): Pic
 
 function getHtml(
   key: "head" | "header" | "footer",
-  data: Record<string, any>,
+  data: FrontMatter,
   {path, [key]: defaultValue}: ParseOptions
 ): string | null {
   return data[key] !== undefined

--- a/test/frontMatter-test.ts
+++ b/test/frontMatter-test.ts
@@ -15,7 +15,9 @@ describe("normalizeFrontMatter(spec)", () => {
     assert.deepStrictEqual(normalizeFrontMatter({title: 42}), {title: "42"});
     assert.deepStrictEqual(normalizeFrontMatter({title: undefined}), {});
     assert.deepStrictEqual(normalizeFrontMatter({title: null}), {title: null});
+    assert.deepStrictEqual(normalizeFrontMatter({title: false}), {title: null});
     assert.deepStrictEqual(normalizeFrontMatter({title: ""}), {title: ""});
+    assert.deepStrictEqual(normalizeFrontMatter({title: 0}), {title: "0"});
     assert.deepStrictEqual(normalizeFrontMatter({title: "foo"}), {title: "foo"});
     assert.deepStrictEqual(normalizeFrontMatter({title: {toString: () => "foo"}}), {title: "foo"});
   });


### PR DESCRIPTION
I noticed that the theme previews erroneously have a head and header again (and so it’s inflating our traffic numbers). It was caused by a regression in #1054 that dropped the **head**, **header**, and **footer** options. These options were also undocumented, but now they are.