### PR TITLE
Revert "use file manifests during uploads (#1278)"

### DIFF
--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -108,7 +108,7 @@ try {
     }
     case "deploy": {
       const {
-        values: {config, root, message, build}
+        values: {config, root, message, build, "no-build": noBuild}
       } = helpArgs(command, {
         options: {
           ...CONFIG_OPTION,
@@ -130,7 +130,7 @@ try {
         deploy.deploy({
           config: await readConfig(config, root),
           message,
-          force: build === true ? "build" : build === false ? "deploy" : null
+          force: build ? "build" : noBuild ? "deploy" : null
         })
       );
       break;

--- a/src/observableApiClient.ts
+++ b/src/observableApiClient.ts
@@ -196,14 +196,6 @@ export class ObservableApiClient {
     }
   }
 
-  async postDeployManifest(deployId: string, files: DeployManifestFile[]): Promise<PostDeployManifestResponse> {
-    return await this._fetch<PostDeployManifestResponse>(new URL(`/cli/deploy/${deployId}/manifest`, this._apiOrigin), {
-      method: "POST",
-      headers: {"content-type": "application/json"},
-      body: JSON.stringify({files})
-    });
-  }
-
   async postDeployUploaded(deployId: string): Promise<DeployInfo> {
     return await this._fetch<DeployInfo>(new URL(`/cli/deploy/${deployId}/uploaded`, this._apiOrigin), {
       method: "POST",
@@ -312,20 +304,4 @@ export interface GetDeployResponse {
   id: string;
   status: string;
   url: string;
-}
-
-export interface DeployManifestFile {
-  path: string;
-  size: number;
-  hash: string;
-}
-
-export interface PostDeployManifestResponse {
-  status: "ok" | "error";
-  detail: string | null;
-  files: {
-    path: string;
-    status: "upload" | "skip" | "error";
-    detail: string | null;
-  }[];
 }

--- a/src/tty.ts
+++ b/src/tty.ts
@@ -33,7 +33,7 @@ export const defaultEffects: TtyEffects = {
   outputColumns: Math.min(80, process.stdout.columns ?? 80)
 };
 
-export function stripColor(s: string): string {
+function stripColor(s: string): string {
   // eslint-disable-next-line no-control-regex
   return s.replace(/\x1b\[[0-9;]*m/g, "");
 }

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -11,7 +11,6 @@ import type {ObservableApiClientOptions} from "../src/observableApiClient.js";
 import type {GetCurrentUserResponse} from "../src/observableApiClient.js";
 import {ObservableApiClient} from "../src/observableApiClient.js";
 import type {DeployConfig} from "../src/observableApiConfig.js";
-import {stripColor} from "../src/tty.js";
 import {MockAuthEffects} from "./mocks/authEffects.js";
 import {TestClackEffects} from "./mocks/clack.js";
 import {MockConfigEffects} from "./mocks/configEffects.js";
@@ -179,11 +178,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+      .handlePostDeployFile({deployId, clientName: "index.html"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId, deployStatus: "uploaded"})
       .start();
@@ -207,11 +206,11 @@ describe("deploy", () => {
       .handleGetProject({...DEPLOY_CONFIG, title: oldTitle})
       .handleUpdateProject({projectId: DEPLOY_CONFIG.projectId, title: TEST_CONFIG.title!})
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+      .handlePostDeployFile({deployId, clientName: "index.html"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -235,11 +234,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(deployConfig)
       .handlePostDeploy({projectId: deployConfig.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+      .handlePostDeployFile({deployId, clientName: "index.html"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -262,11 +261,11 @@ describe("deploy", () => {
       })
       .handlePostProject({projectId: DEPLOY_CONFIG.projectId})
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+      .handlePostDeployFile({deployId, clientName: "index.html"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -473,7 +472,6 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .handlePostDeployManifest({deployId, files: [{deployId, path: "index.html", action: "upload"}]})
       .handlePostDeployFile({deployId, status: 500})
       .start();
     const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG});
@@ -497,11 +495,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+      .handlePostDeployFile({deployId, clientName: "index.html"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId, status: 500})
       .start();
     const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG});
@@ -614,11 +612,11 @@ describe("deploy", () => {
           projectId: newProjectId
         })
         .handlePostDeploy({projectId: newProjectId, deployId})
-        .expectFileUpload({deployId, path: "index.html"})
-        .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-        .expectFileUpload({deployId, path: "_observablehq/client.js"})
-        .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-        .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+        .handlePostDeployFile({deployId, clientName: "index.html"})
+        .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+        .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+        .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+        .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
         .handlePostDeployUploaded({deployId})
         .handleGetDeploy({deployId})
         .start();
@@ -702,11 +700,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+      .handlePostDeployFile({deployId, clientName: "index.html"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -729,11 +727,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+      .handlePostDeployFile({deployId, clientName: "index.html"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId, deployStatus: "created"})
       .handleGetDeploy({deployId, deployStatus: "pending"})
@@ -833,11 +831,11 @@ describe("deploy", () => {
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js"})
+      .handlePostDeployFile({deployId, clientName: "index.html"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/theme-air,near-midnight.css"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/client.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/runtime.js"})
+      .handlePostDeployFile({deployId, clientName: "_observablehq/stdlib.js"})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
       .start();
@@ -861,47 +859,6 @@ describe("deploy", () => {
     await deploy(deployOptions, effects);
 
     effects.close();
-  });
-
-  it("will skip file uploads if instructed by the server", async () => {
-    const deployId = "deploy456";
-    getCurrentObservableApi()
-      .handleGetCurrentUser()
-      .handleGetProject(DEPLOY_CONFIG)
-      .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
-      .expectFileUpload({deployId, path: "index.html", action: "upload"})
-      .expectFileUpload({deployId, path: "_observablehq/theme-air,near-midnight.css", action: "skip"})
-      .expectFileUpload({deployId, path: "_observablehq/client.js", action: "skip"})
-      .expectFileUpload({deployId, path: "_observablehq/runtime.js", action: "skip"})
-      .expectFileUpload({deployId, path: "_observablehq/stdlib.js", action: "skip"})
-      .handlePostDeployUploaded({deployId})
-      .handleGetDeploy({deployId, deployStatus: "uploaded"})
-      .start();
-
-    const effects = new MockDeployEffects({
-      deployConfig: DEPLOY_CONFIG,
-      fixedInputStatTime: new Date("2024-03-09"),
-      fixedOutputStatTime: new Date("2024-03-10")
-    });
-    effects.clack.inputs = ["fix some bugs"]; // "what changed?"
-    await deploy(TEST_OPTIONS, effects);
-
-    effects.close();
-
-    // first is the upload spinner, second is the server processing spinner
-    assert.equal(effects.clack.spinners.length, 2, JSON.stringify(effects.clack.spinners, null, 2));
-    const events = effects.clack.spinners[0]._events.map((e) => {
-      const r: {method: string; message?: string} = {method: e.method};
-      if (e.message) r.message = stripColor(e.message);
-      return r;
-    });
-    assert.deepEqual(events, [
-      {method: "start"},
-      {method: "message", message: "Hashing local files"},
-      {method: "message", message: "Sending file manifest to server"},
-      {method: "message", message: "1 / 1 uploading index.html"},
-      {method: "stop", message: "1 uploaded, 4 unchanged, 5 total."}
-    ]);
   });
 });
 

--- a/test/mocks/clack.ts
+++ b/test/mocks/clack.ts
@@ -5,7 +5,6 @@ import type {ClackEffects} from "../../src/clack.js";
 export class TestClackEffects implements ClackEffects {
   static cancelSymbol = Symbol("cancel");
   inputs: any[] = [];
-  spinners: TestClackSpinner[] = [];
   intro() {}
   outro() {}
   note() {}
@@ -32,9 +31,11 @@ export class TestClackEffects implements ClackEffects {
     return this.inputs.shift();
   }
   spinner() {
-    const spinner = new TestClackSpinner();
-    this.spinners.push(spinner);
-    return spinner;
+    return {
+      start() {},
+      stop() {},
+      message() {}
+    };
   }
   log = new TestClackLogs();
   isCancel(value: unknown): value is symbol {
@@ -81,23 +82,5 @@ class TestClackLogs implements ClackLogs {
         .map((d) => d.message)
         .join("\n          * ")}`
     );
-  }
-}
-
-type ClackSpinnerEvent =
-  | {method: "start"; message?: string}
-  | {method: "stop"; message?: string; code?: number}
-  | {method: "message"; message?: string};
-
-class TestClackSpinner {
-  _events: ClackSpinnerEvent[] = [];
-  start(message?: string | undefined) {
-    this._events.push({method: "start", message});
-  }
-  stop(message?: string | undefined, code?: number) {
-    this._events.push({method: "stop", message, code});
-  }
-  message(message?: string | undefined) {
-    this._events.push({method: "message", message});
   }
 }


### PR DESCRIPTION
Reverts observablehq/framework#1278

We identified a problem on the server side with manifests, and so we can't enable this feature in Framework yet.