### PR TITLE
add github template

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -141,8 +141,8 @@ export async function create(effects: CreateEffects = defaultEffects): Promise<v
         );
         if (GITHUB_TOKEN) {
           s.message("Saving your parameters in the .env file");
-          const env = makeGitHubTemplateEnv(GITHUB_TOKEN, GITHUB_ORG_REPOS);
-          await writeFile(join(rootPath, ".env"), env);
+          const env = makeGitHubTemplateEnv(GITHUB_TOKEN as string, GITHUB_ORG_REPOS);
+          await effects.writeFile(join(rootPath, ".env"), env);
         }
         if (packageManager) {
           s.message(`Installing dependencies via ${packageManager}`);

--- a/templates/github/README.md
+++ b/templates/github/README.md
@@ -1,0 +1,47 @@
+# GitHub Stats
+
+This is an [Observable Framework](https://observablehq.com/framework) project. To start the local preview server, run:
+
+```
+yarn dev
+```
+
+Then visit <http://localhost:3000> to preview your project.
+
+For more, see <https://observablehq.com/framework/getting-started>.
+
+## Configuration
+
+_To run this project, please enter the following information_
+
+Your GitHub access token:
+
+<kbd>GITHUB_TOKEN="gh_xxxxx"</kbd>
+
+This personal access token identifies you as a user, and allows the data loaders to make many requests on your behalf on GitHub’s API.
+
+By default, we collect information on the repos you own or have contributed to. If some of the repos you want to analyze are private, make sure to grant access to them when you define your token.
+
+Instead of looking at your own repos, you might want to indicate an organization name:
+
+<kbd>GITHUB_ORG="observablehq"</kbd>
+
+in that case, the data loaders will retrieve information on repos from that organization.
+
+Alternatively, specify an explicit list of repos to visualize, separated by commas:
+
+<kbd>GITHUB_REPOS="observablehq/framework, mrdoob/three.js"</kbd>
+
+<div class="tip">
+
+TIP: This information is stored in the <code>.env</code> file at the root of the project. It is used by data loaders to request information from GitHub. It is _not_ shared anywhere else on the Internet. If you deploy the build as a public project, visitors will see the list of repos and the information extracted from GitHub, but they will not have access to your PAT.
+
+</div>
+
+## Limits
+
+By default, we set some limits, which you can override in the `.env` file:
+
+- `MAX_REPOS` - number of repos to scan for details; defaults to 10
+- `MAX_COMMITS` - number of commits per repo; defaults to 1,000
+- `MAX_ISSUES` - number of issues per repo; defaults to 1,000

--- a/templates/github/docs/clone.json.ts
+++ b/templates/github/docs/clone.json.ts
@@ -1,0 +1,105 @@
+import { GITHUB_TOKEN, MAX_COMMITS } from "./config.js";
+
+import type { Walker } from "isomorphic-git";
+import git from "isomorphic-git";
+import http from "isomorphic-git/http/node";
+import { fs } from "memfs";
+import { getRepos } from "./github-repos.js";
+
+const data: any[] = [];
+
+const { repos } = await getRepos();
+
+for (const { nameWithOwner: repo } of repos) {
+  console.warn("analyzing", repo);
+  try {
+    data.push(await analyzeRepo(repo));
+  } catch (error) {
+    console.warn(error);
+  }
+}
+
+console.log(JSON.stringify(data));
+
+// https://isomorphic-git.org/docs/en/clone
+async function analyzeRepo(repo: string): Promise<Object> {
+  console.warn("cloning", `github.com/${repo}`);
+  const dir = `/tmp/${repo}`;
+
+  await git.clone({
+    fs,
+    http,
+    dir,
+    depth: MAX_COMMITS, // shallow clone
+    noCheckout: true,
+    singleBranch: true,
+    noTags: true,
+    onProgress: () => void process.stderr.write("."),
+    url: `https://${GITHUB_TOKEN}@github.com/${repo}`,
+  });
+
+  console.warn("\nreading commits");
+  const commits: Object[] = [];
+
+  for (const { oid: id, commit, payload } of await git.log({
+    fs,
+    dir,
+    depth: MAX_COMMITS,
+    ref: "main",
+  })) {
+    let prev;
+    try {
+      const {
+        message,
+        author: { name: author },
+        parent: [parentid],
+      } = commit;
+      process.stderr.write("+");
+      const current = git.TREE({ ref: id });
+      const parent =
+        prev?.id === parentid ? prev.tree : git.TREE({ ref: parentid });
+      commits.push({
+        id,
+        date: getDateFromPayload(payload),
+        author,
+        message,
+        files: await getFileStateChanges(current, parent, dir),
+      });
+      prev = { id, tree: current };
+    } catch (error) {
+      break; // missing commit, we've reached the end of the shallow clone
+    }
+  }
+  console.warn("!\n");
+
+  return { repo, commits };
+}
+
+// git log --name-status
+async function getFileStateChanges(
+  current: Walker,
+  parent: Walker,
+  dir: string
+) {
+  const files: string[] = [];
+  await git.walk({
+    fs,
+    dir,
+    trees: [current, parent],
+    map: async function (walker, [a1, a2]) {
+      if ((await a1?.type()) === "blob") {
+        const [o1, o2] = await Promise.all([a1?.oid(), a2?.oid()]);
+        if (o1 === o2) return false;
+        files.push(walker);
+      }
+      return true;
+    },
+  });
+
+  return files;
+}
+
+function getDateFromPayload(payload: string): Date {
+  const a = payload.match(/^author .* (\d{10}) [+-]?\d{4}$/m);
+  return new Date(1000 * +(a?.[1] ?? NaN));
+}

--- a/templates/github/docs/collaborations.md
+++ b/templates/github/docs/collaborations.md
@@ -1,0 +1,134 @@
+# Collaborations
+
+The graph below represents the collaborations in the selected repositories.
+
+Nodes describe all the authors of the last ${Number(config.MAX_COMMITS).toLocaleString("en-US")} commits in any of the selected repos, and are sized by their total number of commits across the repos. Their color corresponds to the repo in which they did the largest number of commits.
+
+Edges represent collaborations. How do we detect them? Whenever two authors edit the same subset of files during a given time period (a sliding window of 10 commits), their connection accrues points. The edges of the graph are the top-scored connections.
+
+```js
+// normalization
+const maxValue = d3.max(links, (d) => d.value);
+const maxCommits = d3.max(nodes, (d) => d.commits);
+const nodeRadius = (d, i) =>
+  2.5 + 20 * Math.pow((1 + (nodes[i].commits ?? 0)) / (1 + maxCommits), 0.33);
+const nodeGroups = d3
+  .groupSort(
+    nodes,
+    (v) => -d3.sum(v, (d) => d.commits),
+    (d) => d.group
+  )
+  .slice(0, 9);
+
+const chart = ForceGraph(
+  { nodes, links },
+  {
+    nodeId: (d) => d.id,
+    nodeGroup: (d) => (nodeGroups.includes(d.group) ? d.group : "other"),
+    nodeTitle: (d) => `${d.id}\n${d.group}`,
+    linkStrokeWidth: (l) => 5 * Math.sqrt(l.value / maxValue),
+    width,
+    nodeRadius,
+    nodeStrength: -20,
+    //linkStrength: 0.2,
+    linkDistance: 2,
+    height: width,
+    nodeGroups,
+    initialize: (simulation) =>
+      simulation
+        .force("x", d3.forceX().strength(0.05))
+        .force("y", d3.forceY().strength(0.05))
+        .force(
+          "collide2",
+          d3
+            .forceCollide()
+            .radius((d, i) => 2 + nodeRadius(d, i))
+            .strength(0.4)
+        ),
+    invalidation, // a promise to stop the simulation when the cell is re-run
+  }
+);
+display(Object.assign(chart, { style: "overflow: visible;" }));
+```
+
+```js
+const color = view(
+  Inputs.radio(["org", "repo"], { value: "repo", label: "color by" })
+);
+```
+
+```js
+import { ForceGraph } from "/components/force-graph.js";
+```
+
+```js
+const clones = FileAttachment("clone.json").json();
+const config = FileAttachment("config.json").json();
+```
+
+```js
+function distance(a, b) {
+  return (
+    a.length &&
+    b.length &&
+    d3.intersection(a, b).size ** 2 / (a.length * b.length)
+  );
+}
+```
+
+```js
+const pairs = new Map();
+const authors = new Map();
+
+for (const { repo, commits } of clones) {
+  for (let i = 0; i < commits.length; ++i) {
+    const a = commits[i];
+    if (!authors.has(a.author))
+      authors.set(a.author, {
+        id: a.author,
+        commits: 0,
+        repos: [],
+        orgs: [],
+      });
+    const author = authors.get(a.author);
+    author.commits++;
+    author.repos.push(repo);
+    author.orgs.push(repo.split("/")[0]);
+
+    for (let j = i + 1; j < commits.length && j < i + 10; ++j) {
+      const b = commits[j];
+      if (a.author === b.author) continue;
+      const pair = [a.author, b.author].sort().join("\t");
+      if (!pairs.has(pair)) pairs.set(pair, 0);
+      pairs.set(pair, pairs.get(pair) + distance(a.files, b.files));
+    }
+  }
+}
+
+const nodes = [...authors].map(([, { commits, id, repos, orgs }]) => ({
+  id,
+  commits,
+  // org: d3.mode(orgs),
+  // repo: d3.mode(repos),
+  group: d3.mode(color === "repo" ? repos : orgs),
+}));
+const links = d3
+  .sort(pairs, ([, value]) => -value)
+  .slice(0, 1000)
+  .map(([pair, value]) => ({
+    source: pair.split("\t")[0],
+    target: pair.split("\t")[1],
+    value,
+  }));
+
+// regroup the stray nodes
+const solos = d3.difference(
+  nodes.map((d) => d.id),
+  links.map((d) => d.source),
+  links.map((d) => d.target)
+);
+for (let i = 0; i < 2; ++i) {
+  for (const [source, target] of d3.pairs(d3.shuffle([...solos])))
+    links.push({ source, target, value: 5 });
+}
+```

--- a/templates/github/docs/commits.json.ts
+++ b/templates/github/docs/commits.json.ts
@@ -1,0 +1,34 @@
+import { MAX_COMMITS } from "./config.js";
+import { githubList } from "./github.js";
+import { getRepos } from "./github-repos.js";
+
+const { repos } = await getRepos();
+
+const commits: {
+  repo: string;
+  title: string;
+  author_name: string;
+  created_at: string;
+}[] = [];
+
+for (const { nameWithOwner: repo } of repos) {
+  console.warn(`\n${repo}`);
+  console.warn("loading commits");
+
+  let i = 0;
+  for await (const commit of githubList(`/repos/${repo}/commits`)) {
+    process.stderr.write(".");
+    commits.unshift({
+      repo,
+      title: commit.commit.message,
+      author_name: commit.commit.author.name,
+      created_at: commit.commit.author.date,
+    });
+
+    if (++i > MAX_COMMITS) break;
+  }
+}
+
+process.stdout.write("\n");
+
+console.log(JSON.stringify({ repos, commits }));

--- a/templates/github/docs/components/DOM.js
+++ b/templates/github/docs/components/DOM.js
@@ -1,0 +1,27 @@
+// https://github.com/observablehq/stdlib/
+
+var count = 0;
+
+export function uid(name) {
+  return new Id("O-" + (name == null ? "" : name + "-") + ++count);
+}
+
+function Id(id) {
+  this.id = id;
+  this.href = new URL(`#${id}`, location) + "";
+}
+
+Id.prototype.toString = function () {
+  return "url(" + this.href + ")";
+};
+
+export function context2d(width, height, dpi) {
+  if (dpi == null) dpi = devicePixelRatio;
+  var canvas = document.createElement("canvas");
+  canvas.width = width * dpi;
+  canvas.height = height * dpi;
+  canvas.style.width = width + "px";
+  var context = canvas.getContext("2d");
+  context.scale(dpi, dpi);
+  return context;
+}

--- a/templates/github/docs/components/color-legend.js
+++ b/templates/github/docs/components/color-legend.js
@@ -1,0 +1,254 @@
+import * as d3 from "npm:d3";
+import {html} from "npm:htl";
+
+// Copyright 2021, Observable Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/color-legend
+export function Legend(
+  color,
+  {
+    title,
+    tickSize = 6,
+    width = 320,
+    height = 44 + tickSize,
+    marginTop = 18,
+    marginRight = 0,
+    marginBottom = 16 + tickSize,
+    marginLeft = 0,
+    ticks = width / 64,
+    tickFormat,
+    tickValues
+  } = {}
+) {
+  function ramp(color, n = 256) {
+    const canvas = document.createElement("canvas");
+    canvas.width = n;
+    canvas.height = 1;
+    const context = canvas.getContext("2d");
+    for (let i = 0; i < n; ++i) {
+      context.fillStyle = color(i / (n - 1));
+      context.fillRect(i, 0, 1, 1);
+    }
+    return canvas;
+  }
+
+  const svg = d3
+    .create("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .attr("viewBox", [0, 0, width, height])
+    .style("overflow", "visible")
+    .style("display", "block");
+
+  let tickAdjust = (g) => g.selectAll(".tick line").attr("y1", marginTop + marginBottom - height);
+  let x;
+
+  // Continuous
+  if (color.interpolate) {
+    const n = Math.min(color.domain().length, color.range().length);
+
+    x = color.copy().rangeRound(d3.quantize(d3.interpolate(marginLeft, width - marginRight), n));
+
+    svg
+      .append("image")
+      .attr("x", marginLeft)
+      .attr("y", marginTop)
+      .attr("width", width - marginLeft - marginRight)
+      .attr("height", height - marginTop - marginBottom)
+      .attr("preserveAspectRatio", "none")
+      .attr("xlink:href", ramp(color.copy().domain(d3.quantize(d3.interpolate(0, 1), n))).toDataURL());
+  }
+
+  // Sequential
+  else if (color.interpolator) {
+    x = Object.assign(color.copy().interpolator(d3.interpolateRound(marginLeft, width - marginRight)), {
+      range() {
+        return [marginLeft, width - marginRight];
+      }
+    });
+
+    svg
+      .append("image")
+      .attr("x", marginLeft)
+      .attr("y", marginTop)
+      .attr("width", width - marginLeft - marginRight)
+      .attr("height", height - marginTop - marginBottom)
+      .attr("preserveAspectRatio", "none")
+      .attr("xlink:href", ramp(color.interpolator()).toDataURL());
+
+    // scaleSequentialQuantile doesn’t implement ticks or tickFormat.
+    if (!x.ticks) {
+      if (tickValues === undefined) {
+        const n = Math.round(ticks + 1);
+        tickValues = d3.range(n).map((i) => d3.quantile(color.domain(), i / (n - 1)));
+      }
+      if (typeof tickFormat !== "function") {
+        tickFormat = d3.format(tickFormat === undefined ? ",f" : tickFormat);
+      }
+    }
+  }
+
+  // Threshold
+  else if (color.invertExtent) {
+    const thresholds = color.thresholds
+      ? color.thresholds() // scaleQuantize
+      : color.quantiles
+      ? color.quantiles() // scaleQuantile
+      : color.domain(); // scaleThreshold
+
+    const thresholdFormat =
+      tickFormat === undefined ? (d) => d : typeof tickFormat === "string" ? d3.format(tickFormat) : tickFormat;
+
+    x = d3
+      .scaleLinear()
+      .domain([-1, color.range().length - 1])
+      .rangeRound([marginLeft, width - marginRight]);
+
+    svg
+      .append("g")
+      .selectAll("rect")
+      .data(color.range())
+      .join("rect")
+      .attr("x", (d, i) => x(i - 1))
+      .attr("y", marginTop)
+      .attr("width", (d, i) => x(i) - x(i - 1))
+      .attr("height", height - marginTop - marginBottom)
+      .attr("fill", (d) => d);
+
+    tickValues = d3.range(thresholds.length);
+    tickFormat = (i) => thresholdFormat(thresholds[i], i);
+  }
+
+  // Ordinal
+  else {
+    x = d3
+      .scaleBand()
+      .domain(color.domain())
+      .rangeRound([marginLeft, width - marginRight]);
+
+    svg
+      .append("g")
+      .selectAll("rect")
+      .data(color.domain())
+      .join("rect")
+      .attr("x", x)
+      .attr("y", marginTop)
+      .attr("width", Math.max(0, x.bandwidth() - 1))
+      .attr("height", height - marginTop - marginBottom)
+      .attr("fill", color);
+
+    tickAdjust = () => {};
+  }
+
+  svg
+    .append("g")
+    .attr("transform", `translate(0,${height - marginBottom})`)
+    .call(
+      d3
+        .axisBottom(x)
+        .ticks(ticks, typeof tickFormat === "string" ? tickFormat : undefined)
+        .tickFormat(typeof tickFormat === "function" ? tickFormat : undefined)
+        .tickSize(tickSize)
+        .tickValues(tickValues)
+    )
+    .call(tickAdjust)
+    .call((g) => g.select(".domain").remove())
+    .call((g) =>
+      g
+        .append("text")
+        .attr("x", marginLeft)
+        .attr("y", marginTop + marginBottom - height - 6)
+        .attr("fill", "currentColor")
+        .attr("text-anchor", "start")
+        .attr("font-weight", "bold")
+        .attr("class", "title")
+        .text(title)
+    );
+
+  return svg.node();
+}
+
+// Copyright 2021, Observable Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/color-legend
+export function Swatches(
+  color,
+  {
+    columns = null,
+    format,
+    unknown: formatUnknown,
+    swatchSize = 15,
+    swatchWidth = swatchSize,
+    swatchHeight = swatchSize,
+    marginLeft = 0
+  } = {}
+) {
+  const id = `-swatches-${Math.random().toString(16).slice(2)}`;
+  const unknown = formatUnknown == null ? undefined : color.unknown();
+  const unknowns = unknown == null || unknown === d3.scaleImplicit ? [] : [unknown];
+  const domain = color.domain().concat(unknowns);
+  if (format === undefined) format = (x) => (x === unknown ? formatUnknown : x);
+
+  function entity(character) {
+    return `&#${character.charCodeAt(0).toString()};`;
+  }
+
+  if (columns !== null)
+    return html`<div
+      style="display: flex; align-items: center; margin-left: ${+marginLeft}px; min-height: 33px; font: 10px sans-serif;"
+    >
+      <style>
+        .${id}-item {
+          break-inside: avoid;
+          display: flex;
+          align-items: center;
+          padding-bottom: 1px;
+        }
+
+        .${id}-label {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          max-width: calc(100% - ${+swatchWidth}px - 0.5em);
+        }
+
+        .${id}-swatch {
+          width: ${+swatchWidth}px;
+          height: ${+swatchHeight}px;
+          margin: 0 0.5em 0 0;
+        }
+      </style>
+      <div style=${{width: "100%", columns}}>
+        ${domain.map((value) => {
+          const label = `${format(value)}`;
+          return html`<div class="${id}-item">
+            <div class="${id}-swatch" style=${{background: color(value)}}></div>
+            <div class="${id}-label" title=${label}>${label}</div>
+          </div>`;
+        })}
+      </div>
+    </div>`;
+
+  return html`<div
+    style="display: flex; align-items: center; min-height: 33px; margin-left: ${+marginLeft}px; font: 10px sans-serif;"
+  >
+    <style>
+      .${id} {
+        display: inline-flex;
+        align-items: center;
+        margin-right: 1em;
+      }
+
+      .${id}::before {
+        content: "";
+        width: ${+swatchWidth}px;
+        height: ${+swatchHeight}px;
+        margin-right: 0.5em;
+        background: var(--color);
+      }
+    </style>
+    <div>
+      ${domain.map((value) => html`<span class="${id}" style="--color: ${color(value)}">${format(value)}</span>`)}
+    </div>
+  </div>`;
+}

--- a/templates/github/docs/components/force-graph.js
+++ b/templates/github/docs/components/force-graph.js
@@ -1,0 +1,141 @@
+import * as d3 from "npm:d3";
+
+// Copyright 2021-2024 Observable, Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/force-directed-graph
+export function ForceGraph(
+  {
+    nodes, // an iterable of node objects (typically [{id}, …])
+    links // an iterable of link objects (typically [{source, target}, …])
+  },
+  {
+    nodeId = (d) => d.id, // given d in nodes, returns a unique identifier (string)
+    nodeGroup, // given d in nodes, returns an (ordinal) value for color
+    nodeGroups, // an array of ordinal values representing the node groups
+    nodeTitle, // given d in nodes, a title string
+    nodeFill = "currentColor", // node stroke fill (if not using a group color encoding)
+    nodeStroke = "var(--theme-background)", // node stroke color
+    nodeStrokeWidth = 1.5, // node stroke width, in pixels
+    nodeStrokeOpacity = 1, // node stroke opacity
+    nodeRadius = 5, // node radius, in pixels
+    nodeStrength,
+    linkSource = ({source}) => source, // given d in links, returns a node identifier string
+    linkTarget = ({target}) => target, // given d in links, returns a node identifier string
+    linkStroke = "#999", // link stroke color
+    linkStrokeOpacity = 0.6, // link stroke opacity
+    linkStrokeWidth = 1.5, // given d in links, returns a stroke width in pixels
+    linkStrokeLinecap = "round", // link stroke linecap
+    linkStrength,
+    linkDistance,
+    colors = d3.schemeObservable10, // an array of color strings, for the node groups
+    width = 640, // outer width, in pixels
+    height = 400, // outer height, in pixels
+    initialize = (simulation) => simulation, // a callback to tweak the simulation
+    invalidation // when this promise resolves, stop the simulation
+  } = {}
+) {
+  // Compute values.
+  const N = d3.map(nodes, nodeId).map(intern);
+  const R = typeof nodeRadius !== "function" ? null : d3.map(nodes, nodeRadius);
+  const LS = d3.map(links, linkSource).map(intern);
+  const LT = d3.map(links, linkTarget).map(intern);
+  if (nodeTitle === undefined) nodeTitle = (_, i) => N[i];
+  const T = nodeTitle == null ? null : d3.map(nodes, nodeTitle);
+  const G = nodeGroup == null ? null : d3.map(nodes, nodeGroup).map(intern);
+  const W = typeof linkStrokeWidth !== "function" ? null : d3.map(links, linkStrokeWidth);
+  const L = typeof linkStroke !== "function" ? null : d3.map(links, linkStroke);
+
+  // Replace the input nodes and links with mutable objects for the simulation.
+  nodes = d3.map(nodes, (_, i) => ({id: N[i]}));
+  links = d3.map(links, (_, i) => ({source: LS[i], target: LT[i]}));
+
+  // Compute default domains.
+  if (G && nodeGroups === undefined) nodeGroups = d3.sort(G);
+
+  // Construct the scales.
+  const color = nodeGroup == null ? null : d3.scaleOrdinal(nodeGroups, colors);
+
+  // Construct the forces.
+  const forceNode = d3.forceManyBody();
+  const forceLink = d3.forceLink(links).id(({index: i}) => N[i]);
+  if (nodeStrength !== undefined) forceNode.strength(nodeStrength);
+  if (linkStrength !== undefined) forceLink.strength(linkStrength);
+  if (linkDistance !== undefined) forceLink.distance(linkDistance);
+
+  const simulation = initialize(
+    d3.forceSimulation(nodes).force("link", forceLink).force("charge", forceNode).force("center", d3.forceCenter())
+  ).on("tick", ticked);
+
+  const svg = d3
+    .create("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .attr("viewBox", [-width / 2, -height / 2, width, height])
+    .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+  const link = svg
+    .append("g")
+    .attr("stroke", typeof linkStroke !== "function" ? linkStroke : null)
+    .attr("stroke-opacity", linkStrokeOpacity)
+    .attr("stroke-width", typeof linkStrokeWidth !== "function" ? linkStrokeWidth : null)
+    .attr("stroke-linecap", linkStrokeLinecap)
+    .selectAll("line")
+    .data(links.slice(0, 200))
+    .join("line");
+
+  const node = svg
+    .append("g")
+    .attr("fill", nodeFill)
+    .attr("stroke", nodeStroke)
+    .attr("stroke-opacity", nodeStrokeOpacity)
+    .attr("stroke-width", nodeStrokeWidth)
+    .selectAll("circle")
+    .data(nodes)
+    .join("circle")
+    .attr("r", nodeRadius)
+    .call(drag(simulation));
+
+  if (W) link.attr("stroke-width", ({index: i}) => W[i]);
+  if (L) link.attr("stroke", ({index: i}) => L[i]);
+  if (G) node.attr("fill", ({index: i}) => color(G[i]));
+  if (R) node.attr("r", ({index: i}) => R[i]);
+  if (T) node.append("title").text(({index: i}) => T[i]);
+  if (invalidation != null) invalidation.then(() => simulation.stop());
+
+  function intern(value) {
+    return value !== null && typeof value === "object" ? value.valueOf() : value;
+  }
+
+  function ticked() {
+    link
+      .attr("x1", (d) => d.source.x)
+      .attr("y1", (d) => d.source.y)
+      .attr("x2", (d) => d.target.x)
+      .attr("y2", (d) => d.target.y);
+
+    node.attr("cx", (d) => d.x).attr("cy", (d) => d.y);
+  }
+
+  function drag(simulation) {
+    function dragstarted(event) {
+      if (!event.active) simulation.alphaTarget(0.3).restart();
+      event.subject.fx = event.subject.x;
+      event.subject.fy = event.subject.y;
+    }
+
+    function dragged(event) {
+      event.subject.fx = event.x;
+      event.subject.fy = event.y;
+    }
+
+    function dragended(event) {
+      if (!event.active) simulation.alphaTarget(0);
+      event.subject.fx = null;
+      event.subject.fy = null;
+    }
+
+    return d3.drag().on("start", dragstarted).on("drag", dragged).on("end", dragended);
+  }
+
+  return Object.assign(svg.node(), {scales: {color}});
+}

--- a/templates/github/docs/components/plural.js
+++ b/templates/github/docs/components/plural.js
@@ -1,0 +1,7 @@
+export function plural(
+  n,
+  singular,
+  { plural = `${singular}s`, locale = "en-US" } = {}
+) {
+  return `${n.toLocaleString(locale)} ${n === 1 ? singular : plural}`;
+}

--- a/templates/github/docs/components/treemap.js
+++ b/templates/github/docs/components/treemap.js
@@ -1,0 +1,173 @@
+// Copyright 2021-2024 Observable, Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/treemap
+
+import * as d3 from "npm:d3";
+import * as DOM from "./DOM.js";
+
+export function Treemap(
+  data,
+  {
+    // data is either tabular (array of objects) or hierarchy (nested objects)
+    path, // as an alternative to id and parentId, returns an array identifier, imputing internal nodes
+    id = Array.isArray(data) ? (d) => d.id : null, // if tabular data, given a d in data, returns a unique identifier (string)
+    parentId = Array.isArray(data) ? (d) => d.parentId : null, // if tabular data, given a node d, returns its parent’s identifier
+    children, // if hierarchical data, given a d in data, returns its children
+    value, // given a node d, returns a quantitative value (for area encoding; null for count)
+    sort = (a, b) => d3.descending(a.value, b.value), // how to sort nodes prior to layout
+    label, // given a leaf node d, returns the name to display on the rectangle
+    group, // given a leaf node d, returns a categorical value (for color encoding)
+    title, // given a leaf node d, returns its hover text
+    link, // given a leaf node d, its link (if any)
+    linkTarget = "_blank", // the target attribute for links (if any)
+    tile = d3.treemapBinary, // treemap strategy
+    width = 640, // outer width, in pixels
+    height = 400, // outer height, in pixels
+    margin = 0, // shorthand for margins
+    marginTop = margin, // top margin, in pixels
+    marginRight = margin, // right margin, in pixels
+    marginBottom = margin, // bottom margin, in pixels
+    marginLeft = margin, // left margin, in pixels
+    padding = 1, // shorthand for inner and outer padding
+    paddingInner = padding, // to separate a node from its adjacent siblings
+    paddingOuter = padding, // shorthand for top, right, bottom, and left padding
+    paddingTop = paddingOuter, // to separate a node’s top edge from its children
+    paddingRight = paddingOuter, // to separate a node’s right edge from its children
+    paddingBottom = paddingOuter, // to separate a node’s bottom edge from its children
+    paddingLeft = paddingOuter, // to separate a node’s left edge from its children
+    round = true, // whether to round to exact pixels
+    colors = d3.schemeObservable10, // array of colors
+    zDomain, // array of values for the color scale
+    fill = "#ccc", // fill for node rects (if no group color encoding)
+    fillOpacity = group == null ? null : 0.6, // fill opacity for node rects
+    stroke, // stroke for node rects
+    strokeWidth, // stroke width for node rects
+    strokeOpacity, // stroke opacity for node rects
+    strokeLinejoin // stroke line join for node rects
+  } = {}
+) {
+  // If id and parentId options are specified, or the path option, use d3.stratify
+  // to convert tabular data to a hierarchy; otherwise we assume that the data is
+  // specified as an object {children} with nested objects (a.k.a. the “flare.json”
+  // format), and use d3.hierarchy.
+
+  // We take special care of any node that has both a value and children, see
+  // https://observablehq.com/@d3/treemap-parent-with-value.
+  const stratify = (data) =>
+    d3
+      .stratify()
+      .path(path)(data)
+      .each((node) => {
+        if (node.children?.length && node.data != null) {
+          const child = new d3.Node(node.data);
+          node.data = null;
+          child.depth = node.depth + 1;
+          child.height = 0;
+          child.parent = node;
+          child.id = node.id + "/";
+          node.children.unshift(child);
+        }
+      });
+  const root =
+    path != null
+      ? stratify(data)
+      : id != null || parentId != null
+      ? d3.stratify().id(id).parentId(parentId)(data)
+      : d3.hierarchy(data, children);
+
+  // Compute the values of internal nodes by aggregating from the leaves.
+  value == null ? root.count() : root.sum((d) => Math.max(0, d ? value(d) : null));
+
+  // Prior to sorting, if a group channel is specified, construct an ordinal color scale.
+  const leaves = root.leaves();
+  const G = group == null ? null : leaves.map((d) => group(d.data, d));
+  if (zDomain === undefined && G != null)
+    zDomain = d3
+      .groupSort(
+        leaves,
+        (V) => -d3.sum(V, (d) => d.value),
+        (d, i) => G[i]
+      )
+      .filter((d) => d !== undefined);
+  const color = group == null ? null : d3.scaleOrdinal(zDomain, colors).unknown("#333");
+
+  // Compute labels and titles.
+  const L = label == null ? null : leaves.map((d) => label(d.data, d));
+  const T = title === undefined ? L : title == null ? null : leaves.map((d) => title(d.data, d));
+
+  // Sort the leaves (typically by descending value for a pleasing layout).
+  if (sort != null) root.sort(sort);
+
+  // Compute the treemap layout.
+  d3
+    .treemap()
+    .tile(tile)
+    .size([width - marginLeft - marginRight, height - marginTop - marginBottom])
+    .paddingInner(paddingInner)
+    .paddingTop(paddingTop)
+    .paddingRight(paddingRight)
+    .paddingBottom(paddingBottom)
+    .paddingLeft(paddingLeft)
+    .round(round)(root);
+
+  const svg = d3
+    .create("svg")
+    .attr("viewBox", [-marginLeft, -marginTop, width, height])
+    .attr("width", width)
+    .attr("height", height)
+    .attr("style", "max-width: 100%; height: auto; height: intrinsic;")
+    .attr("font-family", "sans-serif")
+    .attr("font-size", 10);
+
+  const node = svg
+    .selectAll("a")
+    .data(leaves)
+    .join("a")
+    .attr("xlink:href", link == null ? null : (d, i) => link(d.data, d))
+    .attr("target", link == null ? null : linkTarget)
+    .attr("transform", (d) => `translate(${d.x0},${d.y0})`);
+
+  node
+    .append("rect")
+    .attr("fill", color ? (d, i) => color(G[i]) : fill)
+    .attr("fill-opacity", fillOpacity)
+    .attr("stroke", stroke)
+    .attr("stroke-width", strokeWidth)
+    .attr("stroke-opacity", strokeOpacity)
+    .attr("stroke-linejoin", strokeLinejoin)
+    .attr("width", (d) => d.x1 - d.x0)
+    .attr("height", (d) => d.y1 - d.y0);
+
+  if (T) {
+    node.append("title").text((d, i) => T[i]);
+  }
+
+  if (L) {
+    // A unique identifier for clip paths (to avoid conflicts).
+    const uid = `O-${Math.random().toString(16).slice(2)}`;
+
+    node
+      .append("clipPath")
+      .attr("id", (d, i) => `${uid}-clip-${i}`)
+      .append("rect")
+      .attr("width", (d) => d.x1 - d.x0)
+      .attr("height", (d) => d.y1 - d.y0);
+
+    node
+      .append("text")
+      .attr("fill", "currentColor")
+      .attr("clip-path", (d, i) => `url(${new URL(`#${uid}-clip-${i}`, location)})`)
+      .selectAll("tspan")
+      .data((d, i) => `${L[i]}`.split(/\n/g))
+      .join("tspan")
+      .attr("x", 3)
+      .attr("y", (d, i, D) => `${(i === D.length - 1) * 0.3 + 1.1 + i * 0.9}em`)
+      .attr("fill-opacity", (d, i, D) => (i === D.length - 1 ? 0.7 : null))
+      .text((d) => d);
+  }
+
+  const n = svg.node();
+  if (color) Object.assign(n, {scales: {color}});
+
+  return n;
+}

--- a/templates/github/docs/config.json.ts
+++ b/templates/github/docs/config.json.ts
@@ -1,0 +1,3 @@
+import { MAX_COMMITS, MAX_REPOS, MAX_ISSUES } from "./config.js";
+
+console.log(JSON.stringify({ MAX_COMMITS, MAX_REPOS, MAX_ISSUES }));

--- a/templates/github/docs/config.ts
+++ b/templates/github/docs/config.ts
@@ -1,0 +1,5 @@
+import "dotenv/config";
+export const MAX_REPOS = Number(process.env.MAX_REPOS ?? 20);
+export const MAX_ISSUES = Number(process.env.MAX_ISSUES ?? 1000);
+export const MAX_COMMITS = Number(process.env.MAX_COMMITS ?? 1000);
+export const { GITHUB_TOKEN, GITHUB_REPOS, GITHUB_ORG } = process.env;

--- a/templates/github/docs/files.json.ts
+++ b/templates/github/docs/files.json.ts
@@ -1,0 +1,25 @@
+import { getRepos } from "./github-repos.js";
+import { github } from "./github.js";
+
+const info: any[] = [];
+const { repos } = await getRepos();
+
+for (const {
+  nameWithOwner: repo,
+  defaultBranchRef: { name: branch },
+} of repos) {
+  console.warn("loading files for", repo, branch);
+  try {
+    const {
+      body: { tree },
+    } = await github(`/repos/${repo}/git/trees/${branch}?recursive=1`);
+    info.push({
+      name: repo,
+      tree: tree.map(({ path, size }) => ({ path, size })),
+    });
+  } catch (error) {
+    console.warn(error);
+  }
+}
+
+console.log(JSON.stringify(info));

--- a/templates/github/docs/files.md
+++ b/templates/github/docs/files.md
@@ -1,0 +1,70 @@
+# Files
+
+```js
+const chart = Treemap(projects, {
+  path: (d) => d.name,
+  label: (d) => `${d.name}\n${d.size.toLocaleString("en-US")}`,
+  width,
+  value: (d) => d.size,
+  height: width / 4,
+  tile: d3.treemapSquarify,
+});
+
+display(chart);
+```
+
+```js
+const repo = view(Inputs.select(projects.map((d) => d.name)));
+```
+
+```js
+const selected = projects.find(({ name }) => name === repo);
+```
+
+${d3.count(selected.tree, (d) => d.size).toLocaleString("en-US")} files, ${selected.size.toLocaleString("en-US")} bytes.
+
+```js
+const chart = Treemap(selected.tree, {
+  path: (d) => d.path,
+  width,
+  label: (d) =>
+    `${d.path.split("/").pop()}\n${d.size?.toLocaleString("en-US")}`,
+  value: (d) => d.size,
+  height: width,
+  group: (d) =>
+    `${d.path.split("/").slice(0, -1).slice(0, 2).join("/") || "/"}`,
+});
+
+display(chart);
+
+display(
+  html`<div class="swatches">
+      ${Swatches(
+        chart.scales.color.domain(chart.scales.color.domain().slice(0, 9))
+      )}
+    </div>
+    <style>
+      .swatches span::before {
+        opacity: 0.7;
+      }
+    </style>`
+);
+```
+
+```js
+const rawfiles = FileAttachment("files.json").json();
+import { Treemap } from "/components/treemap.js";
+import { Swatches } from "/components/color-legend.js";
+```
+
+```js
+const projects = d3.sort(
+  rawfiles.map((d) => ({
+    ...d,
+    size: d3.sum(d.tree, (d) => d.size),
+  })),
+  (d) => -d.size
+);
+```
+
+Treemap of ${html`<a href="https://github.com/${selected.name}/" target="\_blank">${selected.name}</a>`}.

--- a/templates/github/docs/github-repos.ts
+++ b/templates/github/docs/github-repos.ts
@@ -1,0 +1,125 @@
+import { graphql } from "./github.js";
+import { MAX_REPOS, GITHUB_REPOS, GITHUB_ORG } from "./config.js";
+
+const githubRepos = GITHUB_REPOS
+  ? new Set(GITHUB_REPOS.split(/,\s*/g).map((d) => d.toLowerCase().trim()))
+  : null;
+
+const contents = `{
+  nameWithOwner # @d3/d3-geo
+  descriptionHTML
+  archivedAt
+  stargazerCount # 178
+  diskUsage
+  # TODO ADD COUNT OF COMMITS BY USER
+  # TODO filter to only count open issues
+  issues {totalCount}
+  # collaborators {totalCount} # needs "public_repo" scope
+  watchers {totalCount}
+  defaultBranchRef {name}
+}`;
+
+export async function getRepos() {
+  interface N {
+    nameWithOwner: string;
+    descriptionHTML: string;
+    stargazerCount: number;
+    diskUsage: number;
+    issues: { totalCount: number };
+    collaborators: { totalCount: number };
+    watchers: { totalCount: number };
+    defaultBranchRef: { name: string };
+  }
+  const repos: N[] = [];
+
+  if (githubRepos) {
+    for (const repo of githubRepos) {
+      const { repository: node }: { repository: N } = await graphql({
+        query: `query repo ($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) ${contents}
+        }`,
+        owner: repo.split("/")[0].replace(/^@/, ""),
+        name: repo.split("/")[1],
+      });
+      repos.push(node);
+    }
+  } else if (GITHUB_ORG) {
+    let cursor = "";
+    do {
+      const {
+        repositoryOwner: {
+          repositories: { nodes, pageInfo },
+        },
+      } = (await graphql({
+        query: `query repos($org: String!, $cursor: String) {
+  repositoryOwner(login: $org) {
+    ... on Organization {
+      repositories(
+        first: 100,
+        after: $cursor,
+        orderBy: {field: STARGAZERS, direction: DESC},
+      ) {
+        pageInfo {endCursor}
+        nodes ${contents}
+      }
+    }
+  }
+}`,
+        cursor,
+        org: GITHUB_ORG,
+      })) as {
+        repositoryOwner: {
+          repositories: { nodes: N[]; pageInfo: { endCursor: string } };
+        };
+      };
+      cursor = pageInfo.endCursor;
+      for (const node of nodes) {
+        if (repos.length >= MAX_REPOS) {
+          cursor = "";
+          break;
+        }
+        repos.push(node);
+      }
+    } while (cursor);
+  } /* user-connected repos */ else {
+    let cursor = "";
+    do {
+      const {
+        viewer: {
+          repositories: { nodes, pageInfo },
+        },
+      } = (await graphql({
+        query: `query($cursor: String) {
+  viewer {
+    repositories(
+      first: 100,
+      after: $cursor,
+      orderBy: {field: STARGAZERS, direction: DESC},
+      affiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER],
+      ownerAffiliations:[OWNER, ORGANIZATION_MEMBER, COLLABORATOR]
+    ) {
+      pageInfo {endCursor}
+      nodes ${contents}
+    }
+  }
+}`,
+        cursor,
+      })) as {
+        viewer: {
+          repositories: { nodes: N[]; pageInfo: { endCursor: string } };
+        };
+      };
+
+      cursor = pageInfo.endCursor;
+      for (const node of nodes) {
+        if (repos.length >= MAX_REPOS) {
+          cursor = "";
+          break;
+        }
+        repos.push(node);
+      }
+    } while (cursor);
+  }
+
+  return { repos, reason: GITHUB_REPOS ? "list" : GITHUB_ORG ? "org" : "user" };
+}

--- a/templates/github/docs/github.ts
+++ b/templates/github/docs/github.ts
@@ -1,0 +1,60 @@
+import { GITHUB_TOKEN } from "./config.js";
+import { graphql as gql } from "@octokit/graphql";
+
+export async function github(
+  path: string,
+  {
+    authorization = GITHUB_TOKEN && `token ${GITHUB_TOKEN}`,
+    accept = "application/vnd.github.v3+json",
+  } = {}
+) {
+  const url = new URL(path, "https://api.github.com");
+  const headers = { ...(authorization && { authorization }), accept };
+  const response = await fetch(url, { headers });
+  if (!response.ok) throw new Error(`fetch error: ${response.status} ${url}`);
+  return { headers: response.headers, body: await response.json() };
+}
+
+export async function* githubList<T = any>(
+  path: string,
+  { reverse = true, ...options }: any = {}
+): AsyncGenerator<T> {
+  const url = new URL(path, "https://api.github.com");
+  url.searchParams.set("per_page", "100");
+  url.searchParams.set("page", "1");
+  const first = await github(String(url), options);
+  if (reverse) {
+    let prevUrl = findRelLink(first.headers, "last");
+    if (prevUrl) {
+      do {
+        const next = await github(prevUrl, options);
+        yield* next.body.reverse(); // reverse order
+        prevUrl = findRelLink(next.headers, "prev");
+      } while (prevUrl);
+    } else {
+      yield* first.body.reverse();
+    }
+  } else {
+    yield* first.body;
+    let nextUrl = findRelLink(first.headers, "next");
+    while (nextUrl) {
+      const next = await github(nextUrl, options);
+      yield* next.body; // natural order
+      nextUrl = findRelLink(next.headers, "next");
+    }
+  }
+}
+
+function findRelLink(headers, name) {
+  return headers
+    .get("link")
+    ?.split(/,\s+/g)
+    .map((link) => link.split(/;\s+/g))
+    .find(([, rel]) => rel === `rel="${name}"`)?.[0]
+    .replace(/^</, "")
+    .replace(/>$/, "");
+}
+
+export const graphql = gql.defaults({
+  headers: { authorization: `token ${GITHUB_TOKEN}` },
+});

--- a/templates/github/docs/index.md
+++ b/templates/github/docs/index.md
@@ -1,0 +1,112 @@
+# GitHub Stats
+
+## Overview
+
+```js
+const { repos, commits } = await FileAttachment("commits.json").json();
+```
+
+```js
+const { issues } = await FileAttachment("issues.json").json();
+```
+
+```js
+const user = await FileAttachment("user.json").json();
+```
+
+This GitHub collection covers ${plural(repos.length, "repo")} totalling ${plural(commits.length, "commit")} from ${plural(new Set(Plot.valueof(commits, "author_name")).size, "author")}.
+
+## Top repos
+
+```js
+const topRepos = d3
+  .sort(
+    d3.rollups(
+      commits,
+      (v) => ({
+        authors: new Set(Plot.valueof(v, "author_name")).size,
+        commits: v.length,
+        dates: d3.extent(v, (d) => d.created_at),
+      }),
+      (d) => d.repo
+    ),
+    (d) => -d[1].authors,
+    (d) => -d[1].commits
+  )
+  .slice(0, 9);
+
+const colorRepo = Plot.scale({
+  color: {
+    domain: topRepos.map((d) => d[0]),
+    range: d3.schemeObservable10,
+    unknown: d3.schemeObservable10[9],
+  },
+});
+```
+
+```js
+display(
+  html`<ul>
+    ${topRepos.map(
+      (d) =>
+        html`<p
+          ${{
+            style: `border-bottom: 2px solid ${colorRepo.apply(d[0])}`,
+          }}
+        >
+          <span
+            ${{
+              style: `color: ${colorRepo.apply(d[0])} !important;`,
+            }}
+            >▣</span
+          >
+          <span style="text-transform: uppercase;">${d[0]}</span>
+          <small
+            >(${plural(d[1].authors, "author")}, ${plural(
+              d[1].commits,
+              "commit"
+            )})
+          </small>
+        </p>`
+    )}
+  </ul>`
+);
+```
+
+## Overview
+
+```js
+display(
+  Plot.plot({
+    width,
+    marginLeft: 60,
+    x: { type: "utc" },
+    y: { label: "commits" },
+    color: colorRepo,
+    marks: [
+      Plot.rectY(
+        commits,
+        Plot.binX(
+          { y: "count", interval: "year" },
+          {
+            x: "created_at",
+            fill: "repo",
+            order: colorRepo.domain,
+            tip: true,
+          }
+        )
+      ),
+    ],
+  })
+);
+```
+
+---
+
+_Data collected by @${user.login} on ${(() => {
+  const d = new Date(FileAttachment("issues.json").lastModified);
+  return html`<span title="${d3.isoFormat(d)}">${d.toLocaleDateString("en-US", { month: "long",day: "numeric", timeZone: "UTC"})}`})()}._
+
+```js
+import { plural } from "./components/plural.js";
+```

--- a/templates/github/docs/issues.json.ts
+++ b/templates/github/docs/issues.json.ts
@@ -1,0 +1,35 @@
+import { MAX_ISSUES } from "./config.js";
+import { githubList } from "./github.js";
+import { getRepos } from "./github-repos.js";
+
+const { repos } = await getRepos();
+
+const issues: any[] = [];
+
+for (const { nameWithOwner: repo } of repos) {
+  console.warn(`\n${repo}`);
+  console.warn("loading issues");
+
+  let i = 0;
+  for await (const issue of githubList(`/repos/${repo}/issues?state=all`)) {
+    if (i++ >= MAX_ISSUES) break;
+    process.stderr.write(".");
+    issues.unshift({
+      id: issue.id,
+      repo,
+      title: issue.title,
+      user: issue.user?.login,
+      state: issue.state,
+      created_at: issue.created_at,
+      closed_at: issue.closed_at,
+      updated_at: issue.updated_at,
+      comments: issue.comments,
+      reactions: issue.reactions.total_count,
+      url: issue.html_url,
+    });
+  }
+}
+
+process.stderr.write("\n");
+
+console.log(JSON.stringify({ repos, issues }));

--- a/templates/github/docs/issues.md
+++ b/templates/github/docs/issues.md
@@ -1,0 +1,143 @@
+# Issues
+
+```js
+const { issues } = await FileAttachment("issues.json").json();
+```
+
+## Burndown chart
+
+```js
+const today = new Date();
+const burndown = d3.sort(
+  most_discussed
+    .filter((d) => !d.pull_request)
+    .flatMap((issue) => {
+      const start = new Date(issue.created_at);
+      const end = new Date(
+        issue.closed_at ??
+          (issue.state === "closed" ? issue.updated_at : undefined) ??
+          today
+      );
+      const dates = d3.utcMonth.range(
+        d3.utcMonth.offset(d3.utcMonth.floor(start), -1),
+        d3.utcMonth.offset(d3.utcMonth.floor(end), 1)
+      );
+      return dates.map((date, i) => {
+        return {
+          start: start,
+          value: i === 0 || i === dates.length - 1 ? 0 : 1,
+          date,
+        };
+      });
+    }),
+  (d) => d.start
+);
+
+const start = d3.min(burndown, (d) => d.start);
+```
+
+<div class="card grid grid-cols-1" style="grid-auto-rows: 400px;">${
+  resize((width, height) => Plot.plot({
+    width,
+    height,
+    marginRight: 60,
+    round: true,
+    y: {axis: "right", grid: true, label: "↑ Open issues"},
+    marks: [
+      Plot.areaY(burndown, Plot.filter((d) => d.date >= start, {x: "date", y: "value", curve: "step-after", fill: "start"})),
+      Plot.ruleY([0])
+    ]
+  }))
+}
+</div>
+
+## By repo
+
+```js
+const normalize = view(Inputs.toggle({ label: "normalize" }));
+```
+
+```js
+const selectedProject = view(
+  Plot.barX(
+    issues,
+    Plot.groupY(
+      { x: "count" },
+      {
+        fill: "repo",
+        tip: true,
+        order: "-sum",
+        y: "state",
+        offset: normalize ? "normalize" : undefined,
+      }
+    )
+  ).plot({
+    width,
+    style: "overflow: visible;",
+    marginLeft: 80,
+    x: { percent: !!normalize },
+  })
+);
+```
+
+```js
+//display(selectedProject);
+```
+
+```js
+const most_discussed = d3.sort(
+  (selectedProject ?? issues).filter(
+    (d) => d.state.startsWith("open") // note: gitlab uses "opened"
+  ),
+  (d) => -d.comments - d.reactions
+);
+
+// display(most_discussed);
+
+const links = new Map(
+  most_discussed.map(({ id, url }) => [
+    id,
+    html`<a href="${url}" target="_blank">#${id}</a>`,
+  ])
+);
+```
+
+```js
+const searched = view(Inputs.search(most_discussed));
+```
+
+```js
+display(
+  Inputs.table(searched, {
+    rows: 40,
+    columns: [
+      "id",
+      "title",
+      "repo",
+      "comments",
+      "reactions",
+      "created_at",
+      "user",
+    ],
+    width: {
+      id: "4em",
+      title: "40%",
+      repo: "3em",
+      comments: "4em",
+      reactions: "4em",
+      user: "4em",
+    },
+    format: {
+      id: (id) => links.get(id),
+      created_at: (d) => {
+        const delay = d3.utcDay.count(new Date(d), new Date());
+        return delay > 80
+          ? `${d3.utcMonth.count(new Date(d), new Date())} months ago`
+          : `${delay} days ago`;
+      },
+    },
+  })
+);
+```
+
+<div style="min-height: 100vh"></div>

--- a/templates/github/docs/repos.json.ts
+++ b/templates/github/docs/repos.json.ts
@@ -1,0 +1,3 @@
+import { getRepos } from "./github-repos.js";
+
+console.log(JSON.stringify(await getRepos()));

--- a/templates/github/docs/repos.md
+++ b/templates/github/docs/repos.md
@@ -1,0 +1,101 @@
+# Repos
+
+${html`<image src="${user.avatar_url}" class="avatar">`}
+Here are ${plural(repos.length, "repo")}${allRepos.reason === "user" ? ` you own${myOnly ? "": " or contribute to"}` : allRepos.reason === "org" ? " in your organization" : ""}:
+
+```js
+const value = sizeBy;
+
+const chart = Treemap(
+  myOnly ? repos.filter((d) => d.nameWithOwner.startsWith(user.login)) : repos,
+  {
+    path: (d) => `${d.nameWithOwner}`,
+    width,
+    label: (d) =>
+      `${d.nameWithOwner.split("/")[1]} @${d.nameWithOwner.split("/")[0]}\n${
+        value?.(d)?.toLocaleString("en-US") ?? ""
+      }`,
+    value: value ? (d) => value(d) || 0 : () => 1,
+    link: (d) => `https://github.com/${d.nameWithOwner}`,
+    height: width,
+    zDomain,
+    group: (d) => `${d.nameWithOwner.split("/")[0]}`,
+  }
+);
+
+display(
+  html`<div class="swatches">
+      ${Swatches(
+        chart.scales.color.domain(chart.scales.color.domain().slice(0, 9))
+      )}
+    </div>
+    <style>
+      .swatches span::before {
+        opacity: 0.7;
+      }
+    </style>`
+);
+
+display(chart);
+```
+
+```js
+const sizeBy = view(
+  Inputs.select(
+    new Map([
+      ["⭐️  popularity", (d) => d.stargazerCount],
+      ["💾  disk space", (d) => d.diskUsage],
+      ["🌶  issues", (d) => d.issues.totalCount],
+      ["①  unit", null],
+    ]),
+    { label: "size by" }
+  )
+);
+
+const myOnly = view(Inputs.toggle({ label: "my repos" }));
+
+const archived = view(Inputs.toggle({ label: "archived repos" }));
+```
+
+```js
+const rawfiles = FileAttachment("files.json").json();
+import { Treemap } from "/components/treemap.js";
+import { Swatches } from "/components/color-legend.js";
+```
+
+```js
+const allRepos = FileAttachment("repos.json").json();
+```
+
+```js
+const repos = allRepos.repos.filter((d) =>
+  archived ? !!d.archivedAt : !d.archivedAt
+);
+```
+
+```js
+const zDomain = d3.groupSort(
+  allRepos.repos,
+  (v) => -d3.sum(v, (d) => d.stargazerCount),
+  (d) => d.nameWithOwner.split("/")[0]
+);
+```
+
+```js
+const user = FileAttachment("user.json").json();
+```
+
+<style>
+  .avatar {
+    position: absolute;
+    right: -45px;
+    height: auto;
+    width: 80px;
+    border-radius: 80px;
+    border: 5px solid var(--theme-background);
+  }
+</style>
+
+```js
+import { plural } from "./components/plural.js";
+```

--- a/templates/github/docs/user.json.ts
+++ b/templates/github/docs/user.json.ts
@@ -1,0 +1,3 @@
+import { github } from "./github.js";
+const { body: user } = await github("user");
+console.log(JSON.stringify(user));

--- a/templates/github/docs/user.md
+++ b/templates/github/docs/user.md
@@ -1,0 +1,11 @@
+# User
+
+```js
+display(user);
+```
+
+```js
+const user = FileAttachment("user.json").json();
+```
+
+${html`<image src="${user.avatar_url}">`}

--- a/templates/github/package.json.tmpl
+++ b/templates/github/package.json.tmpl
@@ -1,0 +1,26 @@
+{
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "clean": "rimraf docs/.observablehq/cache",
+    "build": "rimraf dist && observable build",
+    "dev": "observable preview",
+    "deploy": "observable deploy",
+    "observable": "observable"
+  },
+  "dependencies": {
+    "@observablehq/framework": "^1.6.0",
+    "@octokit/graphql": "^8.1.1",
+    "d3-dsv": "^3.0.1",
+    "d3-time-format": "^4.1.0",
+    "dotenv": "^16.4.5",
+    "isomorphic-git": "^1.25.7",
+    "memfs": "^4.8.2"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/test/create-test.ts
+++ b/test/create-test.ts
@@ -64,7 +64,7 @@ describe("create", () => {
       "./template-github", // Where to create your project?
       "GitHub Stats", // What to title your project?
       "github", // Include sample files to help you get started?
-      "", // token
+      "ght_xxxxxx", // token
       "", // repos or org
       null, // Install dependencies?
       false // Initialize git repository?
@@ -73,6 +73,7 @@ describe("create", () => {
     assert.deepStrictEqual(
       new Set(effects.outputs.keys()),
       new Set([
+        "template-github/.env",
         "template-github/README.md",
         "template-github/docs/clone.json.ts",
         "template-github/docs/collaborations.md",

--- a/test/create-test.ts
+++ b/test/create-test.ts
@@ -12,7 +12,7 @@ describe("create", () => {
     effects.clack.inputs.push(
       "./template-test", // Where to create your project?
       "Template Test", // What to title your project?
-      true, // Include sample files to help you get started?
+      "default", // Include sample files to help you get started?
       null, // Install dependencies?
       false // Initialize git repository?
     );
@@ -41,7 +41,7 @@ describe("create", () => {
     effects.clack.inputs.push(
       "./template-test", // Where to create your project?
       "Template Test", // What to title your project?
-      false, // Include sample files to help you get started?
+      "empty", // Include sample files to help you get started?
       null, // Install dependencies?
       false // Initialize git repository?
     );

--- a/test/create-test.ts
+++ b/test/create-test.ts
@@ -58,6 +58,47 @@ describe("create", () => {
       ])
     );
   });
+  it("instantiates the github template", async () => {
+    const effects = new TestCreateEffects();
+    effects.clack.inputs.push(
+      "./template-github", // Where to create your project?
+      "GitHub Stats", // What to title your project?
+      "github", // Include sample files to help you get started?
+      "", // token
+      "", // repos or org
+      null, // Install dependencies?
+      false // Initialize git repository?
+    );
+    await create(effects);
+    assert.deepStrictEqual(
+      new Set(effects.outputs.keys()),
+      new Set([
+        "template-github/README.md",
+        "template-github/docs/clone.json.ts",
+        "template-github/docs/collaborations.md",
+        "template-github/docs/commits.json.ts",
+        "template-github/docs/components/DOM.js",
+        "template-github/docs/components/color-legend.js",
+        "template-github/docs/components/force-graph.js",
+        "template-github/docs/components/plural.js",
+        "template-github/docs/components/treemap.js",
+        "template-github/docs/config.json.ts",
+        "template-github/docs/config.ts",
+        "template-github/docs/files.json.ts",
+        "template-github/docs/files.md",
+        "template-github/docs/github-repos.ts",
+        "template-github/docs/github.ts",
+        "template-github/docs/index.md",
+        "template-github/docs/issues.json.ts",
+        "template-github/docs/issues.md",
+        "template-github/docs/repos.json.ts",
+        "template-github/docs/repos.md",
+        "template-github/docs/user.json.ts",
+        "template-github/docs/user.md",
+        "template-github/package.json"
+      ])
+    );
+  });
 });
 
 class TestCreateEffects implements CreateEffects {


### PR DESCRIPTION
Several pages & data loaders. We might want more or less, and better, but we have a base.

An additional clack dialog helps to populate `.env`.

A few options (including limits) are described in the README. They could be shown, commented out, in the default .env.

