### PR TITLE
implicit /+esm if no extension; fix /+esm conflict

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,6 +1,6 @@
 import {existsSync} from "node:fs";
 import {mkdir, readFile, readdir, writeFile} from "node:fs/promises";
-import {dirname, join} from "node:path/posix";
+import {dirname, extname, join} from "node:path/posix";
 import type {CallExpression} from "acorn";
 import {simple} from "acorn-walk";
 import {rsort, satisfies} from "semver";
@@ -249,7 +249,13 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
       ? "dist/echarts.esm.min.js"
       : "+esm"
   } = parseNpmSpecifier(specifier);
-  return `/_npm/${name}@${await resolveNpmVersion(root, {name, range})}/${path.replace(/\+esm$/, "_esm.js")}`;
+  return `/_npm/${name}@${await resolveNpmVersion(root, {name, range})}/${
+    extname(path)
+      ? path // preserve the existing extension
+      : path.endsWith("/+esm") || path === "+esm" || !path
+      ? `${path.slice(0, -"+esm".length)}_esm.js` // remove +esm; add _esm.js
+      : `${path}/_esm.js` // add /_esm.js
+  }`;
 }
 
 /**

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -269,7 +269,18 @@ export async function resolveNpmImports(root: string, path: string): Promise<Imp
  */
 export function extractNpmSpecifier(path: string): string {
   if (!path.startsWith("/_npm/")) throw new Error(`invalid npm path: ${path}`);
-  return path.replace(/^\/_npm\//, "").replace(/\/_esm\.js$/, "/+esm");
+  const parts = path.split("/");
+  parts.splice(0, 2); // delete /_npm
+  const i = parts[0].startsWith("@") ? 2 : 1;
+  if (parts[i] === "_esm" || (i === parts.length - 1 && parts[i] === "_esm.js")) {
+    parts.splice(i, 1); // delete _esm
+    parts.push("+esm"); // append +esm
+  }
+  // TODO If we added an extension to the path, we should remove it here, but
+  // we can’t distinguish between the case where the extension was added by us
+  // (as in `npm:mime/lite`) and the case where it was added by the user (as
+  // in `npm:mime/lite.js/+esm`).
+  return parts.join("/");
 }
 
 /**

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -250,9 +250,9 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
       : "+esm"
   } = parseNpmSpecifier(specifier);
   return `/_npm/${name}@${await resolveNpmVersion(root, {name, range})}/${
-    extname(path)
-      ? path // preserve the existing extension
-      : path.endsWith("/+esm") || path === "+esm" || !path
+    extname(path) || path.endsWith("/") || path === ""
+      ? path // use the path as-is if it has a file extension or trailing slash
+      : path.endsWith("/+esm") || path === "+esm" || path === undefined
       ? `${path.slice(0, -"+esm".length)}_esm.js` // remove +esm; add _esm.js
       : `${path}/_esm.js` // add /_esm.js
   }`;

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -250,17 +250,15 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
       : "+esm"
   } = parseNpmSpecifier(specifier);
   const version = await resolveNpmVersion(root, {name, range});
-  return fromJsDelivrPath(
-    `/npm/${name}@${version}/${
-      extname(path) || // npm:foo/bar.js
-      path === "" || // npm:foo/
-      path.endsWith("/") || // npm:foo/bar/
-      path === "+esm" || // npm:foo/+esm
-      path.endsWith("/+esm") // npm:foo/bar/+esm
-        ? path
-        : `${path}/+esm`
-    }`
-  );
+  return `/_npm/${name}@${version}/${
+    extname(path) || // npm:foo/bar.js
+    path === "" || // npm:foo/
+    path.endsWith("/") // npm:foo/bar/
+      ? path
+      : path === "+esm" // npm:foo/+esm
+      ? "_esm.js"
+      : path.replace(/(?:\/\+esm)?$/, "._esm.js") // npm:foo/bar or npm:foo/bar/+esm
+  }`;
 }
 
 /**

--- a/test/npm-test.ts
+++ b/test/npm-test.ts
@@ -1,12 +1,6 @@
 import assert from "node:assert";
-import {
-  extractNpmSpecifier,
-  getDependencyResolver,
-  parseNpmSpecifier,
-  resolveNpmImport,
-  rewriteNpmImports
-} from "../src/npm.js";
-import {fromJsDelivrPath} from "../src/npm.js";
+import {extractNpmSpecifier, parseNpmSpecifier} from "../src/npm.js";
+import {fromJsDelivrPath, getDependencyResolver, resolveNpmImport, rewriteNpmImports} from "../src/npm.js";
 import {relativePath} from "../src/path.js";
 import {mockJsDelivr} from "./mocks/jsdelivr.js";
 

--- a/test/npm-test.ts
+++ b/test/npm-test.ts
@@ -73,6 +73,9 @@ describe("extractNpmSpecifier(path)", () => {
   it("returns the npm specifier for the given local npm path", () => {
     assert.strictEqual(extractNpmSpecifier("/_npm/d3@7.8.5/_esm.js"), "d3@7.8.5/+esm");
     assert.strictEqual(extractNpmSpecifier("/_npm/d3@7.8.5/dist/d3.js"), "d3@7.8.5/dist/d3.js");
+    assert.strictEqual(extractNpmSpecifier("/_npm/d3@7.8.5/_esm/dist/d3.js"), "d3@7.8.5/dist/d3.js/+esm");
+    assert.strictEqual(extractNpmSpecifier("/_npm/mime@4.0.1/_esm/lite.js"), "mime@4.0.1/lite/+esm");
+    assert.strictEqual(extractNpmSpecifier("/_npm/@uwdata/vgplot@0.7.1/_esm.js"), "@uwdata/vgplot@0.7.1/+esm");
   });
   it("throws if not given a local npm path", () => {
     assert.throws(() => extractNpmSpecifier("/npm/d3@7.8.5/+esm"), /invalid npm path/);

--- a/test/npm-test.ts
+++ b/test/npm-test.ts
@@ -58,7 +58,7 @@ describe("resolveNpmImport(root, specifier)", () => {
   it("replaces /+esm with /_esm.js", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/+esm"), "/_npm/d3-array@3.2.4/_esm.js");
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src/+esm"), "/_npm/d3-array@3.2.4/_esm/src.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js/+esm"), "/_npm/d3-array@3.2.4/_esm/src/index.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js/+esm"), "/_npm/d3-array@3.2.4/_esm/src/index.js"); // prettier-ignore
   });
   it("does not add /_esm.js if given a path with a file extension", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js"), "/_npm/d3-array@3.2.4/src/index.js");

--- a/test/npm-test.ts
+++ b/test/npm-test.ts
@@ -62,6 +62,10 @@ describe("resolveNodeImport(root, specifier)", () => {
   it("does not add /_esm.js if given a path with a file extension", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js"), "/_npm/d3-array@3.2.4/src/index.js");
   });
+  it("does not add /_esm.js if given a path with a trailing slash", async () => {
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/"), "/_npm/d3-array@3.2.4/");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/"), "/_npm/d3-array@3.2.4/src/");
+  });
 });
 
 describe("extractNpmSpecifier(path)", () => {

--- a/test/npm-test.ts
+++ b/test/npm-test.ts
@@ -46,18 +46,19 @@ describe("parseNpmSpecifier(specifier)", () => {
   });
 });
 
-describe("resolveNodeImport(root, specifier)", () => {
+describe("resolveNpmImport(root, specifier)", () => {
   mockJsDelivr();
   const root = "test/input/build/simple";
   it("implicitly adds /_esm.js for specifiers without an extension", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array"), "/_npm/d3-array@3.2.4/_esm.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/src"), "/_npm/d3-array@3.2.4/src/_esm.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+bar"), "/_npm/d3-array@3.2.4/foo+bar/_esm.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+esm"), "/_npm/d3-array@3.2.4/foo+esm/_esm.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src"), "/_npm/d3-array@3.2.4/_esm/src.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+bar"), "/_npm/d3-array@3.2.4/_esm/foo+bar.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+esm"), "/_npm/d3-array@3.2.4/_esm/foo+esm.js");
   });
   it("replaces /+esm with /_esm.js", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/+esm"), "/_npm/d3-array@3.2.4/_esm.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/+esm"), "/_npm/d3-array@3.2.4/src/_esm.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/+esm"), "/_npm/d3-array@3.2.4/_esm/src.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js/+esm"), "/_npm/d3-array@3.2.4/_esm/src/index.js");
   });
   it("does not add /_esm.js if given a path with a file extension", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js"), "/_npm/d3-array@3.2.4/src/index.js");
@@ -83,6 +84,7 @@ describe("fromJsDelivrPath(path)", () => {
   it("returns the local npm path for the given jsDelivr path", () => {
     assert.strictEqual(fromJsDelivrPath("/npm/d3@7.8.5/+esm"), "/_npm/d3@7.8.5/_esm.js");
     assert.strictEqual(fromJsDelivrPath("/npm/d3@7.8.5/dist/d3.js"), "/_npm/d3@7.8.5/dist/d3.js");
+    assert.strictEqual(fromJsDelivrPath("/npm/d3@7.8.5/dist/d3.js/+esm"), "/_npm/d3@7.8.5/_esm/dist/d3.js");
   });
   it("throws if not given a jsDelivr path", () => {
     assert.throws(() => fromJsDelivrPath("/_npm/d3@7.8.5/_esm.js"), /invalid jsDelivr path/);

--- a/test/npm-test.ts
+++ b/test/npm-test.ts
@@ -51,14 +51,14 @@ describe("resolveNpmImport(root, specifier)", () => {
   const root = "test/input/build/simple";
   it("implicitly adds /_esm.js for specifiers without an extension", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array"), "/_npm/d3-array@3.2.4/_esm.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/src"), "/_npm/d3-array@3.2.4/_esm/src.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+bar"), "/_npm/d3-array@3.2.4/_esm/foo+bar.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+esm"), "/_npm/d3-array@3.2.4/_esm/foo+esm.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src"), "/_npm/d3-array@3.2.4/src._esm.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+bar"), "/_npm/d3-array@3.2.4/foo+bar._esm.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+esm"), "/_npm/d3-array@3.2.4/foo+esm._esm.js");
   });
-  it("replaces /+esm with /_esm.js", async () => {
+  it("replaces /+esm with /_esm.js or ._esm.js", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/+esm"), "/_npm/d3-array@3.2.4/_esm.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/+esm"), "/_npm/d3-array@3.2.4/_esm/src.js");
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js/+esm"), "/_npm/d3-array@3.2.4/_esm/src/index.js"); // prettier-ignore
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/+esm"), "/_npm/d3-array@3.2.4/src._esm.js");
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js/+esm"), "/_npm/d3-array@3.2.4/src/index.js._esm.js"); // prettier-ignore
   });
   it("does not add /_esm.js if given a path with a file extension", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js"), "/_npm/d3-array@3.2.4/src/index.js");
@@ -73,8 +73,8 @@ describe("extractNpmSpecifier(path)", () => {
   it("returns the npm specifier for the given local npm path", () => {
     assert.strictEqual(extractNpmSpecifier("/_npm/d3@7.8.5/_esm.js"), "d3@7.8.5/+esm");
     assert.strictEqual(extractNpmSpecifier("/_npm/d3@7.8.5/dist/d3.js"), "d3@7.8.5/dist/d3.js");
-    assert.strictEqual(extractNpmSpecifier("/_npm/d3@7.8.5/_esm/dist/d3.js"), "d3@7.8.5/dist/d3.js/+esm");
-    assert.strictEqual(extractNpmSpecifier("/_npm/mime@4.0.1/_esm/lite.js"), "mime@4.0.1/lite/+esm");
+    assert.strictEqual(extractNpmSpecifier("/_npm/d3@7.8.5/dist/d3.js._esm.js"), "d3@7.8.5/dist/d3.js/+esm");
+    assert.strictEqual(extractNpmSpecifier("/_npm/mime@4.0.1/lite._esm.js"), "mime@4.0.1/lite/+esm");
     assert.strictEqual(extractNpmSpecifier("/_npm/@uwdata/vgplot@0.7.1/_esm.js"), "@uwdata/vgplot@0.7.1/+esm");
   });
   it("throws if not given a local npm path", () => {
@@ -87,7 +87,7 @@ describe("fromJsDelivrPath(path)", () => {
   it("returns the local npm path for the given jsDelivr path", () => {
     assert.strictEqual(fromJsDelivrPath("/npm/d3@7.8.5/+esm"), "/_npm/d3@7.8.5/_esm.js");
     assert.strictEqual(fromJsDelivrPath("/npm/d3@7.8.5/dist/d3.js"), "/_npm/d3@7.8.5/dist/d3.js");
-    assert.strictEqual(fromJsDelivrPath("/npm/d3@7.8.5/dist/d3.js/+esm"), "/_npm/d3@7.8.5/_esm/dist/d3.js");
+    assert.strictEqual(fromJsDelivrPath("/npm/d3@7.8.5/dist/d3.js/+esm"), "/_npm/d3@7.8.5/dist/d3.js._esm.js");
   });
   it("throws if not given a jsDelivr path", () => {
     assert.throws(() => fromJsDelivrPath("/_npm/d3@7.8.5/_esm.js"), /invalid jsDelivr path/);


### PR DESCRIPTION
In the process of documenting imports, I noticed we don’t handle specifying named entry points well. This fixes importing a named entry point such as:

```js
import mime from "npm:mime/lite";
```

Without this, the import would fail because the `.js` extension is needed to set the MIME type correctly, and also because jsDelivr doesn’t support loading a named entry point without `/+esm` ([e.g.](https://cdn.jsdelivr.net/npm/mime@4.0.1/lite)). You could workaround it like so:

```js
import mime from "npm:mime/lite/+esm";
```

But I figure that it would be better if it “just worked” rather than knowing you need to add `/+esm`, just like the default `npm:mime` without a path works.

I also thought about implicitly adding `/+esm` for paths with JavaScript extensions, such as:

```js
import "npm:katex/contrib/mhchem/mhchem.js";
```

However, since the import could already be valid as-is, I figure it’s better to opt-in to the `/+esm` explicitly. And there are also cases where `/+esm` is broken, such as `echarts`, so we’d have to invent a way to opt-out if we add `/+esm` implicitly.

```js
import "npm:echarts/dist/echarts.esm.min.js";
```

~~In the latest commit, I’ve also tacked on a fix #1163, which is to change how we’re rewriting `/+esm`. Instead of replacing it with `/_esm.js`, we now move it to a leading `/_esm`. This is the same in the default case _e.g._ `npm:d3` resolves to the jsDelivr path `/npm/d3/+esm` and the local path `/_npm/d3/_esm.js`, but in a more complicated case such as `npm:d3@7.8.5/dist/d3.js` which is `/npm/d3@7.8.5/dist/d3.js/+esm`, it is now `/_npm/d3@7.8.5/_esm/dist/d3.js` which avoids the problem of `/_npm/d3@7.8.5/dist/d3.js` potentially needing to be both a file and a directory.~~

I’ve now changed the fix for #1163 to be smaller, which is instead of always replace `/+esm` with `/_esm.js`, in every case except for the top-level `/+esm`, it gets replaced with `._esm.js` instead. The exception for the top-level path is to produce `/_npm/d3@7.8.5/_esm.js` instead of `/_npm/d3@7.8.5._esm.js`. In some was the latter would be preferred and more readable, but I think it’s better for everything to live under `/_npm/d3@7.8.5/` so that you can more easily clear the cache for a specific package. Perhaps a further improvement would change it to `/_npm/d3/7.8.5._esm.js`? At any rate I think that’s an aesthetic decision that I would prefer to defer to future work.