### PR TITLE
ignore node built-ins

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -100,6 +100,7 @@ async function bundle(input: string, cacheRoot: string, packageRoot: string): Pr
 function importResolve(input: string, cacheRoot: string, packageRoot: string): Plugin {
   async function resolve(specifier: string | AstNode): Promise<ResolveIdResult> {
     return typeof specifier !== "string" || // AST node?
+      isNodeBuiltin(specifier) || // node built-in, e.g., "node:fs" or "fs"
       isPathImport(specifier) || // relative path, e.g., ./foo.js
       /^\w+:/.test(specifier) || // windows file path, https: URL, etc.
       specifier === input // entry point
@@ -112,3 +113,67 @@ function importResolve(input: string, cacheRoot: string, packageRoot: string): P
     resolveDynamicImport: resolve
   };
 }
+
+export function isNodeBuiltin(specifier: string): boolean {
+  return specifier.startsWith("node:") || nodeBuiltins.has(specifier.replace(/\/.*/, ""));
+}
+
+// https://github.com/evanw/esbuild/blob/9d1777f23d9b64c186345223d92f319e59388d8b/internal/resolver/resolver.go#L2802-L2874
+const nodeBuiltins = new Set([
+  "_http_agent",
+  "_http_client",
+  "_http_common",
+  "_http_incoming",
+  "_http_outgoing",
+  "_http_server",
+  "_stream_duplex",
+  "_stream_passthrough",
+  "_stream_readable",
+  "_stream_transform",
+  "_stream_wrap",
+  "_stream_writable",
+  "_tls_common",
+  "_tls_wrap",
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "constants",
+  "crypto",
+  "dgram",
+  "diagnostics_channel",
+  "dns",
+  "domain",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "inspector",
+  "module",
+  "net",
+  "os",
+  "path",
+  "perf_hooks",
+  "process",
+  "punycode",
+  "querystring",
+  "readline",
+  "repl",
+  "stream",
+  "string_decoder",
+  "sys",
+  "timers",
+  "tls",
+  "trace_events",
+  "tty",
+  "url",
+  "util",
+  "v8",
+  "vm",
+  "wasi",
+  "worker_threads",
+  "zlib"
+]);

--- a/test/node-test.ts
+++ b/test/node-test.ts
@@ -1,7 +1,33 @@
 import assert from "node:assert";
 import {existsSync} from "node:fs";
 import {rm} from "node:fs/promises";
-import {extractNodeSpecifier, resolveNodeImport, resolveNodeImports} from "../src/node.js";
+import {extractNodeSpecifier, isNodeBuiltin, resolveNodeImport, resolveNodeImports} from "../src/node.js";
+
+describe("isNodeBuiltin(specifier)", () => {
+  it("returns true for node: specifiers", () => {
+    assert.strictEqual(isNodeBuiltin("node:fs"), true);
+    assert.strictEqual(isNodeBuiltin("node:path"), true);
+    assert.strictEqual(isNodeBuiltin("node:path/posix"), true);
+  });
+  it("returns false for what are probably not node built-ins", () => {
+    assert.strictEqual(isNodeBuiltin(""), false);
+    assert.strictEqual(isNodeBuiltin("/fs"), false);
+    assert.strictEqual(isNodeBuiltin("./fs"), false);
+    assert.strictEqual(isNodeBuiltin("/node:fs"), false);
+    assert.strictEqual(isNodeBuiltin("./node:fs"), false);
+    assert.strictEqual(isNodeBuiltin("foo"), false);
+    assert.strictEqual(isNodeBuiltin("notnode:fs"), false);
+  });
+  it("returns true for certain know built-in modules:", () => {
+    assert.strictEqual(isNodeBuiltin("fs"), true);
+    assert.strictEqual(isNodeBuiltin("path"), true);
+    assert.strictEqual(isNodeBuiltin("path/posix"), true);
+  });
+  it("considers submodules such as fs/promises", () => {
+    assert.strictEqual(isNodeBuiltin("fs/promises"), true);
+    assert.strictEqual(isNodeBuiltin("fs/whatever"), true);
+  });
+});
 
 describe("resolveNodeImport(root, spec)", () => {
   const importRoot = "../../input/packages/.observablehq/cache";


### PR DESCRIPTION
Fixes #1181, to the best of our abilities. You still can’t import deck.gl successfully, though (because deck.gl’s `package.json` doesn’t declare the `dist.min.js` as an export so you’re not allowed to import it, and because the default export `dist/index.js` depends on a variety of modules that esbuild complains about because they use `require` which I’m not sure how to fix).