### PR TITLE
handle build error

### DIFF
--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -242,8 +242,8 @@ try {
         // clack.outro doesn't handle multiple lines well, so do it manually
         console.log(
           `${faint("│\n│")}  If you think this is a bug, please file an issue at\n${faint("└")}  ${link(
-            "https://github.com/observablehq/framework/issues\n"
-          )}`
+            "https://github.com/observablehq/framework/issues"
+          )}\n`
         );
       }
     } else {
@@ -255,8 +255,8 @@ try {
         console.error("\nTip: To see the full stack trace, run with the --debug flag.\n");
         console.error(
           `If you think this is a bug, please file an issue at\n↳ ${link(
-            "https://github.com/observablehq/framework/issues\n"
-          )}`
+            "https://github.com/observablehq/framework/issues"
+          )}\n`
         );
       }
     }

--- a/test/create-test.ts
+++ b/test/create-test.ts
@@ -4,6 +4,7 @@ import type {CreateEffects} from "../src/create.js";
 import {create} from "../src/create.js";
 import {fromOsPath} from "../src/files.js";
 import {TestClackEffects} from "./mocks/clack.js";
+import {MockLogger} from "./mocks/logger.js";
 
 describe("create", () => {
   it("instantiates the default template", async () => {
@@ -60,10 +61,12 @@ describe("create", () => {
 });
 
 class TestCreateEffects implements CreateEffects {
+  isTty = true;
+  outputColumns = 80;
+  logger = new MockLogger();
   outputs = new Map<string, string>();
   clack = new TestClackEffects();
   async sleep(): Promise<void> {}
-  log(): void {}
   async mkdir(): Promise<void> {} // TODO test?
   async copyFile(sourcePath: string, outputPath: string): Promise<void> {
     this.outputs.set(fromOsPath(outputPath), await readFile(sourcePath, "utf-8"));


### PR DESCRIPTION
Fixes #1189. Looks like this:

```
◇  Initialize git repository?
│  Yes
│
◇  Installed! 🎉
│
▲  Failed to initialize Framework cache. This may be a transient error loading data
│  from external servers or downloading imported modules from jsDelivr; or it might
│  be a network configuration issue such as a firewall blocking traffic. You can
│  ignore this error for now and Framework will automatically try to download again
│  on preview or build. If you continue to experience network issues, please check
│  your network configuration.
│
│  Want help? https://github.com/observablehq/framework/issues
│
│
◇  Next steps… ────────╮
│                      │
│  cd hello-framework  │
│  yarn dev            │
│                      │
├──────────────────────╯
│
└  Problems? https://observablehq.com/framework/getting-started

✨  Done in 8.04s.
```