### PR TITLE
fix elliptic import

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@observablehq/inputs": "^0.10.6",
     "@observablehq/runtime": "^5.9.4",
     "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-virtual": "^3.0.2",
     "acorn": "^8.11.2",

--- a/src/node.ts
+++ b/src/node.ts
@@ -102,7 +102,7 @@ async function bundle(
       ...(isBadCommonJs(input) ? [(virtual as any)({"-": shimCommonJs(input, require)})] : []),
       importResolve(input, cacheRoot, packageRoot),
       nodeResolve({browser: true, rootDir: packageRoot}),
-      json(),
+      (json as any)(),
       (commonjs as any)({
         esmExternals: true,
         requireReturnsDefault: "preferred"

--- a/src/node.ts
+++ b/src/node.ts
@@ -138,7 +138,7 @@ function importResolve(input: string, cacheRoot: string, packageRoot: string): P
     return typeof specifier !== "string" || // AST node?
       isNodeBuiltin(specifier) || // node built-in, e.g., "node:fs" or "fs"
       isPathImport(specifier) || // relative path, e.g., ./foo.js
-      /^\0?[\w-]+:/.test(specifier) || // windows file path, https: URL, \x00node-resove:, etc.
+      /^\0?[\w-]+:/.test(specifier) || // windows file path, https: URL, \x00node-resolve:, etc.
       specifier === input // entry point
       ? null // don’t do any additional resolution
       : {id: await resolveNodeImportInternal(cacheRoot, packageRoot, specifier), external: true}; // resolve bare import

--- a/src/node.ts
+++ b/src/node.ts
@@ -5,6 +5,7 @@ import op from "node:path";
 import {extname, join} from "node:path/posix";
 import {pathToFileURL} from "node:url";
 import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
 import {nodeResolve} from "@rollup/plugin-node-resolve";
 import virtual from "@rollup/plugin-virtual";
 import {packageDirectory} from "pkg-dir";
@@ -101,7 +102,11 @@ async function bundle(
       ...(isBadCommonJs(input) ? [(virtual as any)({"-": shimCommonJs(input, require)})] : []),
       importResolve(input, cacheRoot, packageRoot),
       nodeResolve({browser: true, rootDir: packageRoot}),
-      (commonjs as any)({esmExternals: true}),
+      json(),
+      (commonjs as any)({
+        esmExternals: true,
+        requireReturnsDefault: "preferred"
+      }),
       esbuild({
         format: "esm",
         platform: "browser",
@@ -133,7 +138,7 @@ function importResolve(input: string, cacheRoot: string, packageRoot: string): P
     return typeof specifier !== "string" || // AST node?
       isNodeBuiltin(specifier) || // node built-in, e.g., "node:fs" or "fs"
       isPathImport(specifier) || // relative path, e.g., ./foo.js
-      /^\w+:/.test(specifier) || // windows file path, https: URL, etc.
+      /^\0?[\w-]+:/.test(specifier) || // windows file path, https: URL, \x00node-resove:, etc.
       specifier === input // entry point
       ? null // don’t do any additional resolution
       : {id: await resolveNodeImportInternal(cacheRoot, packageRoot, specifier), external: true}; // resolve bare import

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,6 +422,13 @@
     is-reference "1.2.1"
     magic-string "^0.30.3"
 
+"@rollup/plugin-json@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-6.1.0.tgz#fbe784e29682e9bb6dee28ea75a1a83702e7b805"
+  integrity sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==
+  dependencies:
+    "@rollup/pluginutils" "^5.1.0"
+
 "@rollup/plugin-node-resolve@^15.2.3":
   version "15.2.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz#e5e0b059bd85ca57489492f295ce88c2d4b0daf9"
@@ -439,7 +446,7 @@
   resolved "https://registry.yarnpkg.com/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz#17e17eeecb4c9fa1c0a6e72c9e5f66382fddbb82"
   integrity sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==
 
-"@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.0.5":
+"@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.0.5", "@rollup/pluginutils@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.0.tgz#7e53eddc8c7f483a4ad0b94afb1f7f5fd3c771e0"
   integrity sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==


### PR DESCRIPTION
This fixes an import of the [elliptic](https://github.com/indutny/elliptic) package (and its dependencies). This comes from a [Slack request](https://observable-community.slack.com/archives/C03SEMPUF6F/p1713346102969629) which I debugged. I’ll comment on the changes below.

I tested manually with:

````md
# Elliptic

[Elliptic](https://github.com/indutny/elliptic) is an implementation of “fast elliptic curve cryptography in plain JavaScript.”

```js echo
import elliptic from "elliptic";
const {ec: EC} = elliptic;

// Create and initialize EC context
// (better do it once and reuse it)
const ec = new EC("secp256k1");

// Generate keys
const key = ec.genKeyPair();

// Sign the message's hash (input must be an array, or a hex-string)
const msgHash = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
const signature = key.sign(msgHash);

// Export DER encoded signature in Array
const derSign = signature.toDER();

display(derSign);
```
````

(Yes, I should probably write a test, but this isn’t especially high-value work and it’s all a hack anyway.)