### PR TITLE
use file manifests during uploads

### DIFF
--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -108,7 +108,7 @@ try {
     }
     case "deploy": {
       const {
-        values: {config, root, message, build, "no-build": noBuild, manifest}
+        values: {config, root, message, build}
       } = helpArgs(command, {
         options: {
           ...CONFIG_OPTION,
@@ -123,17 +123,14 @@ try {
           "no-build": {
             type: "boolean",
             description: "Don’t build before deploying; deploy as is"
-          },
-          manifest: {type: "boolean", description: "Use the new upload strategy"},
-          "no-manifest": {type: "boolean", description: "Use the old upload strategy"}
+          }
         }
       });
       await import("../deploy.js").then(async (deploy) =>
         deploy.deploy({
           config: await readConfig(config, root),
           message,
-          force: build ? "build" : noBuild ? "deploy" : null,
-          manifest
+          force: build === true ? "build" : build === false ? "deploy" : null
         })
       );
       break;

--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -108,7 +108,7 @@ try {
     }
     case "deploy": {
       const {
-        values: {config, root, message, build, "no-build": noBuild}
+        values: {config, root, message, build, "no-build": noBuild, manifest}
       } = helpArgs(command, {
         options: {
           ...CONFIG_OPTION,
@@ -123,14 +123,17 @@ try {
           "no-build": {
             type: "boolean",
             description: "Don’t build before deploying; deploy as is"
-          }
+          },
+          manifest: {type: "boolean", description: "Use the new upload strategy"},
+          "no-manifest": {type: "boolean", description: "Use the old upload strategy"}
         }
       });
       await import("../deploy.js").then(async (deploy) =>
         deploy.deploy({
           config: await readConfig(config, root),
           message,
-          force: build ? "build" : noBuild ? "deploy" : null
+          force: build ? "build" : noBuild ? "deploy" : null,
+          manifest
         })
       );
       break;

--- a/src/observableApiClient.ts
+++ b/src/observableApiClient.ts
@@ -196,6 +196,14 @@ export class ObservableApiClient {
     }
   }
 
+  async postDeployManifest(deployId: string, files: DeployManifestFile[]): Promise<PostDeployManifestResponse> {
+    return await this._fetch<PostDeployManifestResponse>(new URL(`/cli/deploy/${deployId}/manifest`, this._apiOrigin), {
+      method: "POST",
+      headers: {"content-type": "application/json"},
+      body: JSON.stringify({files})
+    });
+  }
+
   async postDeployUploaded(deployId: string): Promise<DeployInfo> {
     return await this._fetch<DeployInfo>(new URL(`/cli/deploy/${deployId}/uploaded`, this._apiOrigin), {
       method: "POST",
@@ -304,4 +312,20 @@ export interface GetDeployResponse {
   id: string;
   status: string;
   url: string;
+}
+
+export interface DeployManifestFile {
+  path: string;
+  size: number;
+  hash: string;
+}
+
+export interface PostDeployManifestResponse {
+  status: "ok" | "error";
+  detail: string | null;
+  files: {
+    path: string;
+    status: "upload" | "skip" | "error";
+    detail: string | null;
+  }[];
 }

--- a/src/tty.ts
+++ b/src/tty.ts
@@ -33,7 +33,7 @@ export const defaultEffects: TtyEffects = {
   outputColumns: Math.min(80, process.stdout.columns ?? 80)
 };
 
-function stripColor(s: string): string {
+export function stripColor(s: string): string {
   // eslint-disable-next-line no-control-regex
   return s.replace(/\x1b\[[0-9;]*m/g, "");
 }

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -11,6 +11,7 @@ import type {ObservableApiClientOptions} from "../src/observableApiClient.js";
 import type {GetCurrentUserResponse} from "../src/observableApiClient.js";
 import {ObservableApiClient} from "../src/observableApiClient.js";
 import type {DeployConfig} from "../src/observableApiConfig.js";
+import {stripColor} from "../src/tty.js";
 import {MockAuthEffects} from "./mocks/authEffects.js";
 import {TestClackEffects} from "./mocks/clack.js";
 import {MockConfigEffects} from "./mocks/configEffects.js";
@@ -178,11 +179,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .handlePostDeployFile({deployId, clientName: "index.html"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+      .expectFileUpload({deployId, path: "index.html"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId, deployStatus: "uploaded"})
       .start();
@@ -206,11 +207,11 @@ describe("deploy", () => {
       .handleGetProject({...DEPLOY_CONFIG, title: oldTitle})
       .handleUpdateProject({projectId: DEPLOY_CONFIG.projectId, title: TEST_CONFIG.title!})
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .handlePostDeployFile({deployId, clientName: "index.html"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+      .expectFileUpload({deployId, path: "index.html"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -234,11 +235,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(deployConfig)
       .handlePostDeploy({projectId: deployConfig.projectId, deployId})
-      .handlePostDeployFile({deployId, clientName: "index.html"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+      .expectFileUpload({deployId, path: "index.html"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -261,11 +262,11 @@ describe("deploy", () => {
       })
       .handlePostProject({projectId: DEPLOY_CONFIG.projectId})
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .handlePostDeployFile({deployId, clientName: "index.html"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+      .expectFileUpload({deployId, path: "index.html"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -472,6 +473,7 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
+      .handlePostDeployManifest({deployId, files: [{deployId, path: "index.html", action: "upload"}]})
       .handlePostDeployFile({deployId, status: 500})
       .start();
     const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG});
@@ -495,11 +497,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .handlePostDeployFile({deployId, clientName: "index.html"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+      .expectFileUpload({deployId, path: "index.html"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId, status: 500})
       .start();
     const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG});
@@ -612,11 +614,11 @@ describe("deploy", () => {
           projectId: newProjectId
         })
         .handlePostDeploy({projectId: newProjectId, deployId})
-        .handlePostDeployFile({deployId, clientName: "index.html"})
-        .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-        .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-        .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-        .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+        .expectFileUpload({deployId, path: "index.html"})
+        .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+        .expectFileUpload({deployId, path: "_observablehq/client.js"})
+        .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+        .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
         .handlePostDeployUploaded({deployId})
         .handleGetDeploy({deployId})
         .start();
@@ -700,11 +702,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .handlePostDeployFile({deployId, clientName: "index.html"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+      .expectFileUpload({deployId, path: "index.html"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -727,11 +729,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .handlePostDeployFile({deployId, clientName: "index.html"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+      .expectFileUpload({deployId, path: "index.html"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId, deployStatus: "created"})
       .handleGetDeploy({deployId, deployStatus: "pending"})
@@ -831,11 +833,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .handlePostDeployFile({deployId, clientName: "index.html"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
-      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
+      .expectFileUpload({deployId, path: "index.html"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -860,6 +862,48 @@ describe("deploy", () => {
 
     effects.close();
   });
+
+  it("will skip file uploads if instructed by the server", async () => {
+    const deployId = "deploy456";
+    getCurrentObservableApi()
+      .handleGetCurrentUser()
+      .handleGetProject(DEPLOY_CONFIG)
+      .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
+      .expectFileUpload({deployId, path: "index.html", action: "upload"})
+      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css", action: "skip"})
+      .expectFileUpload({deployId, path: "_observablehq/client.js", action: "skip"})
+      .expectFileUpload({deployId, path: "_observablehq/runtime.js", action: "skip"})
+      .expectFileUpload({deployId, path: "_observablehq/stdlib.js", action: "skip"})
+      .handlePostDeployUploaded({deployId})
+      .handleGetDeploy({deployId, deployStatus: "uploaded"})
+      .start();
+
+    const effects = new MockDeployEffects({
+      deployConfig: DEPLOY_CONFIG,
+      fixedInputStatTime: new Date("2024-03-09"),
+      fixedOutputStatTime: new Date("2024-03-10")
+    });
+    effects.clack.inputs = ["fix some bugs"]; // "what changed?"
+    await deploy(TEST_OPTIONS, effects);
+
+    effects.close();
+
+    // first is the upload spinner, second is the server processing spinner
+    assert.equal(effects.clack.spinners.length, 2, JSON.stringify(effects.clack.spinners, null, 2));
+    const events = effects.clack.spinners[0]._events.map((e) => {
+      const r: {method: string; message?: string} = {method: e.method};
+      if (e.message) r.message = stripColor(e.message);
+      return r;
+    });
+    assert.deepEqual(events, [
+      {method: "start"},
+      {method: "message", message: "Hashing local files"},
+      {method: "message", message: "Sending file manifest to server"},
+      {method: "message", message: "1 / 1 uploading index.html"},
+      {method: "stop", message: "1 uploaded, 4 unchanged, 5 total."}
+    ]);
+  });
+
 });
 
 describe("promptDeployTarget", () => {

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -903,7 +903,6 @@ describe("deploy", () => {
       {method: "stop", message: "1 uploaded, 4 unchanged, 5 total."}
     ]);
   });
-
 });
 
 describe("promptDeployTarget", () => {

--- a/test/mocks/clack.ts
+++ b/test/mocks/clack.ts
@@ -5,6 +5,7 @@ import type {ClackEffects} from "../../src/clack.js";
 export class TestClackEffects implements ClackEffects {
   static cancelSymbol = Symbol("cancel");
   inputs: any[] = [];
+  spinners: TestClackSpinner[] = [];
   intro() {}
   outro() {}
   note() {}
@@ -31,11 +32,9 @@ export class TestClackEffects implements ClackEffects {
     return this.inputs.shift();
   }
   spinner() {
-    return {
-      start() {},
-      stop() {},
-      message() {}
-    };
+    const spinner = new TestClackSpinner();
+    this.spinners.push(spinner);
+    return spinner;
   }
   log = new TestClackLogs();
   isCancel(value: unknown): value is symbol {
@@ -82,5 +81,23 @@ class TestClackLogs implements ClackLogs {
         .map((d) => d.message)
         .join("\n          * ")}`
     );
+  }
+}
+
+type ClackSpinnerEvent =
+  | {method: "start"; message?: string}
+  | {method: "stop"; message?: string; code?: number}
+  | {method: "message"; message?: string};
+
+class TestClackSpinner {
+  _events: ClackSpinnerEvent[] = [];
+  start(message?: string | undefined) {
+    this._events.push({method: "start", message});
+  }
+  stop(message?: string | undefined, code?: number) {
+    this._events.push({method: "stop", message, code});
+  }
+  message(message?: string | undefined) {
+    this._events.push({method: "message", message});
   }
 }

--- a/test/mocks/observableApi.ts
+++ b/test/mocks/observableApi.ts
@@ -6,7 +6,8 @@ import type {
   GetProjectResponse,
   PaginatedList,
   PostAuthRequestPollResponse,
-  PostAuthRequestResponse
+  PostAuthRequestResponse,
+  PostDeployManifestResponse
 } from "../../src/observableApiClient.js";
 import {getObservableApiOrigin, getObservableUiOrigin} from "../../src/observableApiClient.js";
 import {getCurrentAgent, mockAgent} from "./undici.js";
@@ -27,7 +28,7 @@ export function mockObservableApi() {
     agent.get(getOrigin());
   });
 
-  afterEach(() => {
+  afterEach(function () {
     apiMock.after();
   });
 }
@@ -41,14 +42,22 @@ function getOrigin() {
   return getObservableApiOrigin().toString().replace(/\/$/, "");
 }
 
+type ExpectedFile = {
+  path: string;
+  deployId: string;
+  action: "skip" | "upload";
+};
+
 class ObservableApiMock {
   private _agent: MockAgent | null = null;
   private _handlers: ((pool: Interceptable) => void)[] = [];
+  private _expectedFiles: ExpectedFile[] = [];
 
   public start(): ObservableApiMock {
     this._agent = getCurrentAgent();
     const mockPool = this._agent.get(getOrigin());
     for (const handler of this._handlers) handler(mockPool);
+    this.handleExpectedFiles(mockPool);
     return this;
   }
 
@@ -71,6 +80,46 @@ class ObservableApiMock {
   addHandler(handler: (pool: Interceptable) => void): ObservableApiMock {
     this._handlers.push(handler);
     return this;
+  }
+
+  private handleExpectedFiles(mockPool: Interceptable) {
+    if (this._expectedFiles.length > 0) {
+      const headers = authorizationHeader(true);
+      for (const {path, deployId, action} of this._expectedFiles) {
+        if (action === "upload") {
+          mockPool
+            .intercept({
+              path: `/cli/deploy/${deployId}/file`,
+              method: "POST",
+              headers: headersMatcher(headers),
+              body: formDataMatcher({client_name: path})
+            })
+            .reply(204, "");
+        }
+      }
+
+      const byDeployId: Record<string, ExpectedFile[]> = this._expectedFiles.reduce((acc, file) => {
+        (acc[file.deployId] ??= []).push(file);
+        return acc;
+      }, {});
+      for (const [deployId, files] of Object.entries(byDeployId)) {
+        mockPool
+          .intercept({
+            path: `/cli/deploy/${deployId}/manifest`,
+            method: "POST",
+            headers: headersMatcher(headers)
+          })
+          .reply(
+            200,
+            JSON.stringify({
+              status: "ok",
+              detail: null,
+              files: files.map((f) => ({path: f.path, detail: null, status: f.action}))
+            } satisfies PostDeployManifestResponse),
+            {headers: {"content-type": "application/json"}}
+          );
+      }
+    }
   }
 
   handleGetCurrentUser({
@@ -221,6 +270,45 @@ class ObservableApiMock {
     this.addHandler((pool) =>
       pool
         .intercept({path: `/cli/project/${projectId}/deploy`, method: "POST", headers: headersMatcher(headers)})
+        .reply(status, response, {headers: {"content-type": "application/json"}})
+    );
+    return this;
+  }
+
+  /** Register a file that is expected to be uploaded. Also includes that file in
+   * an automatic interceptor to `/deploy/:deployId/manifest`. If the action is
+   * "upload", an interceptor for `/deploy/:deployId/file` will be registered.
+   * If it is set to "skip", that interceptor will not be registered. */
+  expectFileUpload({
+    deployId,
+    path,
+    action = "upload"
+  }: {
+    deployId: string;
+    path: string;
+    action?: "skip" | "upload";
+  }): ObservableApiMock {
+    this._expectedFiles.push({deployId, path, action});
+    return this;
+  }
+
+  handlePostDeployManifest({
+    deployId,
+    status = 200,
+    files = []
+  }: {deployId?: string; status?: number; files?: ExpectedFile[]} = {}): ObservableApiMock {
+    const response =
+      status == 200
+        ? JSON.stringify({
+            status: "ok",
+            detail: null,
+            files: files.map((f) => ({path: f.path, detail: null, status: f.action}))
+          } satisfies PostDeployManifestResponse)
+        : emptyErrorBody;
+    const headers = authorizationHeader(status !== 403);
+    this.addHandler((pool) =>
+      pool
+        .intercept({path: `/cli/deploy/${deployId}/manifest`, method: "POST", headers: headersMatcher(headers)})
         .reply(status, response, {headers: {"content-type": "application/json"}})
     );
     return this;


### PR DESCRIPTION
This changes the deploy command to first upload a manifest of files in the output directory. The manifest contains the path, size, and hash of each file found. The server then sends back instructions to either upload the file, skip it (because it already exists on the server), or an error (such as a file being too large).

The manifest process is mostly invisible to the user. The upload spinner briefly shows that it is preparing a manifest, and the final total shows files that were skipped because they already exist.

I added a new pair of flags, `--manifest` and `--no-manifest`, which use the new and old upload strategies, respectively. The default is to use manifests. My thinking here was that we should merge this PR with the flag, and validate it in CI for a few days. If there is a problem, we can use the `--no-manifest` option while we fix it. I expect that for the next release we should remove the flag and only have one upload strategy.

This depends on server side changes that haven't been deployed yet. I'll update this PR once they are ready to test on observablehq.com.
