### PR TITLE
more readable _node urls (and cache structure)

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -10,7 +10,6 @@ import {transpileModule} from "./javascript/transpile.js";
 import type {Logger, Writer} from "./logger.js";
 import type {MarkdownPage} from "./markdown.js";
 import {parseMarkdown} from "./markdown.js";
-import {extractNodeSpecifier} from "./node.js";
 import {extractNpmSpecifier, populateNpmCache, resolveNpmImport} from "./npm.js";
 import {isPathImport, relativePath, resolvePath} from "./path.js";
 import {renderPage} from "./render.js";
@@ -181,7 +180,7 @@ export async function build(
       const sourcePath = await populateNpmCache(root, path); // TODO effects
       await effects.copyFile(sourcePath, path);
     } else if (path.startsWith("/_node/")) {
-      effects.output.write(`${faint("copy")} ${extractNodeSpecifier(path)} ${faint("→")} `);
+      effects.output.write(`${faint("copy")} ${path.slice("/_node/".length)} ${faint("→")} `);
       await effects.copyFile(join(root, ".observablehq", "cache", path), path);
     }
   }

--- a/src/node.ts
+++ b/src/node.ts
@@ -63,15 +63,6 @@ export async function resolveNodeImports(root: string, path: string): Promise<Im
   return parseImports(join(root, ".observablehq", "cache"), path);
 }
 
