### PR TITLE
tidier build prompt

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -221,15 +221,19 @@ export async function deploy(
     const mostRecentSourceMtimeMs = await findMostRecentSourceMtimeMs(effects, config);
     const buildAge = Date.now() - leastRecentBuildMtimeMs;
     let initialValue = buildAge > BUILD_AGE_WARNING_MS;
-    let message = "";
     if (mostRecentSourceMtimeMs > leastRecentBuildMtimeMs) {
-      message += "Your source files have changed since the last time you built. ";
+      clack.log.warn(
+        wrapAnsi(
+          `Your source files have changed since you built ${formatAge(buildAge)}.`,
+          effects.outputColumns
+        )
+      );
       initialValue = true;
+    } else {
+      clack.log.info(wrapAnsi(`You built this project ${formatAge(buildAge)}.`, effects.outputColumns));
     }
-    message += `You built this project ${formatAge(buildAge)}. `;
-    message += "Would you like to build again before deploying?";
     const choice = await clack.confirm({
-      message,
+      message: "Would you like to build again before deploying?",
       initialValue,
       active: "Yes, build and then deploy",
       inactive: "No, deploy as is"

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -223,10 +223,7 @@ export async function deploy(
     let initialValue = buildAge > BUILD_AGE_WARNING_MS;
     if (mostRecentSourceMtimeMs > leastRecentBuildMtimeMs) {
       clack.log.warn(
-        wrapAnsi(
-          `Your source files have changed since you built ${formatAge(buildAge)}.`,
-          effects.outputColumns
-        )
+        wrapAnsi(`Your source files have changed since you built ${formatAge(buildAge)}.`, effects.outputColumns)
       );
       initialValue = true;
     } else {

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -777,7 +777,10 @@ describe("deploy", () => {
       fixedInputStatTime: new Date("2024-03-09"),
       fixedOutputStatTime: new Date("2024-03-10")
     });
-    await assert.rejects(() => deploy(deployOptions, effects), /out of inputs for select: You built this project/);
+    await assert.rejects(
+      () => deploy(deployOptions, effects),
+      /out of inputs for select: Would you like to build again/
+    );
     effects.close();
   });
 
@@ -794,7 +797,7 @@ describe("deploy", () => {
     });
     await assert.rejects(
       () => deploy(deployOptions, effects),
-      /out of inputs for select: Your source files have changed/
+      /out of inputs for select: Would you like to build again/
     );
     effects.close();
   });


### PR DESCRIPTION
Before:
<img width="824" alt="Screenshot 2024-04-26 at 11 31 03 AM" src="https://github.com/observablehq/framework/assets/230541/173931db-bdb3-441e-92d9-c29b24f0154d">

After, if the source files have changed since build:
<img width="740" alt="Screenshot 2024-04-26 at 11 27 58 AM" src="https://github.com/observablehq/framework/assets/230541/7180d81d-1cef-4431-a469-cf4a8662396e">

After, if the source files haven’t changed since build:
<img width="700" alt="Screenshot 2024-04-26 at 11 27 35 AM" src="https://github.com/observablehq/framework/assets/230541/88aac07c-36ec-43d5-95e1-f050477d7af2">
