### PR TITLE
Add interactive version of PMMS dashboard

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,5 +10,5 @@
 - **Google analytics** — Load data from the G.A. API and analyze your website’s traffic. [[code](./google-analytics)] [[live project](https://observablehq.com/framework/examples/google-analytics/)]
 - **Hello, world!** — A minimal test. [[code](./hello-world)] [[live project](https://observablehq.com/framework/examples/hello-world/)]
 - **Plot** — TypeScript data loaders that access metadata from the Observable Plot Github repo. [[code](./plot)] [[live project](https://observablehq.com/framework/examples/plot/)]
-- **Mortgage rates** — A small dashboard reproducing Freddie Mac’s historic mortgage rates dashboard. [[code](./mortgage-rates)] [[live project](https://observablehq.com/framework/examples/mortgage-rates/)]
+- **Mortgage rates** — A small dashboard reproducing Freddie Mac’s historic mortgage rates dashboard. [[code](./mortgage-rates)] [[live project](https://observablehq.com/framework/examples/mortgage-rates/)][[interactive version](https://observablehq.com/framework/examples/mortgage-rates/interactive)]
 - **Penguin classification** — In a Python data loader, we use logistic regression to predict penguin species based on body size measurements. [[code](./penguin-classification)] [[live project](https://observablehq.com/framework/examples/penguin-classification/)]

--- a/examples/mortgage-rates/README.md
+++ b/examples/mortgage-rates/README.md
@@ -3,6 +3,7 @@
 This is an example Observable Framework project that tracks mortage rates published by Freddie Mac — Federal Home Loan Mortgage Corporation — every week since 1971.
 
 View the [live project](https://observablehq.com/framework/examples/mortgage-rates/). 
+View the [interactive version](https://observablehq.com/framework/examples/mortgage-rates/interactive). 
 
 ## Data loader
 
@@ -11,3 +12,7 @@ A single TypeScript data loader `docs/data/pmms.csv.ts` fetches the data from Fr
 ## Charts
 
 The cards and charts reinterpret the original elements of Freddie Mac’s [PMMS dashboard](https://www.freddiemac.com/pmms). We use [Observable Plot](https://observablehq.com/plot/) to draw the charts. The chart code is simple enough to be directly inlined in the page’s markdown `docs/index.md`.
+
+## Interactive version
+
+There is also [an interactive version](https://observablehq.com/framework/examples/mortgage-rates/interactive) that adds control over the year being shown. See [this blog post to read about how it was done](https://observablehq.com/blog/how-to-add-interactivity-observable-framework-dashboard).

--- a/examples/mortgage-rates/docs/interactive.md
+++ b/examples/mortgage-rates/docs/interactive.md
@@ -1,0 +1,147 @@
+# Primary mortgage market survey
+
+```js
+const pmms = FileAttachment("data/pmms.csv").csv({typed: true});
+```
+
+```js
+const color = Plot.scale({color: {domain: ["30Y FRM", "15Y FRM"]}});
+const colorLegend = (y) => html`<span style="border-bottom: solid 2px ${color.apply(`${y}Y FRM`)};">${y}-year fixed-rate</span>`;
+```
+
+```js
+const tidy = pmms.flatMap(({date, pmms30, pmms15}) => [{date, rate: pmms30, type: "30Y FRM"}, {date, rate: pmms15, type: "15Y FRM"}]);
+```
+
+```js
+function frmCard(y, pmms) {
+  const key = `pmms${y}`;
+  const pmmsSubset = pmms.filter(d => d.date.getFullYear() === selectedYear);
+  const diff1 = pmmsSubset.at(-1)[key] - pmmsSubset.at(-2)[key];
+  const diffY = pmmsSubset.at(-1)[key] - pmmsSubset.at(0)[key];
+  const range = d3.extent(pmmsSubset, (d) => d[key]);
+  const stroke = color.apply(`${y}Y FRM`);
+  return html.fragment`
+    <h2 style="color: ${stroke}">${y}-year fixed-rate in ${selectedYear}</b></h2>
+    <h1>${formatPercent(pmmsSubset.at(-1)[key])}</h1>
+    <table>
+      <tr>
+        <td>1-week change</td>
+        <td align="right">${formatPercent(diff1, {signDisplay: "always"})}</td>
+        <td>${trend(diff1)}</td>
+      </tr>
+      <tr>
+        <td>1-year change</td>
+        <td align="right">${formatPercent(diffY, {signDisplay: "always"})}</td>
+        <td>${trend(diffY)}</td>
+      </tr>
+      <tr>
+        <td>4-week average</td>
+        <td align="right">${formatPercent(d3.mean(pmmsSubset.slice(-4), (d) => d[key]))}</td>
+      </tr>
+      <tr>
+        <td>52-week average</td>
+        <td align="right">${formatPercent(d3.mean(pmmsSubset, (d) => d[key]))}</td>
+      </tr>
+    </table>
+    ${resize((width) =>
+      Plot.plot({
+        width,
+        height: 40,
+        axis: null,
+        x: {inset: 40},
+        marks: [
+          Plot.tickX(pmmsSubset, {
+            x: key,
+            stroke,
+            insetTop: 10,
+            insetBottom: 10,
+            title: (d) => `${d.date?.toLocaleDateString("en-us")}: ${d[key]}%`,
+            tip: {anchor: "bottom"}
+          }),
+          Plot.tickX(pmmsSubset.slice(-1), {x: key, strokeWidth: 2}),
+          Plot.text([`${range[0]}%`], {frameAnchor: "left"}),
+          Plot.text([`${range[1]}%`], {frameAnchor: "right"})
+        ]
+      })
+    )}
+    <span class="small muted">52-week range</span>
+  `;
+}
+
+function formatPercent(value, format) {
+  return value == null
+    ? "N/A"
+    : (value / 100).toLocaleString("en-US", {minimumFractionDigits: 2, style: "percent", ...format});
+}
+
+function trend(v) {
+  return v >= 0.005 ? html`<span class="green">↗︎</span>`
+    : v <= -0.005 ? html`<span class="red">↘︎</span>`
+    : "→";
+}
+
+```
+
+Each week, [Freddie Mac](https://www.freddiemac.com/pmms/about-pmms.html) surveys lenders on rates and points for their ${colorLegend(30)}, ${colorLegend(15)}, and other mortgage products. Data as of ${pmms.at(-1).date?.toLocaleDateString("en-US", {year: "numeric", month: "long", day: "numeric"})}.
+
+```js
+const selectedYear = view(Inputs.range(d3.extent(pmms, d => d.date.getFullYear()), {label: 'Year:', step: 1, value: 2023}));
+```
+
+<style type="text/css">
+
+@container (min-width: 560px) {
+  .grid-cols-2-3 {
+    grid-template-columns: 1fr 1fr;
+  }
+  .grid-cols-2-3 .grid-colspan-2 {
+    grid-column: span 2;
+  }
+}
+
+@container (min-width: 840px) {
+  .grid-cols-2-3 {
+    grid-template-columns: 1fr 2fr;
+    grid-auto-flow: column;
+  }
+}
+
+</style>
+
+<div class="grid grid-cols-2-3">
+  <div class="card">${frmCard(30, pmms)}</div>
+  <div class="card">${frmCard(15, pmms)}</div>
+  <div class="card grid-colspan-2 grid-rowspan-2" style="display: flex; flex-direction: column;">
+    <h2>Rates over the year ${selectedYear}</h2>
+    <span style="flex-grow: 1;">${resize((width, height) =>
+      Plot.plot({
+        width,
+        height,
+        y: {grid: true, label: "rate (%)"},
+        color,
+        marks: [
+          Plot.lineY(tidy.filter(d => d.date.getFullYear() === selectedYear), {x: "date", y: "rate", stroke: "type", curve: "step", tip: true, markerEnd: true})
+        ]
+      })
+    )}</span>
+  </div>
+</div>
+
+<div class="grid">
+  <div class="card">
+    <h2>Rates over all time (${d3.extent(pmms, (d) => d.date.getUTCFullYear()).join("–")})</h2>
+    ${resize((width) =>
+      Plot.plot({
+        width,
+        y: {grid: true, label: "rate (%)"},
+        color,
+        marks: [
+          Plot.rectY([{year: selectedYear}], {x1: d => new Date(d.year, 0, 1), x2: d => new Date(d.year+1, 0), y1: 0, y2: d3.max(tidy, d => d.rate), fill: "var(--theme-foreground)", opacity: 0.15}),
+          Plot.ruleY([0]),
+          Plot.lineY(tidy, {x: "date", y: "rate", stroke: "type", tip: true})
+        ]
+      })
+    )}
+  </div>
+</div>

--- a/examples/mortgage-rates/docs/interactive.md
+++ b/examples/mortgage-rates/docs/interactive.md
@@ -1,4 +1,4 @@
-# Primary mortgage market survey
+# Primary mortgage market survey (interactive)
 
 ```js
 const pmms = FileAttachment("data/pmms.csv").csv({typed: true});

--- a/examples/mortgage-rates/observablehq.config.ts
+++ b/examples/mortgage-rates/observablehq.config.ts
@@ -2,6 +2,7 @@ export default {
   title: "Primary mortgage market survey",
   pager: false,
   toc: false,
+  sidebar: false,
   head:
     process.env.CI &&
     `<script type="module" async src="https://events.observablehq.com/client.js"></script>


### PR DESCRIPTION
This adds a (simple) interactive version of the PMMS dashboard, as described in this blog post: https://observablehq.com/blog/how-to-add-interactivity-observable-framework-dashboard