### PR TITLE
implicit /+esm for JavaScript extensions

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -247,6 +247,8 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
       ? "dist/mermaid.esm.min.mjs/+esm"
       : name === "echarts"
       ? "dist/echarts.esm.min.js/+esm"
+      : name === "deck.gl"
+      ? "dist.min.js/+esm"
       : "+esm"
   } = parseNpmSpecifier(specifier);
   const version = await resolveNpmVersion(root, {name, range});

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -6,7 +6,7 @@ import {simple} from "acorn-walk";
 import {rsort, satisfies} from "semver";
 import {isEnoent} from "./error.js";
 import type {ExportNode, ImportNode, ImportReference} from "./javascript/imports.js";
-import {isImportMetaResolve, parseImports} from "./javascript/imports.js";
+import {isImportMetaResolve, isJavaScript, parseImports} from "./javascript/imports.js";
 import {parseProgram} from "./javascript/parse.js";
 import type {StringLiteral} from "./javascript/source.js";
 import {getStringLiteralValue, isStringLiteral} from "./javascript/source.js";
@@ -246,12 +246,12 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
     path = name === "mermaid"
       ? "dist/mermaid.esm.min.mjs/+esm"
       : name === "echarts"
-      ? "dist/echarts.esm.min.js"
+      ? "dist/echarts.esm.min.js/+esm"
       : "+esm"
   } = parseNpmSpecifier(specifier);
   const version = await resolveNpmVersion(root, {name, range});
   return `/_npm/${name}@${version}/${
-    extname(path) || // npm:foo/bar.js
+    (extname(path) && !isJavaScript(path)) || // npm:foo/bar.css
     path === "" || // npm:foo/
     path.endsWith("/") // npm:foo/bar/
       ? path

--- a/test/npm-test.ts
+++ b/test/npm-test.ts
@@ -10,13 +10,13 @@ describe("getDependencyResolver(root, path, input)", () => {
     const root = "test/input/build/simple-public";
     const specifier = "/npm/d3-array@3.2.3/dist/d3-array.js";
     const resolver = await getDependencyResolver(root, "/_npm/d3@7.8.5/_esm.js", `import '${specifier}';\n`); // prettier-ignore
-    assert.strictEqual(resolver(specifier), "../d3-array@3.2.4/dist/d3-array.js");
+    assert.strictEqual(resolver(specifier), "../d3-array@3.2.4/dist/d3-array.js._esm.js");
   });
   it("finds /npm/ import resolutions and re-resolves their versions", async () => {
     const root = "test/input/build/simple-public";
     const specifier = "/npm/d3-array@3.2.3/dist/d3-array.js";
     const resolver = await getDependencyResolver(root, "/_npm/d3@7.8.5/_esm.js", `import.meta.resolve('${specifier}');\n`); // prettier-ignore
-    assert.strictEqual(resolver(specifier), "../d3-array@3.2.4/dist/d3-array.js");
+    assert.strictEqual(resolver(specifier), "../d3-array@3.2.4/dist/d3-array.js._esm.js");
   });
 });
 
@@ -49,21 +49,24 @@ describe("parseNpmSpecifier(specifier)", () => {
 describe("resolveNpmImport(root, specifier)", () => {
   mockJsDelivr();
   const root = "test/input/build/simple";
-  it("implicitly adds /_esm.js for specifiers without an extension", async () => {
+  it("implicitly adds ._esm.js for specifiers without an extension", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array"), "/_npm/d3-array@3.2.4/_esm.js");
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src"), "/_npm/d3-array@3.2.4/src._esm.js");
     assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+bar"), "/_npm/d3-array@3.2.4/foo+bar._esm.js");
     assert.strictEqual(await resolveNpmImport(root, "d3-array/foo+esm"), "/_npm/d3-array@3.2.4/foo+esm._esm.js");
+  });
+  it("implicitly adds ._esm.js for specifiers with a JavaScript extension", async () => {
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js"), "/_npm/d3-array@3.2.4/src/index.js._esm.js"); // prettier-ignore
   });
   it("replaces /+esm with /_esm.js or ._esm.js", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/+esm"), "/_npm/d3-array@3.2.4/_esm.js");
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src/+esm"), "/_npm/d3-array@3.2.4/src._esm.js");
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js/+esm"), "/_npm/d3-array@3.2.4/src/index.js._esm.js"); // prettier-ignore
   });
-  it("does not add /_esm.js if given a path with a file extension", async () => {
-    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.js"), "/_npm/d3-array@3.2.4/src/index.js");
+  it("does not add ._esm.js for specifiers with a non-JavaScript extension", async () => {
+    assert.strictEqual(await resolveNpmImport(root, "d3-array/src/index.css"), "/_npm/d3-array@3.2.4/src/index.css");
   });
-  it("does not add /_esm.js if given a path with a trailing slash", async () => {
+  it("does not add /_esm.js for specifiers with a trailing slash", async () => {
     assert.strictEqual(await resolveNpmImport(root, "d3-array/"), "/_npm/d3-array@3.2.4/");
     assert.strictEqual(await resolveNpmImport(root, "d3-array/src/"), "/_npm/d3-array@3.2.4/src/");
   });


### PR DESCRIPTION
This makes imports such as this work out of the box:

```js
import Deck from "npm:deck.gl/dist.min.js";
```
```js
import mermaid from "npm:mermaid/dist/mermaid.esm.min.mjs";
```

Previously these imports would error because they require `/+esm`; now the `/+esm` is added implicitly so it “just works.”

This also fixes the default entry for deck.gl, so that this now works, too:

```js
import Deck from "npm:deck.gl";
```

(I did see an error once about “multiple versions of luma detected”… but couldn’t reproduce it reliably.)