### PR TITLE
Check most-recent source modification time when deciding to do a build.

### DIFF
--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -108,8 +108,9 @@ try {
     case "deploy": {
       const missingDescription = "one of 'build', 'cancel', or 'prompt' (the default)";
       const staleDescription = "one of 'build', 'cancel', 'deploy', or 'prompt' (the default)";
+      const olderDescription = "one of 'build', 'cancel', 'deploy', or 'prompt' (the default)";
       const {
-        values: {config, root, message, "if-stale": ifStale, "if-missing": ifMissing}
+        values: {config, root, message, "if-stale": ifStale, "if-missing": ifMissing, "if-older": ifOlder}
       } = helpArgs(command, {
         options: {
           ...CONFIG_OPTION,
@@ -124,6 +125,10 @@ try {
           "if-missing": {
             type: "string",
             description: `What to do if the output directory is missing: ${missingDescription}`
+          },
+          "if-older": {
+            type: "string",
+            description: `What to do if the output files are older than source files: ${olderDescription}`
           }
         }
       });
@@ -135,6 +140,10 @@ try {
         console.log(`Invalid --if-missing option: ${ifMissing}, expected ${missingDescription}`);
         process.exit(1);
       }
+      if (ifOlder && ifOlder !== "prompt" && ifOlder !== "build" && ifOlder !== "cancel" && ifOlder !== "deploy") {
+        console.log(`Invalid --if-older option: ${ifOlder}, expected ${olderDescription}`);
+        process.exit(1);
+      }
       if (!process.stdin.isTTY && (ifStale === "prompt" || ifMissing === "prompt")) {
         throw new CliError("Cannot prompt for input in non-interactive mode");
       }
@@ -144,7 +153,8 @@ try {
           config: await readConfig(config, root),
           message,
           ifBuildMissing: (ifMissing ?? "prompt") as "prompt" | "build" | "cancel",
-          ifBuildStale: (ifStale ?? "prompt") as "prompt" | "build" | "cancel" | "deploy"
+          ifBuildStale: (ifStale ?? "prompt") as "prompt" | "build" | "cancel" | "deploy",
+          ifBuildOlder: (ifOlder ?? "prompt") as "prompt" | "build" | "cancel" | "deploy"
         })
       );
       break;

--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -106,24 +106,14 @@ try {
       break;
     }
     case "deploy": {
-      const missingDescription = "one of 'build', 'cancel', or 'prompt' (the default)";
-      const staleDescription = "one of 'build', 'cancel', 'deploy', or 'prompt' (the default)";
       const {
-        values: {config, root, message, "if-stale": ifStale, "if-missing": ifMissing, build, "no-build": noBuild}
+        values: {config, root, message, build, "no-build": noBuild}
       } = helpArgs(command, {
         options: {
           ...CONFIG_OPTION,
           message: {
             type: "string",
             short: "m"
-          },
-          "if-stale": {
-            type: "string",
-            description: `What to do if the output directory is stale: ${staleDescription}`
-          },
-          "if-missing": {
-            type: "string",
-            description: `What to do if the output directory is missing: ${missingDescription}`
           },
           build: {
             type: "boolean",
@@ -135,23 +125,10 @@ try {
           }
         }
       });
-      if (ifStale && ifStale !== "prompt" && ifStale !== "build" && ifStale !== "cancel" && ifStale !== "deploy") {
-        console.log(`Invalid --if-stale option: ${ifStale}, expected ${staleDescription}`);
-        process.exit(1);
-      }
-      if (ifMissing && ifMissing !== "prompt" && ifMissing !== "build" && ifMissing !== "cancel") {
-        console.log(`Invalid --if-missing option: ${ifMissing}, expected ${missingDescription}`);
-        process.exit(1);
-      }
-      if (!process.stdin.isTTY && (ifStale === "prompt" || ifMissing === "prompt")) {
-        throw new CliError("Cannot prompt for input in non-interactive mode");
-      }
       await import("../deploy.js").then(async (deploy) =>
         deploy.deploy({
           config: await readConfig(config, root),
           message,
-          ifBuildMissing: (ifMissing ?? "prompt") as "prompt" | "build" | "cancel",
-          ifBuildStale: (ifStale ?? "prompt") as "prompt" | "build" | "cancel" | "deploy",
           force: build ? "build" : noBuild ? "deploy" : null
         })
       );

--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -127,11 +127,11 @@ try {
           },
           build: {
             type: "boolean",
-            description: "Always re-build project before deploying"
+            description: "Always build before deploying"
           },
           "no-build": {
             type: "boolean",
-            description: "Don't re-build project if needed; deploy as-is"
+            description: "Don’t build before deploying; deploy as is"
           }
         }
       });