-/**
- * Given a local npm path such as "/_node/d3-array@3.2.4/src/index.js", returns
- * the corresponding npm specifier such as "d3-array@3.2.4/src/index.js".
- */
-export function extractNodeSpecifier(path: string): string {
-  if (!path.startsWith("/_node/")) throw new Error(`invalid node path: ${path}`);
-  return path.slice("/_node/".length);
-}
-
 async function bundle(input: string, cacheRoot: string, packageRoot: string): Promise<string> {
   const bundle = await rollup({
     input,

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -8,7 +8,7 @@ import {getImplicitDependencies, getImplicitDownloads} from "./libraries.js";
 import {getImplicitFileImports, getImplicitInputImports} from "./libraries.js";
 import {getImplicitStylesheets} from "./libraries.js";
 import type {MarkdownPage} from "./markdown.js";
-import {extractNodeSpecifier, resolveNodeImport, resolveNodeImports} from "./node.js";
+import {resolveNodeImport, resolveNodeImports} from "./node.js";
 import {extractNpmSpecifier, populateNpmCache, resolveNpmImport, resolveNpmImports} from "./npm.js";
 import {isAssetPath, isPathImport, relativePath, resolveLocalPath, resolvePath} from "./path.js";
 
@@ -200,9 +200,9 @@ export async function getResolvers(
       for (const i of await resolveNodeImports(root, value)) {
         if (i.type === "local") {
           const path = resolvePath(value, i.name);
-          const specifier = extractNodeSpecifier(path);
-          globalImports.add(specifier);
-          resolutions.set(specifier, path);
+          const cache = path.slice("/_node/".length);
+          globalImports.add(cache);
+          resolutions.set(cache, path);
         }
       }
     }
@@ -230,9 +230,9 @@ export async function getResolvers(
       for (const i of await resolveNodeImports(root, value)) {
         if (i.type === "local" && i.method === "static") {
           const path = resolvePath(value, i.name);
-          const specifier = extractNodeSpecifier(path);
-          staticImports.add(specifier);
-          staticResolutions.set(specifier, path);
+          const cache = path.slice("/_node/".length);
+          staticImports.add(cache);
+          staticResolutions.set(cache, path);
         }
       }
     }

--- a/test/node-test.ts
+++ b/test/node-test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import {existsSync} from "node:fs";
 import {rm} from "node:fs/promises";
-import {extractNodeSpecifier, resolveNodeImport, resolveNodeImports} from "../src/node.js";
+import {resolveNodeImport, resolveNodeImports} from "../src/node.js";
 
 describe("resolveNodeImport(root, spec)", () => {
   const importRoot = "../../input/packages/.observablehq/cache";
@@ -10,37 +10,42 @@ describe("resolveNodeImport(root, spec)", () => {
     await rm("test/input/packages/.observablehq/cache", {recursive: true, force: true});
   });
   it("resolves the version of a direct dependency", async () => {
-    assert.deepStrictEqual(await resolveNodeImport("docs", "d3-array"), "/_node/d3-array@3.2.4/index.js");
-    assert.deepStrictEqual(await resolveNodeImport("docs", "mime"), "/_node/mime@4.0.1/index.js");
+    assert.deepStrictEqual(await resolveNodeImport("docs", "d3-array"), "/_node/d3-array@3.2.4/a6083063/d3-array.js");
+    assert.deepStrictEqual(await resolveNodeImport("docs", "mime"), "/_node/mime@4.0.1/2c7c74a5/mime.js");
   });
   it("allows entry points", async () => {
-    assert.deepStrictEqual(await resolveNodeImport("docs", "mime/lite"), "/_node/mime@4.0.1/lite.js");
+    assert.deepStrictEqual(await resolveNodeImport("docs", "mime/lite"), "/_node/mime@4.0.1/148dd32d/lite.js");
   });
   it("allows non-javascript entry points", async () => {
-    assert.deepStrictEqual(await resolveNodeImport("docs", "glob/package.json"), "/_node/glob@10.3.10/package.json");
+    assert.deepStrictEqual(await resolveNodeImport("docs", "glob/package.json"), "/_node/glob@10.3.10/eb5efdd4/package.json"); // prettier-ignore
   });
   it("does not allow version ranges", async () => {
     await assert.rejects(() => resolveNodeImport("docs", "mime@4"), /Cannot find module/);
   });
   it("bundles a package with a shorthand export", async () => {
-    assert.strictEqual(await resolveNodeImport("test/input/packages", "test-shorthand-export"), "/_node/test-shorthand-export@1.0.0/index.js"); // prettier-ignore
-    assert.strictEqual((await import(`${importRoot}/_node/test-shorthand-export@1.0.0/index.js`)).name, "test-shorthand-export"); // prettier-ignore
+    const im = await resolveNodeImport("test/input/packages", "test-shorthand-export");
+    assert.strictEqual(im, "/_node/test-shorthand-export@1.0.0/5c9d6142/test-shorthand-export.js"); // prettier-ignore
+    assert.strictEqual((await import(`${importRoot}${im}`)).name, "test-shorthand-export"); // prettier-ignore
   });
   it("bundles a package with an import conditional export", async () => {
-    assert.strictEqual(await resolveNodeImport("test/input/packages", "test-import-condition"), "/_node/test-import-condition@1.0.0/index.js"); // prettier-ignore
-    assert.strictEqual((await import(`${importRoot}/_node/test-import-condition@1.0.0/index.js`)).name, "test-import-condition:import"); // prettier-ignore
+    const im = await resolveNodeImport("test/input/packages", "test-import-condition");
+    assert.strictEqual(im, "/_node/test-import-condition@1.0.0/ae19a520/test-import-condition.js"); // prettier-ignore
+    assert.strictEqual((await import(`${importRoot}/${im}`)).name, "test-import-condition:import"); // prettier-ignore
   });
   it("bundles a package with a browser field", async () => {
-    assert.strictEqual(await resolveNodeImport("test/input/packages", "test-browser-field"), "/_node/test-browser-field@1.0.0/index.js"); // prettier-ignore
-    assert.strictEqual((await import(`${importRoot}/_node/test-browser-field@1.0.0/index.js`)).name, "test-browser-field:browser"); // prettier-ignore
+    const im = await resolveNodeImport("test/input/packages", "test-browser-field");
+    assert.strictEqual(im, "/_node/test-browser-field@1.0.0/ccc4528f/test-browser-field.js"); // prettier-ignore
+    assert.strictEqual((await import(`${importRoot}/${im}`)).name, "test-browser-field:browser"); // prettier-ignore
   });
   it("bundles a package with a browser map", async () => {
-    assert.strictEqual(await resolveNodeImport("test/input/packages", "test-browser-map"), "/_node/test-browser-map@1.0.0/index.js"); // prettier-ignore
-    assert.strictEqual((await import(`${importRoot}/_node/test-browser-map@1.0.0/index.js`)).name, "test-browser-map:browser"); // prettier-ignore
+    const im = await resolveNodeImport("test/input/packages", "test-browser-map");
+    assert.strictEqual(im, "/_node/test-browser-map@1.0.0/28e99e1e/test-browser-map.js"); // prettier-ignore
+    assert.strictEqual((await import(`${importRoot}/${im}`)).name, "test-browser-map:browser"); // prettier-ignore
   });
   it("bundles a package with a browser conditional export", async () => {
-    assert.strictEqual(await resolveNodeImport("test/input/packages", "test-browser-condition"), "/_node/test-browser-condition@1.0.0/index.js"); // prettier-ignore
-    assert.strictEqual((await import(`${importRoot}/_node/test-browser-condition@1.0.0/index.js`)).name, "test-browser-condition:browser"); // prettier-ignore
+    const im = await resolveNodeImport("test/input/packages", "test-browser-condition");
+    assert.strictEqual(im, "/_node/test-browser-condition@1.0.0/53e104e3/test-browser-condition.js"); // prettier-ignore
+    assert.strictEqual((await import(`${importRoot}/${im}`)).name, "test-browser-condition:browser"); // prettier-ignore
   });
 });
 
@@ -54,18 +59,12 @@ describe("resolveNodeImports(root, path)", () => {
     assert.deepStrictEqual(await resolveNodeImports("docs", await resolveNodeImport("docs", "d3-array")), [
       {
         method: "static",
-        name: "../internmap@2.0.3/index.js",
+        name: "../../internmap@2.0.3/e0fb710d/internmap.js",
         type: "local"
       }
     ]);
   });
   it("ignores non-JavaScript paths", async () => {
     assert.deepStrictEqual(await resolveNodeImports("docs", await resolveNodeImport("docs", "glob/package.json")), []);
-  });
-});
-
-describe("extractNodeSpecifier(path)", () => {
-  it("returns the node specifier from the given path", () => {
-    assert.strictEqual(extractNodeSpecifier("/_node/d3-array@3.2.4/index.js"), "d3-array@3.2.4/index.js");
   });
 });


### PR DESCRIPTION
Since we're free to name the resolutions of `/_node/` files (bare module specifiers) as we want, why not give them names that are easy to read in the browser's network tab and make cache busting easier.

Here's what this combination gives when using node_modules versions of `duckdb-wasm`, `d3-array` and `internmap@1` (when `d3-array` requires `internmap@2`, generating two files):


```
<link rel="modulepreload" href="./_node/internmap@1.0.1/77f92c63/internmap.js">
<link rel="modulepreload" href="./_node/d3-array@3.2.4/a6083063/d3-array.js">
<link rel="modulepreload" href="./_node/@duckdb/duckdb-wasm@1.28.1-dev106.0/5e9b2fc6/duckdb-wasm.js">
<link rel="modulepreload" href="./_node/internmap@2.0.3/e0fb710d/internmap.js">
<link rel="modulepreload" href="./_node/apache-arrow@14.0.2/8d522eb1/apache-arrow.js">
<link rel="modulepreload" href="./_node/tslib@2.6.2/b26fe5c0/tslib.js">
<link rel="modulepreload" href="./_node/flatbuffers@23.5.26/ada4f5af/flatbuffers.js">


...

const duckdb = await import("./_node/@duckdb/duckdb-wasm@1.28.1-dev106.0/5e9b2fc6/duckdb-wasm.js");
const MANUAL_BUNDLES = {
  mvp: {
    mainModule: new URL("./_node/@duckdb/duckdb-wasm@1.28.1-dev106.0/b08f36ee/duckdb-mvp.wasm", location).href,
    mainWorker: new URL("./_node/@duckdb/duckdb-wasm@1.28.1-dev106.0/b6de1549/duckdb-browser-mvp.worker.js", location).href
  },
  eh: {
    mainModule: new URL("./_node/@duckdb/duckdb-wasm@1.28.1-dev106.0/75338043/duckdb-eh.wasm", location).href,
    mainWorker: new URL("./_node/@duckdb/duckdb-wasm@1.28.1-dev106.0/d80d9fe7/duckdb-browser-eh.worker.js", location).href
  },
};

```

This also removes the `extractNodeSpecifier` function which was has no more purpose.


(Leaving as a draft for now because it might depend on whether we are doing the same for `/_npm/`, see https://github.com/observablehq/framework/pull/1165#issuecomment-2027081844.)