### PR TITLE
support open graph (exploration)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -174,6 +174,10 @@ export default {
 
 The base path when serving the site. Currently this only affects the custom 404 page, if any.
 
+## origin
+
+The site’s [origin](https://developer.mozilla.org/en-US/docs/Web/API/URL/origin). As a shorthand, specify a complete URL of the site’s home page to define both origin and base.
+
 ## cleanUrls <a href="https://github.com/observablehq/framework/releases/tag/v1.3.0" class="observablehq-version-badge" data-version="^1.3.0" title="Added in 1.3.0"></a>
 
 Whether page links should be “clean”, _i.e._, formatted without a `.html` extension. Defaults to true. If true, a link to `config.html` will be formatted as `config`. Regardless of this setting, a link to an index page will drop the implied `index.html`; for example `foo/index.html` will be formatted as `foo/`.

--- a/docs/opengraph.md
+++ b/docs/opengraph.md
@@ -1,0 +1,7 @@
+---
+thumbnail: favicon.png
+---
+
+# Hello, opengraph
+
+This generates an opengraph card at the top of the page.

--- a/observablehq.config.ts
+++ b/observablehq.config.ts
@@ -1,4 +1,5 @@
 import {formatPrefix} from "d3-format";
+import type {Config} from "./src/config.js";
 
 let stargazers_count: number;
 try {
@@ -7,6 +8,28 @@ try {
   if (process.env.CI) throw error;
   stargazers_count = NaN;
 }
+
+const headprod = process.env.CI
+  ? `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
+<script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>
+`
+  : "";
+
+function openGraph(path, data, config) {
+  return `<meta property="og:title" content="${data.title || config.title}" />
+<meta property="og:url" content="${config.origin}${config.base}${path.slice(1)}" />${
+    data.thumbnail ? `\n<meta property="og:image" content="${data.thumbnail}" />` : ""
+  }
+`;
+}
+
+const head = function (path: string, data: any /* FrontMatter */, config: Config) {
+  const og = openGraph(path, data, config);
+  return `<link rel="apple-touch-icon" href="/favicon.png">
+<link rel="icon" type="image/png" href="/favicon.png" sizes="512x512">
+${og}${headprod}<script type="module"> /Win/.test(navigator.platform) || Array.from(document.querySelectorAll(".win"), (e) => e.remove()) < /script>`;
+};
 
 export default {
   output: "docs/.observablehq/dist",
@@ -95,17 +118,8 @@ export default {
     },
     {name: "Contributing", path: "/contributing"}
   ],
-  base: "/framework",
-  head: `<link rel="apple-touch-icon" href="/favicon.png">
-<link rel="icon" type="image/png" href="/favicon.png" sizes="512x512">${
-    process.env.CI
-      ? `
-<script type="module" async src="https://events.observablehq.com/client.js"></script>
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
-<script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`
-      : ""
-  }
-<script type="module">/Win/.test(navigator.platform) || Array.from(document.querySelectorAll(".win"), (e) => e.remove())</script>`,
+  origin: "https://observablehq.com/framework",
+  head,
   header: `<div style="display: flex; align-items: center; gap: 0.5rem; height: 2.2rem; margin: -1.5rem -2rem 2rem -2rem; padding: 0.5rem 2rem; border-bottom: solid 1px var(--theme-foreground-faintest); font: 500 16px var(--sans-serif);">
   <a href="https://observablehq.com/" target="_self" rel="" style="display: flex; align-items: center;">
     <svg width="22" height="22" viewBox="0 0 21.92930030822754 22.68549919128418" fill="currentColor">

--- a/src/frontMatter.ts
+++ b/src/frontMatter.ts
@@ -15,6 +15,7 @@ export interface FrontMatter {
   draft?: boolean;
   sidebar?: boolean;
   sql?: {[key: string]: string};
+  [key: string]: any;
 }
 
 export function readFrontMatter(input: string): {content: string; data: FrontMatter} {
@@ -31,9 +32,8 @@ export function readFrontMatter(input: string): {content: string; data: FrontMat
 }
 
 export function normalizeFrontMatter(spec: any = {}): FrontMatter {
-  const frontMatter: FrontMatter = {};
-  if (spec == null || typeof spec !== "object") return frontMatter;
-  const {title, sidebar, toc, index, keywords, draft, sql, head, header, footer, style, theme} = spec;
+  if (spec == null || typeof spec !== "object") return {} as FrontMatter;
+  const {title, sidebar, toc, index, keywords, draft, sql, head, header, footer, style, theme, ...frontMatter} = spec;
   if (title !== undefined) frontMatter.title = stringOrNull(title);
   if (sidebar !== undefined) frontMatter.sidebar = Boolean(sidebar);
   if (toc !== undefined) frontMatter.toc = normalizeToc(toc);
@@ -46,7 +46,7 @@ export function normalizeFrontMatter(spec: any = {}): FrontMatter {
   if (footer !== undefined) frontMatter.footer = stringOrNull(footer);
   if (style !== undefined) frontMatter.style = stringOrNull(style);
   if (theme !== undefined) frontMatter.theme = normalizeTheme(theme);
-  return frontMatter;
+  return frontMatter as FrontMatter;
 }
 
 function stringOrNull(spec: unknown): string | null {

--- a/src/html.ts
+++ b/src/html.ts
@@ -5,6 +5,8 @@ import type {DOMWindow} from "jsdom";
 import {JSDOM, VirtualConsole} from "jsdom";
 import {isAssetPath, relativePath, resolveLocalPath} from "./path.js";
 
+const ABSOLUTE_PATH_ATTRIBUTES: readonly [selector: string, src: string][] = [["meta[property='og:image']", "content"]];
+
 const ASSET_ATTRIBUTES: readonly [selector: string, src: string][] = [
   ["a[href][download]", "href"],
   ["audio source[src]", "src"],
@@ -14,7 +16,8 @@ const ASSET_ATTRIBUTES: readonly [selector: string, src: string][] = [
   ["link[href]", "href"],
   ["picture source[srcset]", "srcset"],
   ["video source[src]", "src"],
-  ["video[src]", "src"]
+  ["video[src]", "src"],
+  ...ABSOLUTE_PATH_ATTRIBUTES
 ];
 
 const PATH_ATTRIBUTES: readonly [selector: string, src: string][] = [
@@ -26,7 +29,8 @@ const PATH_ATTRIBUTES: readonly [selector: string, src: string][] = [
   ["link[href]", "href"],
   ["picture source[srcset]", "srcset"],
   ["video source[src]", "src"],
-  ["video[src]", "src"]
+  ["video[src]", "src"],
+  ...ABSOLUTE_PATH_ATTRIBUTES
 ];
 
 export function isJavaScript({type}: HTMLScriptElement): boolean {
@@ -135,8 +139,10 @@ export function rewriteHtml(
 
   for (const [selector, src] of ASSET_ATTRIBUTES) {
     for (const element of document.querySelectorAll(selector)) {
-      const source = decodeURI(element.getAttribute(src)!);
-      element.setAttribute(src, src === "srcset" ? resolveSrcset(source, maybeResolveFile) : maybeResolveFile(source));
+      let source = decodeURI(element.getAttribute(src)!);
+      source = src === "srcset" ? resolveSrcset(source, maybeResolveFile) : maybeResolveFile(source);
+      console.warn({selector, src, source, html});
+      element.setAttribute(src, source);
     }
   }
 


### PR DESCRIPTION
This branch (which is probably not going to be a PR) explores what's needed to support open graph (#178) and rel-canonical (#179). It raises a few questions:

- [x] support an **origin** option (#180)
- [x] allow the user to add their own custom values in front matter (part of #1036)
- [ ] `["meta[property='og:image']", "content"]` must be an _absolute_ URL, which means we need a proper way either to apply the origin+base transform after the HTML has been produced, or conversely that we might want to process a file with an absolute url that corresponds to the site as fileattachments? (There is also `og:image:secure_url`)
- [ ] Should #1083 also have treated a head/header/footer value passed as front-matter? (see #1255).