@@ -146,7 +146,6 @@ try {
       if (!process.stdin.isTTY && (ifStale === "prompt" || ifMissing === "prompt")) {
         throw new CliError("Cannot prompt for input in non-interactive mode");
       }
-
       await import("../deploy.js").then(async (deploy) =>
         deploy.deploy({
           config: await readConfig(config, root),

--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -107,7 +107,7 @@ try {
     }
     case "deploy": {
       const missingDescription = "one of 'build', 'cancel', or 'prompt' (the default)";
-      const staleDescription = "one of 'build', 'cancel', 'deploy', or 'prompt' (the default)";      
+      const staleDescription = "one of 'build', 'cancel', 'deploy', or 'prompt' (the default)";
       const {
         values: {config, root, message, "if-stale": ifStale, "if-missing": ifMissing, build, "no-build": noBuild}
       } = helpArgs(command, {
@@ -124,7 +124,7 @@ try {
           "if-missing": {
             type: "string",
             description: `What to do if the output directory is missing: ${missingDescription}`
-          },                    
+          },
           build: {
             type: "boolean",
             description: "Always re-build project before deploying"
@@ -152,7 +152,7 @@ try {
           config: await readConfig(config, root),
           message,
           ifBuildMissing: (ifMissing ?? "prompt") as "prompt" | "build" | "cancel",
-          ifBuildStale: (ifStale ?? "prompt") as "prompt" | "build" | "cancel" | "deploy",          
+          ifBuildStale: (ifStale ?? "prompt") as "prompt" | "build" | "cancel" | "deploy",
           force: build ? "build" : noBuild ? "deploy" : null
         })
       );

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -39,7 +39,7 @@ export interface DeployOptions {
   deployPollInterval?: number;
   force: "build" | "deploy" | null;
   ifBuildStale: "prompt" | "build" | "cancel" | "deploy";
-  ifBuildMissing: "prompt" | "build" | "cancel";  
+  ifBuildMissing: "prompt" | "build" | "cancel";
   maxConcurrency?: number;
 }
 
@@ -84,12 +84,12 @@ type DeployTargetInfo =
 /** Deploy a project to ObservableHQ */
 export async function deploy(
   {
-    config, 
-    force,     
+    config,
+    force,
     ifBuildMissing,
     ifBuildStale,
-    message, 
-    deployPollInterval = DEPLOY_POLL_INTERVAL_MS, 
+    message,
+    deployPollInterval = DEPLOY_POLL_INTERVAL_MS,
     maxConcurrency
   }: DeployOptions,
   effects = defaultEffects
@@ -244,7 +244,8 @@ export async function deploy(
     if (mostRecentSourceMtimeMs > leastRecentBuildMtimeMs) {
       if (force === "deploy") {
         // do nothing
-      } if (ifBuildStale === "cancel") {
+      }
+      if (ifBuildStale === "cancel") {
         throw new CliError("Build is stale.");
       } else if (ifBuildStale === "build") {
         doBuild = true;
@@ -260,7 +261,7 @@ export async function deploy(
           inactive: "No, deploy as is"
         });
         if (clack.isCancel(choice)) throw new CliError("User canceled deploy", {print: false, exitCode: 0});
-        doBuild = !!choice;  
+        doBuild = !!choice;
       }
     }
   }
@@ -292,7 +293,7 @@ export async function deploy(
           initialValue: ageMinutes <= 5
         });
         if (clack.isCancel(choice)) throw new CliError("User canceled deploy", {print: false, exitCode: 0});
-        doBuild = !!choice;  
+        doBuild = !!choice;
       }
     }
   }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -50,7 +50,7 @@ export interface DeployEffects extends ConfigEffects, TtyEffects, AuthEffects {
   logger: Logger;
   input: NodeJS.ReadableStream;
   output: NodeJS.WritableStream;
-  visitFiles: (root: string, { ignoreObservable }?: {ignoreObservable?: boolean | undefined}) => Generator<string>;
+  visitFiles: (root: string, {ignoreObservable}?: {ignoreObservable?: boolean | undefined}) => Generator<string>;
   stat: (path: string) => Promise<Stats>;
   build: ({config, addPublic}: BuildOptions, effects?: BuildEffects) => Promise<void>;
 }
@@ -250,9 +250,11 @@ export async function deploy(
           break;
         }
         case "prompt": {
-          if (!effects.isTty) throw new CliError("Build is older than source files. Pass --if-older=build to automatically rebuild.");
+          if (!effects.isTty)
+            throw new CliError("Build is older than source files. Pass --if-older=build to automatically rebuild.");
           const choice = await clack.confirm({
-            message: "Your source files have changed since the last time you built. Would you like to re-build before deploy?",
+            message:
+              "Your source files have changed since the last time you built. Would you like to re-build before deploy?",
             active: "Yes, re-build",
             inactive: "No, deploy as is"
           });

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -219,7 +219,7 @@ export async function deploy(
         if (!effects.isTty) throw new CliError("No build files found. Pass --build to automatically build.");
         const choice = await clack.confirm({
           message: "No build files found. Do you want to build the project now?",
-          active: "Yes, build now and then deploy",
+          active: "Yes, build and then deploy",
           inactive: "No, cancel deploy"
         });
         if (clack.isCancel(choice) || !choice) {
@@ -262,7 +262,7 @@ export async function deploy(
         message += "Would you like to build before deploying?";
         const choice = await clack.confirm({
           message,
-          active: "Yes, build",
+          active: "Yes, build and then deploy",
           inactive: "No, deploy as is"
         });
         if (clack.isCancel(choice)) throw new CliError("User canceled deploy", {print: false, exitCode: 0});

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -85,17 +85,17 @@ type DeployTargetInfo =
 export async function deploy(
   {
     config,
+    message,
     force,
     ifBuildMissing,
     ifBuildStale,
-    message,
     deployPollInterval = DEPLOY_POLL_INTERVAL_MS,
     maxConcurrency
   }: DeployOptions,
   effects = defaultEffects
 ): Promise<void> {
   const {clack} = effects;
-  Telemetry.record({event: "deploy", step: "start", force});
+  Telemetry.record({event: "deploy", step: "start", ifBuildMissing, ifBuildStale, force});
   clack.intro(inverse(" observable deploy "));
 
   let apiKey = await effects.getObservableApiKey(effects);

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -234,7 +234,7 @@ export async function deploy(
 
   if (!doBuild) {
     const mostRecentSourceMtimeMs = await findMostRecentSourceMtimeMs(effects, config);
-    const buildAge = new Date().getTime() - leastRecentBuildMtimeMs;
+    const buildAge = Date.now() - leastRecentBuildMtimeMs;
     if (mostRecentSourceMtimeMs > leastRecentBuildMtimeMs || buildAge > BUILD_AGE_WARNING_MS) {
       if (force === "deploy") {
         // do nothing

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -461,8 +461,8 @@ async function findOldestSourceAge(effects: DeployEffects, config: Config): Prom
       try {
         stat = await effects.stat(joinedPath);
         if (stat?.isFile()) {
-          if (nowMs - stat.ctimeMs > oldestAge) {
-            oldestAge = nowMs - stat.ctimeMs;
+          if (nowMs - stat.mtimeMs > oldestAge) {
+            oldestAge = nowMs - stat.mtimeMs;
           }
         }
       } catch (error) {
@@ -494,9 +494,9 @@ async function findBuildFiles(
       }
       if (stat?.isFile()) {
         buildFilePaths.push(file);
-        // youngestAge = Math.min(youngestAge, nowMs - stat.ctimeMs);
-        if (nowMs - stat.ctimeMs < youngestAge) {
-          youngestAge = nowMs - stat.ctimeMs;
+        // youngestAge = Math.min(youngestAge, nowMs - stat.mtimeMs);
+        if (nowMs - stat.mtimeMs < youngestAge) {
+          youngestAge = nowMs - stat.mtimeMs;
         }
       }
     }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -450,10 +450,7 @@ export async function deploy(
   Telemetry.record({event: "deploy", step: "finish"});
 }
 
-async function findYoungestSourceAge(
-  effects: DeployEffects,
-  config: Config
-): Promise<number> {
+async function findYoungestSourceAge(effects: DeployEffects, config: Config): Promise<number> {
   let youngestAge = Infinity;
   const nowMs = Date.now();
 

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -233,8 +233,8 @@ export async function deploy(
       throw error;
     }
   }
-  const youngestSourceAge = await findYoungestSourceAge(effects, config);
-  if (youngestSourceAge < youngestBuildAge) {
+  const oldestSourceAge = await findOldestSourceAge(effects, config);
+  if (oldestSourceAge < youngestBuildAge) {
     // We have newer source files, so rebuild.
     doBuild = true;
   }
@@ -450,8 +450,8 @@ export async function deploy(
   Telemetry.record({event: "deploy", step: "finish"});
 }
 
-async function findYoungestSourceAge(effects: DeployEffects, config: Config): Promise<number> {
-  let youngestAge = Infinity;
+async function findOldestSourceAge(effects: DeployEffects, config: Config): Promise<number> {
+  let oldestAge = -Infinity;
   const nowMs = Date.now();
 
   try {
@@ -461,8 +461,8 @@ async function findYoungestSourceAge(effects: DeployEffects, config: Config): Pr
       try {
         stat = await effects.stat(joinedPath);
         if (stat?.isFile()) {
-          if (nowMs - stat.ctimeMs < youngestAge) {
-            youngestAge = nowMs - stat.ctimeMs;
+          if (nowMs - stat.ctimeMs > oldestAge) {
+            oldestAge = nowMs - stat.ctimeMs;
           }
         }
       } catch (error) {
@@ -472,7 +472,7 @@ async function findYoungestSourceAge(effects: DeployEffects, config: Config): Pr
   } catch (error) {
     // ignore
   }
-  return youngestAge;
+  return oldestAge;
 }
 
 async function findBuildFiles(

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -259,10 +259,10 @@ export async function deploy(
               : `at ${new Date(Date.now() - buildAge).toLocaleString()}`;
           message += `You last built this project ${ageFormatted}. `;
         }
-        message += "Would you like to re-build before deploy?";
+        message += "Would you like to build before deploying?";
         const choice = await clack.confirm({
           message,
-          active: "Yes, re-build",
+          active: "Yes, build",
           inactive: "No, deploy as is"
         });
         if (clack.isCancel(choice)) throw new CliError("User canceled deploy", {print: false, exitCode: 0});

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -244,8 +244,7 @@ export async function deploy(
     if (mostRecentSourceMtimeMs > leastRecentBuildMtimeMs) {
       if (force === "deploy") {
         // do nothing
-      }
-      if (ifBuildStale === "cancel") {
+      } else if (ifBuildStale === "cancel") {
         throw new CliError("Build is stale.");
       } else if (ifBuildStale === "build") {
         doBuild = true;

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -462,8 +462,17 @@ async function findMostRecentSourceMtimeMs(effects: DeployEffects, config: Confi
     }
   }
   const cachePath = join(config.root, ".observablehq/cache");
-  const cacheStat = await effects.stat(cachePath);
-  return Math.max(mostRecentMtimeMs, cacheStat.mtimeMs);
+  try {
+    const cacheStat = await effects.stat(cachePath);
+    if (cacheStat.mtimeMs > mostRecentMtimeMs) {
+      mostRecentMtimeMs = cacheStat.mtimeMs;
+    }
+  } catch (error) {
+    if (!isEnoent(error)) {
+      throw error;
+    }
+  }
+  return mostRecentMtimeMs;
 }
 
 async function findBuildFiles(

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -51,7 +51,7 @@ export interface DeployEffects extends ConfigEffects, TtyEffects, AuthEffects {
   output: NodeJS.WritableStream;
   visitFiles: (root: string, {ignoreObservable}?: {ignoreObservable?: boolean}) => Generator<string>;
   stat: (path: string) => Promise<Stats>;
-  build: ({ config, addPublic }: BuildOptions, effects?: BuildEffects) => Promise<void>;
+  build: ({config, addPublic}: BuildOptions, effects?: BuildEffects) => Promise<void>;
 }
 
 const defaultEffects: DeployEffects = {
@@ -277,7 +277,10 @@ export async function deploy(
 
   if (doBuild) {
     clack.log.step("Building project");
-    await effects.build({config}, new FileBuildEffects(config.output, {logger: effects.logger, output: effects.output}));
+    await effects.build(
+      {config},
+      new FileBuildEffects(config.output, {logger: effects.logger, output: effects.output})
+    );
     ({buildFilePaths} = await findBuildFiles(effects, config));
   }
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -49,7 +49,7 @@ export function* visitMarkdownFiles(root: string): Generator<string> {
 }
 
 /** Yields every file within the given root, recursively, ignoring .observablehq. */
-export function* visitFiles(root: string, {ignoreObservable = true} = {}): Generator<string> {
+export function* visitFiles(root: string): Generator<string> {
   const visited = new Set<number>();
   const queue: string[] = [(root = normalize(root))];
   for (const path of queue) {
@@ -58,7 +58,7 @@ export function* visitFiles(root: string, {ignoreObservable = true} = {}): Gener
       if (visited.has(status.ino)) continue; // circular symlink
       visited.add(status.ino);
       for (const entry of readdirSync(path)) {
-        if (ignoreObservable && entry === ".observablehq") continue;
+        if (entry === ".observablehq") continue; // ignore the .observablehq directory
         queue.push(join(path, entry));
       }
     } else {

--- a/src/files.ts
+++ b/src/files.ts
@@ -49,7 +49,7 @@ export function* visitMarkdownFiles(root: string): Generator<string> {
 }
 
 /** Yields every file within the given root, recursively, ignoring .observablehq. */
-export function* visitFiles(root: string): Generator<string> {
+export function* visitFiles(root: string, {ignoreObservable = true} = {}): Generator<string> {
   const visited = new Set<number>();
   const queue: string[] = [(root = normalize(root))];
   for (const path of queue) {
@@ -58,7 +58,7 @@ export function* visitFiles(root: string): Generator<string> {
       if (visited.has(status.ino)) continue; // circular symlink
       visited.add(status.ino);
       for (const entry of readdirSync(path)) {
-        if (entry === ".observablehq") continue; // ignore the .observablehq directory
+        if (ignoreObservable && entry === ".observablehq") continue;
         queue.push(join(path, entry));
       }
     } else {

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -130,7 +130,7 @@ class MockDeployEffects extends MockAuthEffects implements DeployEffects {
 
   async build(): Promise<void> {
     // Don't actually build.
-  };
+  }
 
   addIoResponse(prompt: RegExp, response: string) {
     this.ioResponses.push({prompt, response});

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -766,7 +766,7 @@ describe("deploy", () => {
   it("prompts if the build is stale", async () => {
     const deployOptions = {
       ...TEST_OPTIONS,
-      force: null,
+      force: null
     } satisfies DeployOptions;
     getCurrentObservableApi().handleGetCurrentUser().handleGetProject(DEPLOY_CONFIG).start();
     const effects = new MockDeployEffects({
@@ -847,7 +847,7 @@ describe("deploy", () => {
     const effects = new MockDeployEffects({
       deployConfig: DEPLOY_CONFIG,
       apiKey: null,
-      fixedInputStatTime: new Date("2024-03-11"),  // newer source files
+      fixedInputStatTime: new Date("2024-03-11"), // newer source files
       fixedOutputStatTime: new Date("2024-03-10")
     });
     effects.clack.inputs = [

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -2,6 +2,8 @@ import assert, {fail} from "node:assert";
 import type {Stats} from "node:fs";
 import {stat} from "node:fs/promises";
 import {Readable, Writable} from "node:stream";
+import type {BuildEffects, BuildOptions} from "../src/build.js";
+import {FileBuildEffects} from "../src/build.js";
 import {normalizeConfig, setCurrentDate} from "../src/config.js";
 import type {DeployEffects, DeployOptions} from "../src/deploy.js";
 import {deploy, promptDeployTarget} from "../src/deploy.js";
@@ -128,6 +130,10 @@ class MockDeployEffects extends MockAuthEffects implements DeployEffects {
     return s;
   }
 
+  async build(): Promise<void> {
+    // Don't actually build.
+  };
+
   addIoResponse(prompt: RegExp, response: string) {
     this.ioResponses.push({prompt, response});
     return this;
@@ -150,7 +156,7 @@ const TEST_SOURCE_ROOT = "test/input/build/simple-public";
 const TEST_CONFIG = normalizeConfig({
   root: TEST_SOURCE_ROOT,
   output: "test/output/build/simple-public",
-  title: "Mock BI"
+  title: "Build test case"
 });
 const TEST_OPTIONS: DeployOptions = {
   config: TEST_CONFIG,
@@ -860,7 +866,7 @@ describe("promptDeployTarget", () => {
       accessLevel,
       create: true,
       projectSlug,
-      title: "Mock BI",
+      title: "Build test case",
       workspace
     });
   });

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -845,7 +845,8 @@ describe("deploy", () => {
 
     const deployOptions = {
       ...TEST_OPTIONS,
-      force: "deploy"
+      force: "deploy", // will trump ifBuildStale
+      ifBuildStale: "prompt"
     } satisfies DeployOptions;
 
     const effects = new MockDeployEffects({

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -108,10 +108,9 @@ class MockDeployEffects extends MockAuthEffects implements DeployEffects {
     this.deployConfig = config;
   }
 
-  *visitFiles(path: string, {ignoreObservable = true} = {}) {
-    yield* visitFiles(path, {ignoreObservable});
+  *visitFiles(path: string, options?: {ignoreObservable?: boolean}) {
+    yield* visitFiles(path, options);
   }
-
   async stat(path: string) {
     function overrideTime(s: Stats, date: Date) {
       for (const key of ["a", "c", "m", "birth"] as const) {

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -159,8 +159,6 @@ const TEST_OPTIONS: DeployOptions = {
   config: TEST_CONFIG,
   message: undefined,
   deployPollInterval: 0,
-  ifBuildMissing: "cancel",
-  ifBuildStale: "deploy",
   force: "deploy" // default to not re-building and just deploying output as-is
 };
 const DEPLOY_CONFIG: DeployConfig & {projectId: string; projectSlug: string; workspaceLogin: string} = {
@@ -753,7 +751,6 @@ describe("deploy", () => {
     const deployOptions = {
       ...TEST_OPTIONS,
       force: null,
-      ifBuildMissing: "prompt",
       config: {...TEST_OPTIONS.config, output: "test/output/does-not-exist"}
     } satisfies DeployOptions;
     getCurrentObservableApi().handleGetCurrentUser().handleGetProject(DEPLOY_CONFIG).start();
@@ -769,8 +766,7 @@ describe("deploy", () => {
   it("prompts if the build is stale", async () => {
     const deployOptions = {
       ...TEST_OPTIONS,
-      force: null,
-      ifBuildStale: "prompt"
+      force: null
     } satisfies DeployOptions;
     getCurrentObservableApi().handleGetCurrentUser().handleGetProject(DEPLOY_CONFIG).start();
     const effects = new MockDeployEffects({
@@ -778,7 +774,7 @@ describe("deploy", () => {
       fixedInputStatTime: new Date("2024-03-09"),
       fixedOutputStatTime: new Date("2024-03-10")
     });
-    await assert.rejects(() => deploy(deployOptions, effects), /out of inputs for select: You last built this project/);
+    await assert.rejects(() => deploy(deployOptions, effects), /out of inputs for select: You built this project/);
     effects.close();
   });
 
@@ -845,8 +841,7 @@ describe("deploy", () => {
 
     const deployOptions = {
       ...TEST_OPTIONS,
-      force: "deploy", // will trump ifBuildStale
-      ifBuildStale: "prompt"
+      force: "deploy"
     } satisfies DeployOptions;
 
     const effects = new MockDeployEffects({

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -2,8 +2,6 @@ import assert, {fail} from "node:assert";
 import type {Stats} from "node:fs";
 import {stat} from "node:fs/promises";
 import {Readable, Writable} from "node:stream";
-import type {BuildEffects, BuildOptions} from "../src/build.js";
-import {FileBuildEffects} from "../src/build.js";
 import {normalizeConfig, setCurrentDate} from "../src/config.js";
 import type {DeployEffects, DeployOptions} from "../src/deploy.js";
 import {deploy, promptDeployTarget} from "../src/deploy.js";

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -776,10 +776,7 @@ describe("deploy", () => {
       fixedInputStatTime: new Date("2024-03-09"),
       fixedOutputStatTime: new Date("2024-03-10")
     });
-    await assert.rejects(
-      () => deploy(deployOptions, effects),
-      /out of inputs for select: You last built this project/
-    );
+    await assert.rejects(() => deploy(deployOptions, effects), /out of inputs for select: You last built this project/);
     effects.close();
   });
 

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -161,7 +161,7 @@ const TEST_OPTIONS: DeployOptions = {
   deployPollInterval: 0,
   ifBuildMissing: "cancel",
   ifBuildStale: "deploy",
-  force: "deploy", // default to not re-building and just deploying output as-is
+  force: "deploy" // default to not re-building and just deploying output as-is
 };
 const DEPLOY_CONFIG: DeployConfig & {projectId: string; projectSlug: string; workspaceLogin: string} = {
   projectId: "project123",

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -812,15 +812,7 @@ describe("deploy", () => {
       "fix some bugs" // deploy message
     ];
 
-    // getCurrentObservableApi().handleGetCurrentUser().handleGetProject(DEPLOY_CONFIG).start();
-    // const effects = new MockDeployEffects({
-    //   deployConfig: DEPLOY_CONFIG,
-    //   fixedInputStatTime: new Date("2024-03-11"),
-    //   fixedOutputStatTime: new Date("2024-03-10")
-    // });
-
     await deploy(deployOptions, effects);
-    // await deploy(TEST_OPTIONS, effects);
 
     effects.close();
   });

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -118,7 +118,7 @@ class MockDeployEffects extends MockAuthEffects implements DeployEffects {
         s[`${key}time`] = date;
         s[`${key}timeMs`] = date.getTime();
       }
-    };
+    }
     const s = await stat(path);
     if (path.startsWith("test/input/") && this.fixedInputStatTime) {
       overrideTime(s, this.fixedInputStatTime);
@@ -185,7 +185,11 @@ describe("deploy", () => {
       .handleGetDeploy({deployId, deployStatus: "uploaded"})
       .start();
 
-    const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG, fixedInputStatTime: new Date("2024-03-09"), fixedOutputStatTime: new Date("2024-03-10")});
+    const effects = new MockDeployEffects({
+      deployConfig: DEPLOY_CONFIG,
+      fixedInputStatTime: new Date("2024-03-09"),
+      fixedOutputStatTime: new Date("2024-03-10")
+    });
     effects.clack.inputs = ["fix some bugs"]; // "what changed?"
     await deploy(TEST_OPTIONS, effects);
 
@@ -209,7 +213,11 @@ describe("deploy", () => {
       .handleGetDeploy({deployId})
       .start();
 
-    const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG, fixedInputStatTime: new Date("2024-03-09"), fixedOutputStatTime: new Date("2024-03-10")});
+    const effects = new MockDeployEffects({
+      deployConfig: DEPLOY_CONFIG,
+      fixedInputStatTime: new Date("2024-03-09"),
+      fixedOutputStatTime: new Date("2024-03-10")
+    });
     effects.clack.inputs.push("change project title"); // "what changed?"
     await deploy(TEST_OPTIONS, effects);
 
@@ -744,7 +752,11 @@ describe("deploy", () => {
       config: {...TEST_OPTIONS.config, output: "test/output/does-not-exist"}
     } satisfies DeployOptions;
     getCurrentObservableApi().handleGetCurrentUser().handleGetProject(DEPLOY_CONFIG).start();
-    const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG, fixedInputStatTime: new Date("2024-03-09"), fixedOutputStatTime: new Date("2024-03-10")});
+    const effects = new MockDeployEffects({
+      deployConfig: DEPLOY_CONFIG,
+      fixedInputStatTime: new Date("2024-03-09"),
+      fixedOutputStatTime: new Date("2024-03-10")
+    });
     await assert.rejects(() => deploy(deployOptions, effects), /out of inputs for select: No build files/);
     effects.close();
   });
@@ -755,7 +767,11 @@ describe("deploy", () => {
       ifBuildStale: "prompt"
     } satisfies DeployOptions;
     getCurrentObservableApi().handleGetCurrentUser().handleGetProject(DEPLOY_CONFIG).start();
-    const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG, fixedInputStatTime: new Date("2024-03-09"), fixedOutputStatTime: new Date("2024-03-10")});
+    const effects = new MockDeployEffects({
+      deployConfig: DEPLOY_CONFIG,
+      fixedInputStatTime: new Date("2024-03-09"),
+      fixedOutputStatTime: new Date("2024-03-10")
+    });
     await assert.rejects(
       () => deploy(deployOptions, effects),
       /out of inputs for select: Your project was last built at/

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -159,7 +159,9 @@ const TEST_OPTIONS: DeployOptions = {
   config: TEST_CONFIG,
   message: undefined,
   deployPollInterval: 0,
-  force: "deploy" // default to not re-building and just deploying output as-is
+  ifBuildMissing: "cancel",
+  ifBuildStale: "deploy",
+  force: "deploy", // default to not re-building and just deploying output as-is
 };
 const DEPLOY_CONFIG: DeployConfig & {projectId: string; projectSlug: string; workspaceLogin: string} = {
   projectId: "project123",
@@ -751,6 +753,7 @@ describe("deploy", () => {
     const deployOptions = {
       ...TEST_OPTIONS,
       force: null,
+      ifBuildMissing: "prompt",
       config: {...TEST_OPTIONS.config, output: "test/output/does-not-exist"}
     } satisfies DeployOptions;
     getCurrentObservableApi().handleGetCurrentUser().handleGetProject(DEPLOY_CONFIG).start();
@@ -766,7 +769,8 @@ describe("deploy", () => {
   it("prompts if the build is stale", async () => {
     const deployOptions = {
       ...TEST_OPTIONS,
-      force: null
+      force: null,
+      ifBuildStale: "prompt"
     } satisfies DeployOptions;
     getCurrentObservableApi().handleGetCurrentUser().handleGetProject(DEPLOY_CONFIG).start();
     const effects = new MockDeployEffects({

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -108,8 +108,8 @@ class MockDeployEffects extends MockAuthEffects implements DeployEffects {
     this.deployConfig = config;
   }
 
-  *visitFiles(path: string, options?: {ignoreObservable?: boolean}) {
-    yield* visitFiles(path, options);
+  *visitFiles(path: string) {
+    yield* visitFiles(path);
   }
   async stat(path: string) {
     function overrideTime(s: Stats, date: Date) {

--- a/test/mocks/observableApi.ts
+++ b/test/mocks/observableApi.ts
@@ -91,7 +91,7 @@ class ObservableApiMock {
     workspaceLogin,
     projectSlug,
     projectId = "project123",
-    title = "Mock BI",
+    title = "Build test case",
     accessLevel = "private",
     status = 200
   }: {


### PR DESCRIPTION
Fixes #1214

Also introduces --build and --no-build deploy flags. Uses Clack `confirm` where possible, and switches "youngest" / "age" variables to prefer least-recent and most-recent modification time millis.
