### PR TITLE
unpin parquet-wasm

### DIFF
--- a/examples/api/docs/index.md
+++ b/examples/api/docs/index.md
@@ -1,6 +1,4 @@
 ```js
-import "npm:apache-arrow";
-import "npm:parquet-wasm/esm/arrow1.js";
 import {ApiHeatmap} from "./components/apiHeatmap.js";
 import {ApiHistogram} from "./components/apiHistogram.js";
 ```

--- a/src/client/stdlib/fileAttachment.js
+++ b/src/client/stdlib/fileAttachment.js
@@ -72,7 +72,7 @@ export class AbstractFile {
     return Arrow.tableFromIPC(response);
   }
   async parquet() {
-    const [Arrow, Parquet, buffer] = await Promise.all([import("npm:apache-arrow"), import("npm:parquet-wasm/esm/arrow1.js").then(async (Parquet) => (await Parquet.default(), Parquet)), this.arrayBuffer()]); // prettier-ignore
+    const [Arrow, Parquet, buffer] = await Promise.all([import("npm:apache-arrow"), import("npm:parquet-wasm").then(async (Parquet) => (await Parquet.default(import.meta.resolve("npm:parquet-wasm/esm/parquet_wasm_bg.wasm")), Parquet)), this.arrayBuffer()]); // prettier-ignore
     return Arrow.tableFromIPC(Parquet.readParquet(new Uint8Array(buffer)).intoIPCStream());
   }
   async sqlite() {

--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -3,7 +3,7 @@ export function getImplicitFileImports(methods: Iterable<string>): Set<string> {
   const implicits = new Set<string>();
   if (set.has("arrow")) implicits.add("npm:apache-arrow");
   if (set.has("csv") || set.has("tsv")) implicits.add("npm:d3-dsv");
-  if (set.has("parquet")) implicits.add("npm:apache-arrow").add("npm:parquet-wasm/esm/arrow1.js");
+  if (set.has("parquet")) implicits.add("npm:apache-arrow").add("npm:parquet-wasm");
   if (set.has("sqlite")) implicits.add("npm:@observablehq/sqlite");
   if (set.has("xlsx")) implicits.add("npm:@observablehq/xlsx");
   if (set.has("zip")) implicits.add("npm:@observablehq/zip");
@@ -140,11 +140,8 @@ export function getImplicitDownloads(imports: Iterable<string>): Set<string> {
     implicits.add("npm:katex/dist/fonts/KaTeX_Typewriter-Regular.woff");
     implicits.add("npm:katex/dist/fonts/KaTeX_Typewriter-Regular.woff2");
   }
-  if (set.has("npm:parquet-wasm/esm/arrow1.js")) {
-    implicits.add("npm:parquet-wasm/esm/arrow1_bg.wasm");
-  }
-  if (set.has("npm:parquet-wasm/esm/arrow2.js")) {
-    implicits.add("npm:parquet-wasm/esm/arrow2_bg.wasm");
+  if (set.has("npm:parquet-wasm")) {
+    implicits.add("npm:parquet-wasm/esm/parquet_wasm_bg.wasm");
   }
   return implicits;
 }

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -246,8 +246,6 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
     name,
     range = name === "@duckdb/duckdb-wasm"
       ? "1.28.0" // https://github.com/duckdb/duckdb-wasm/issues/1561
-      : name === "parquet-wasm"
-      ? "0.5.0" // https://github.com/observablehq/framework/issues/733
       : undefined,
     path = name === "mermaid"
       ? "dist/mermaid.esm.min.mjs/+esm"

--- a/test/libraries-test.ts
+++ b/test/libraries-test.ts
@@ -7,7 +7,7 @@ describe("getImplicitFileImports(files)", () => {
     assert.deepStrictEqual(getImplicitFileImports(["csv"]), new Set(["npm:d3-dsv"]));
     assert.deepStrictEqual(getImplicitFileImports(["tsv"]), new Set(["npm:d3-dsv"]));
     assert.deepStrictEqual(getImplicitFileImports(["arrow"]), new Set(["npm:apache-arrow"]));
-    assert.deepStrictEqual(getImplicitFileImports(["parquet"]), new Set(["npm:apache-arrow", "npm:parquet-wasm/esm/arrow1.js"])); // prettier-ignore
+    assert.deepStrictEqual(getImplicitFileImports(["parquet"]), new Set(["npm:apache-arrow", "npm:parquet-wasm"]));
     assert.deepStrictEqual(getImplicitFileImports(["sqlite"]), new Set(["npm:@observablehq/sqlite"]));
     assert.deepStrictEqual(getImplicitFileImports(["xlsx"]), new Set(["npm:@observablehq/xlsx"]));
     assert.deepStrictEqual(getImplicitFileImports(["zip"]), new Set(["npm:@observablehq/zip"]));

--- a/test/mocks/jsdelivr.ts
+++ b/test/mocks/jsdelivr.ts
@@ -20,7 +20,7 @@ const packages: [name: string, {version: string; dependencies?: Record<string, s
   ["lodash", {version: "4.17.21"}],
   ["mapbox-gl", {version: "3.1.2"}],
   ["mermaid", {version: "10.6.1"}],
-  ["parquet-wasm", {version: "0.6.0-beta.1"}],
+  ["parquet-wasm", {version: "0.6.0"}],
   ["sql.js", {version: "1.9.0"}],
   ["topojson-client", {version: "3.1.0"}]
 ];


### PR DESCRIPTION
The latest [0.6.0 release of parquet-wasm](https://github.com/kylebarron/parquet-wasm/releases/tag/v0.6.0) fixes the conditional exports so this mostly works out of the box. There’s a slight wrinkle that the default path to the `.wasm` file is incorrect when loaded via the `/+esm` entry point, but we can fix that by passing in the URL to the `.wasm` file explicitly.

Thanks @kylebarron for the fixes!