### PR TITLE
fix remote imports docs

### DIFF
--- a/docs/imports.md
+++ b/docs/imports.md
@@ -137,7 +137,7 @@ The `npm:canvas-confetti` import above is approximately equivalent to importing 
 import confetti from "https://cdn.jsdelivr.net/npm/canvas-confetti/+esm";
 ```
 
-Unlike `npm:` and `node_modules` imports, remove imports are not be self-hosted; the module will be fetched from the remote server at runtime. Use remote imports with caution as they are less secure and may degrade performance.
+Unlike `npm:` and `node_modules` imports, remote imports will not be self-hosted; the module will be fetched from the remote server at runtime. Use remote imports with caution as they are less secure and may degrade performance.
 
 ## Dynamic imports
 

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -137,7 +137,7 @@ The `npm:canvas-confetti` import above is approximately equivalent to importing 
 import confetti from "https://cdn.jsdelivr.net/npm/canvas-confetti/+esm";
 ```
 
-Unlike `npm:` and `node_modules` imports, remote imports will not be self-hosted; the module will be fetched from the remote server at runtime. Use remote imports with caution as they are less secure and may degrade performance.
+Unlike `npm:` and `node_modules` imports, remote imports are not self-hosted; the module will be fetched from the remote server at runtime. Use remote imports with caution as they are less secure and may degrade performance.
 
 ## Dynamic imports
 


### PR DESCRIPTION
This fixes a minor typo/confusing sentence in the `Remote imports` section of of the imports documentation page. I've made an assumption on what was originally intended, but its a bit unclear as it seems two different thoughts got jumbled into one.

This changes:

`Unlike npm: and node_modules imports, remove imports are not be self-hosted;...`

to 

`Unlike npm: and node_modules imports, remote imports will not be self-hosted;`