### PR TITLE
browser entry point

### DIFF
--- a/test/node-test.ts
+++ b/test/node-test.ts
@@ -49,3 +49,17 @@ describe("extractNodeSpecifier(path)", () => {
     assert.strictEqual(extractNodeSpecifier("/_node/d3-array@3.2.4/src/index.js"), "d3-array@3.2.4/src/index.js");
   });
 });
+
+describe("browser condition", () => {
+  before(async () => {
+    if (existsSync("docs/.observablehq/cache/_node")) {
+      await rm("docs/.observablehq/cache/_node", {recursive: true});
+    }
+  });
+  it("bundles the file specified as browser condition (string)", async () => {
+    assert.deepStrictEqual(await resolveNodeImport("docs", "supports-color"), "/_node/supports-color@7.2.0/browser.js");
+  });
+  it("bundles the file specified as browser condition (map)", async () => {
+    assert.deepStrictEqual(await resolveNodeImport("docs", "asap"), "/_node/asap@2.0.6/browser-asap.js");
+  });
+});


### PR DESCRIPTION
Re:  https://github.com/observablehq/framework/pull/1156#issuecomment-2024391100.

Instead of taking at face value what pathResolution returns, we find package.json then see if the "browser" ~~condition~~  entry point is present and update pathResolution as a consequence. The [spec](https://github.com/defunctzombie/package-browser-field-spec) indicates that there are two possibilities to cover:
- a string (found in _e.g._ "supports-color@7.2.0"), 
- a replacement map (found in _e.g._ "asap@2.0.6").

My tests use two modules that are already here by "chance", and will break if any of these modules gets updated (for example supports-color@9 does not use the browser field anymore), but we can fix that when it happens. (Alternatively, we could add these precise versions in devDependencies just for these tests?)


I checked what [@rollup/plugin-node-resolve](https://www.npmjs.com/package/@rollup/plugin-node-resolve) plugin does: it looks at the entry with the ~~condition~~ key in [resolvePackageTarget](https://github.com/rollup/plugins/blob/2a19079892f0bef53b557da965339cdef0a13a93/packages/node-resolve/src/package/resolvePackageTarget.ts#L145). The chain of calls: < [resolvePackageImportsExports](https://github.com/rollup/plugins/blob/master/packages/node-resolve/src/package/resolvePackageImportsExports.ts#L96) < [resolvePackageImports](https://github.com/rollup/plugins/blob/master/packages/node-resolve/src/package/resolvePackageImports.ts#L14) < [resolveImportSpecifiers](https://github.com/rollup/plugins/blob/2a19079892f0bef53b557da965339cdef0a13a93/packages/node-resolve/src/resolveImportSpecifiers.js#L37) < [resolveImportSpecifiers](https://github.com/rollup/plugins/blob/2a19079892f0bef53b557da965339cdef0a13a93/packages/node-resolve/src/resolveImportSpecifiers.js#L108)