### PR TITLE
jquery-ui shim

### DIFF
--- a/docs/lib/jquery-ui.md
+++ b/docs/lib/jquery-ui.md
@@ -1,0 +1,27 @@
+# jQuery UI
+
+```js echo
+import $ from "npm:jquery";
+import "npm:jquery-ui";
+```
+
+<p>
+  <label for="amount">Price range:</label>
+  ${value.join("–")}
+</p>
+
+<div style="max-width: 320px;" id="slider"></div>
+
+```js
+const value = Generators.observe((notify) => {
+  const slider = $("#slider");
+  slider.slider({
+    range: true,
+    min: 0,
+    max: 500,
+    values: [5, 300],
+    slide: (event, ui) => notify(ui.values)
+  });
+  notify(slider.slider("values"));
+});
+```

--- a/src/client/stdlib/jquery-ui.js
+++ b/src/client/stdlib/jquery-ui.js
@@ -1,0 +1,7 @@
+import $ from "npm:jquery";
+
+self.jQuery = $;
+
+await import("npm:jquery-ui/dist/jquery-ui.min.js/+esm");
+
+export default $;

--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -47,6 +47,7 @@ export function getImplicitStylesheets(imports: Iterable<string>): Set<string> {
   if (set.has("npm:katex")) implicits.add("npm:katex/dist/katex.min.css");
   if (set.has("npm:leaflet")) implicits.add("npm:leaflet/dist/leaflet.css");
   if (set.has("npm:mapbox-gl")) implicits.add("npm:mapbox-gl/dist/mapbox-gl.css");
+  if (set.has("npm:jquery-ui")) implicits.add("npm:jquery-ui/dist/themes/base/jquery-ui.css");
   return implicits;
 }
 

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -247,18 +247,19 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
       ? "dist/mermaid.esm.min.mjs/+esm"
       : name === "echarts"
       ? "dist/echarts.esm.min.js"
-      : "+esm"
+      : undefined
   } = parseNpmSpecifier(specifier);
-  const version = await resolveNpmVersion(root, {name, range});
-  return `/_npm/${name}@${version}/${
-    extname(path) || // npm:foo/bar.js
-    path === "" || // npm:foo/
-    path.endsWith("/") // npm:foo/bar/
-      ? path
-      : path === "+esm" // npm:foo/+esm
+  if (name === "jquery-ui" && range === undefined && path === undefined) return "/_observablehq/stdlib/jquery-ui.js"; // jquery-ui shim
+  const rpath =
+    path === undefined || path === "+esm" // npm:foo/+esm
       ? "_esm.js"
-      : path.replace(/(?:\/\+esm)?$/, "._esm.js") // npm:foo/bar or npm:foo/bar/+esm
-  }`;
+      : extname(path) || // npm:foo/bar.js
+        path === "" || // npm:foo/
+        path.endsWith("/") // npm:foo/bar/
+      ? path
+      : path.replace(/(?:\/\+esm)?$/, "._esm.js"); // npm:foo/bar or npm:foo/bar/+esm
+  const version = await resolveNpmVersion(root, {name, range});
+  return `/_npm/${name}@${version}/${rpath}`;
 }
 
 /**

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -187,7 +187,7 @@ export async function getResolvers(
   // of populating the npm cache; the node import cache is already transitively
   // populated above.
   for (const [key, value] of resolutions) {
-    if (key.startsWith("npm:")) {
+    if (key.startsWith("npm:") && value.startsWith("/_npm/")) {
       for (const i of await resolveNpmImports(root, value)) {
         if (i.type === "local") {
           const path = resolvePath(value, i.name);
@@ -217,7 +217,7 @@ export async function getResolvers(
     }
   }
   for (const [key, value] of staticResolutions) {
-    if (key.startsWith("npm:")) {
+    if (key.startsWith("npm:") && value.startsWith("/_npm/")) {
       for (const i of await resolveNpmImports(root, value)) {
         if (i.type === "local" && i.method === "static") {
           const path = resolvePath(value, i.name);


### PR DESCRIPTION
I don’t think we want to do this, but sharing just as a pedagogical example. This makes the following imports work:

```js
import $ from "npm:jquery";
import "npm:jquery-ui";
```

This is quite a bit simpler than the current alternative:

````md
<link rel="stylesheet" href="npm:jquery-ui/dist/themes/base/jquery-ui.css">

```js
import $ from "npm:jquery";
self.jQuery = $;
await import("npm:jquery-ui/dist/jquery-ui.js/+esm");
```
````

The downsides are:

* This only works when the semver range is not specified (or `latest` maybe?)
* This only works when the path is not specified
* This hard-codes the `base` theme, which may not be wanted

In general, I think it’s nice if we can make things “just work”, but maybe inserting a special shim is a little too far.

I suggest we close this PR but might be useful as a future technique.