### PR TITLE
Import with auto pageLoad event

### DIFF
--- a/examples/api/observablehq.config.ts
+++ b/examples/api/observablehq.config.ts
@@ -4,7 +4,7 @@ export default {
   toc: false,
   head:
     process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>

--- a/examples/chess/observablehq.config.ts
+++ b/examples/chess/observablehq.config.ts
@@ -4,7 +4,7 @@ export default {
   toc: false,
   head:
     process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>

--- a/examples/eia/observablehq.config.ts
+++ b/examples/eia/observablehq.config.ts
@@ -5,7 +5,7 @@ export default {
   toc: false,
   head:
     process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>

--- a/examples/google-analytics/observablehq.config.ts
+++ b/examples/google-analytics/observablehq.config.ts
@@ -5,7 +5,7 @@ export default {
   toc: false,
   head:
     process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>

--- a/examples/hello-world/observablehq.config.ts
+++ b/examples/hello-world/observablehq.config.ts
@@ -4,7 +4,7 @@ export default {
   pager: false,
   head:
     process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>

--- a/examples/mortgage-rates/observablehq.config.ts
+++ b/examples/mortgage-rates/observablehq.config.ts
@@ -5,7 +5,7 @@ export default {
   sidebar: false,
   head:
     process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>

--- a/examples/penguin-classification/observablehq.config.ts
+++ b/examples/penguin-classification/observablehq.config.ts
@@ -4,7 +4,7 @@ export default {
   toc: false,
   head:
     process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>

--- a/examples/plot/observablehq.config.ts
+++ b/examples/plot/observablehq.config.ts
@@ -5,7 +5,7 @@ export default {
   toc: false,
   head:
     process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js"></script>
+    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>

--- a/observablehq.config.ts
+++ b/observablehq.config.ts
@@ -100,7 +100,7 @@ export default {
 <link rel="icon" type="image/png" href="/favicon.png" sizes="512x512">${
     process.env.CI
       ? `
-<script type="module" async src="https://events.observablehq.com/client.js"></script>
+<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`
       : ""


### PR DESCRIPTION
The analytics client script used to always send an automatic pageLoad event for us unless it detected other usage within a certain time period. Instead of the finicky (and race condition prone) time-based method, the latest script uses a request parameter to indicate if it should automatically emit a pageLoad event.