### PR TITLE
page stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "cross-env": "^7.0.3",
     "cross-spawn": "^7.0.3",
     "d3-array": "^3.2.4",
+    "d3-hierarchy": "^3.1.2",
     "esbuild": "^0.20.1",
     "fast-array-diff": "^1.1.0",
     "gray-matter": "^4.0.3",

--- a/src/build.ts
+++ b/src/build.ts
@@ -21,7 +21,7 @@ import {bundleStyles, rollupClient} from "./rollup.js";
 import {searchIndex} from "./search.js";
 import {Telemetry} from "./telemetry.js";
 import {tree} from "./tree.js";
-import {faint, green, red, yellow} from "./tty.js";
+import {faint, green, magenta, red, yellow} from "./tty.js";
 
 export interface BuildOptions {
   config: Config;
@@ -278,9 +278,9 @@ export async function build(
       totalImportSize += await accumulateSize(resolvers.staticImports, resolvers.resolveImport, resolveOutput);
       effects.logger.log(
         `${faint(indent)}${name}${description} ${[
-          `${formatByteSizeColor(size, 12)}`,
-          `${formatByteSizeColor(totalImportSize, 12)}`,
-          `${formatByteSizeColor(totalFileSize, 12)}`
+          `${formatBytes(size, 12)}`,
+          `${formatBytes(totalImportSize, 12)}`,
+          `${formatBytes(totalFileSize, 12)}`
         ].join(" ")}`
       );
     } else {
@@ -315,15 +315,20 @@ async function accumulateSize(
   return size;
 }
 
-function formatByteSizeColor(size: number, length: number, locale: Intl.LocalesArgument = "en-US"): string {
+function formatBytes(size: number, length: number, locale: Intl.LocalesArgument = "en-US"): string {
   let color: (text: string) => string;
-  let s: string;
-  if (size < 1e3) (s = "<1 kB"), (color = faint);
-  else if (size < 1e6) (s = (size / 1e3).toLocaleString(locale, {maximumFractionDigits: 0}) + " kB"), (color = green);
-  else
-    (s = (size / 1e6).toLocaleString(locale, {minimumFractionDigits: 3, maximumFractionDigits: 3}) + " MB"),
-      (color = size < 50e6 ? yellow : red);
-  return color(s.padStart(length));
+  let text: string;
+  if (size < 1e3) {
+    text = "<1 kB";
+    color = faint;
+  } else if (size < 1e6) {
+    text = (size / 1e3).toLocaleString(locale, {maximumFractionDigits: 0}) + " kB";
+    color = green;
+  } else {
+    text = (size / 1e6).toLocaleString(locale, {minimumFractionDigits: 3, maximumFractionDigits: 3}) + " MB";
+    color = size < 10e6 ? yellow : size < 50e6 ? magenta : red;
+  }
+  return color(text.padStart(length));
 }
 
 export class FileBuildEffects implements BuildEffects {

--- a/src/build.ts
+++ b/src/build.ts
@@ -20,6 +20,7 @@ import {resolveImportPath, resolveStylesheetPath} from "./resolvers.js";
 import {bundleStyles, rollupClient} from "./rollup.js";
 import {searchIndex} from "./search.js";
 import {Telemetry} from "./telemetry.js";
+import {tree} from "./tree.js";
 import {faint, yellow} from "./tty.js";
 
 export interface BuildOptions {
@@ -261,37 +262,50 @@ export async function build(
   }
 
   // Log page sizes. TODO Log individual files that are larger than 1MB?
-  for (const [sourceFile, {resolvers}] of pages) {
-    const outputPath = join(dirname(sourceFile), basename(sourceFile, ".md") + ".html");
-    const path = join("/", dirname(sourceFile), basename(sourceFile, ".md"));
-    const size = (await stat(join(config.output, outputPath))).size;
-    let totalFileSize = 0;
-    let totalImportSize = 0;
-    for (const file of [...resolvers.files, ...resolvers.assets]) {
-      const fileResolution = resolvers.resolveFile(file);
-      if (isAssetPath(fileResolution)) {
-        const filePath = resolvePath(path, fileResolution);
-        const fileSize = (await stat(join(config.output, filePath))).size;
-        totalFileSize += fileSize;
-        effects.logger.log(`${outputPath} → file ${filePath} ${yellow(`${fileSize}`)} bytes`);
+  for (const [indent, name, sourceFile, data] of tree(pages)) {
+    if (data) {
+      const {resolvers} = data;
+      const outputPath = join(dirname(sourceFile), basename(sourceFile, ".md") + ".html");
+      const path = join("/", dirname(sourceFile), basename(sourceFile, ".md"));
+      const size = (await stat(join(config.output, outputPath))).size;
+      let totalFileSize = 0;
+      let totalImportSize = 0;
+      for (const file of [...resolvers.files, ...resolvers.assets]) {
+        const fileResolution = resolvers.resolveFile(file);
+        if (isAssetPath(fileResolution)) {
+          const filePath = resolvePath(path, fileResolution);
+          try {
+            const fileSize = (await stat(join(config.output, filePath))).size;
+            totalFileSize += fileSize;
+            // effects.logger.log(`${outputPath} → file ${filePath} ${yellow(`${fileSize}`)} bytes`);
+          } catch {
+            // ignore missing file
+          }
+        }
       }
-    }
-    for (const staticImport of resolvers.staticImports) {
-      const staticImportResolution = resolvers.resolveImport(staticImport);
-      if (isAssetPath(staticImportResolution)) {
-        const staticImportPath = resolvePath(path, staticImportResolution);
-        const staticImportSize = (await stat(join(config.output, staticImportPath))).size;
-        totalImportSize += staticImportSize;
-        effects.logger.log(`${outputPath} → import ${staticImportPath} ${yellow(`${staticImportSize}`)} bytes`);
+      for (const staticImport of resolvers.staticImports) {
+        const staticImportResolution = resolvers.resolveImport(staticImport);
+        if (isAssetPath(staticImportResolution)) {
+          try {
+            const staticImportPath = resolvePath(path, staticImportResolution);
+            const staticImportSize = (await stat(join(config.output, staticImportPath))).size;
+            totalImportSize += staticImportSize;
+            // effects.logger.log(`${outputPath} → import ${staticImportPath} ${yellow(`${staticImportSize}`)} bytes`);
+          } catch {
+            // ignore missing file
+          }
+        }
       }
+      effects.logger.log(
+        `${faint(indent)}${name.replace(/\.md$/, "")} ${[
+          `${yellow(`${size}`)} bytes page`,
+          `${yellow(`${totalFileSize}`)} bytes files`,
+          `${yellow(`${totalImportSize}`)} bytes imports`
+        ].join("; ")}`
+      );
+    } else {
+      effects.logger.log(`${faint(indent)}${name}`);
     }
-    effects.logger.log(
-      `${outputPath} ${[
-        `${yellow(`${size}`)} bytes page`,
-        `${yellow(`${totalFileSize}`)} bytes files`,
-        `${yellow(`${totalImportSize}`)} bytes imports`
-      ].join("; ")}`
-    );
   }
 
   Telemetry.record({event: "build", step: "finish", pageCount});

--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -9,6 +9,7 @@ import JSZip from "jszip";
 import {extract} from "tar-stream";
 import {maybeStat, prepareOutput} from "./files.js";
 import {FileWatchers} from "./fileWatchers.js";
+import {formatByteSize} from "./format.js";
 import {getFileInfo} from "./javascript/module.js";
 import type {Logger, Writer} from "./logger.js";
 import {cyan, faint, green, red, yellow} from "./tty.js";
@@ -267,8 +268,9 @@ export abstract class Loader {
     const start = performance.now();
     command.then(
       (path) => {
+        const {size} = statSync(join(this.root, path));
         effects.logger.log(
-          `${green("success")} ${cyan(formatSize(statSync(join(this.root, path)).size))} ${faint(
+          `${green("success")} ${size ? cyan(formatByteSize(size)) : yellow("empty output")} ${faint(
             `in ${formatElapsed(start)}`
           )}`
         );
@@ -394,12 +396,6 @@ const extractors = [
   [".tar.gz", TarGzExtractor],
   [".tgz", TarGzExtractor]
 ] as const;
-
-function formatSize(size: number): string {
-  if (!size) return yellow("empty output");
-  const e = Math.floor(Math.log(size) / Math.log(1024));
-  return `${+(size / 1024 ** e).toFixed(2)} ${["bytes", "KiB", "MiB", "GiB", "TiB"][e]}`;
-}
 
 function formatElapsed(start: number): string {
   const elapsed = performance.now() - start;

--- a/src/format.ts
+++ b/src/format.ts
@@ -14,14 +14,16 @@ function pad(number: number, length: number): string {
   return String(number).padStart(length, "0");
 }
 
-export function formatByteSize(n: number): string {
-  const suffixes = ["bytes", "KB", "MB", "GB"];
-  for (const suffix of suffixes) {
-    if (n < 1300) {
-      if (suffix === "bytes") return `${n} ${suffix}`;
-      return `${n > 100 ? n.toFixed(0) : n.toFixed(1)} ${suffix}`;
+export function formatByteSize(x: number, locale: Intl.LocalesArgument = "en-US"): string {
+  const formatOptions = {maximumSignificantDigits: 3, maximumFractionDigits: 2};
+  for (const [k, suffix] of [
+    [1e9, " GB"],
+    [1e6, " MB"],
+    [1e3, " kB"]
+  ] as const) {
+    if (Math.round((x / k) * 1e3) >= 1e3) {
+      return (x / k).toLocaleString(locale, formatOptions) + suffix;
     }
-    n /= 1000;
   }
-  return `${n.toFixed(1)} TB`;
+  return x.toLocaleString(locale, formatOptions) + " B";
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,0 +1,52 @@
+import {ascending, max} from "d3-array";
+import {stratify} from "d3-hierarchy";
+
+export type TreeItem<T> = [path: string, value?: T];
+
+interface TreeNode<T> {
+  data?: TreeItem<T>;
+  parent?: TreeNode<T>;
+  children?: TreeNode<T>[];
+  height: number;
+  depth: number;
+  id: string;
+}
+
+export function tree<T>(items: Iterable<TreeItem<T>>): [indent: string, name: string, path: string, value?: T][] {
+  const lines: [indent: string, name: string, node: TreeNode<T>][] = [];
+  stratify()
+    .path(([path]) => path)([...items, ["/"]]) // add root to avoid implicit truncation
+    .sort(treeOrder)
+    .eachBefore((node: TreeNode<T>) => {
+      let p = node;
+      let indent = "";
+      if (p.parent) {
+        indent = (hasFollowingSibling(p) ? "├── " : "└── ") + indent;
+        while ((p = p.parent!).parent) {
+          indent = (hasFollowingSibling(p) ? "│   " : "    ") + indent;
+        }
+      }
+      lines.push([indent, node.id.split("/").pop() || ".", node]);
+    });
+  const width = (max(lines, ([indent, name]) => indent.length + stringLength(name)) || 0) + 1;
+  return lines.map(([indent, name, node]) => [indent, stringPad(name, width - indent.length), node.id, node.data?.[1]]);
+}
+
+/** Like string.padEnd, but correctly handles graphemes via Intl.Segmenter. */
+function stringPad(string: string, length: number): string {
+  const n = length - stringLength(string);
+  return n > 0 ? string + " ".repeat(n) : string;
+}
+
+/** Counts the number of graphemes in the specified string. */
+function stringLength(string: string): number {
+  return [...new Intl.Segmenter().segment(string)].length;
+}
+
+function hasFollowingSibling(node: TreeNode<unknown>): boolean {
+  return node.parent != null && node.parent.children!.indexOf(node) < node.parent.children!.length - 1;
+}
+
+function treeOrder(a: TreeNode<unknown>, b: TreeNode<unknown>): number {
+  return ascending(!a.children, !b.children) || ascending(a.id, b.id);
+}

--- a/test/format-test.ts
+++ b/test/format-test.ts
@@ -24,19 +24,22 @@ describe("formatLocaleDate", () => {
 
 describe("formatByteSize", () => {
   it("returns a human-readable byte size", () => {
-    assert.strictEqual(formatByteSize(0), "0 bytes");
-    assert.strictEqual(formatByteSize(500), "500 bytes");
-    assert.strictEqual(formatByteSize(1200), "1200 bytes");
-    assert.strictEqual(formatByteSize(1_500), "1.5 KB");
-    assert.strictEqual(formatByteSize(3_000), "3.0 KB");
-    assert.strictEqual(formatByteSize(400_000), "400 KB");
-    assert.strictEqual(formatByteSize(50_000_000), "50.0 MB");
-    assert.strictEqual(formatByteSize(1_250_000_000), "1250 MB");
+    assert.strictEqual(formatByteSize(0), "0 B");
+    assert.strictEqual(formatByteSize(500), "500 B");
+    assert.strictEqual(formatByteSize(999), "999 B");
+    assert.strictEqual(formatByteSize(999.49), "999 B");
+    assert.strictEqual(formatByteSize(999.51), "1 kB");
+    assert.strictEqual(formatByteSize(1200), "1.2 kB");
+    assert.strictEqual(formatByteSize(1_500), "1.5 kB");
+    assert.strictEqual(formatByteSize(3_000), "3 kB");
+    assert.strictEqual(formatByteSize(400_000), "400 kB");
+    assert.strictEqual(formatByteSize(50_000_000), "50 MB");
+    assert.strictEqual(formatByteSize(1_250_000_000), "1.25 GB");
     assert.strictEqual(formatByteSize(1_500_000_000), "1.5 GB");
-    assert.strictEqual(formatByteSize(3_000_000_000), "3.0 GB");
+    assert.strictEqual(formatByteSize(3_000_000_000), "3 GB");
     assert.strictEqual(formatByteSize(600_000_000_000), "600 GB");
     assert.strictEqual(formatByteSize(60_598_160), "60.6 MB");
     assert.strictEqual(formatByteSize(60_598_160_000), "60.6 GB");
-    assert.strictEqual(formatByteSize(60_598_160_000_000), "60.6 TB");
+    assert.strictEqual(formatByteSize(60_598_160_000_000), "60,600 GB");
   });
 });

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -8,7 +8,7 @@ import {isEnoent} from "../src/error.js";
 import type {MarkdownPage} from "../src/markdown.js";
 import {makeLinkNormalizer, parseMarkdown} from "../src/markdown.js";
 
-const {md} = normalizeConfig();
+const {md} = normalizeConfig({root: "docs"});
 
 describe("parseMarkdown(input)", () => {
   const inputRoot = "test/input";

--- a/test/tree-test.ts
+++ b/test/tree-test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert";
+import {tree} from "../src/tree.js";
+
+function stree(items: string[]): string[] {
+  return tree(items.map((item) => [item])).map(([indent, name]) => indent + name);
+}
+
+describe("tree(items, options)", () => {
+  it("creates implicit internal nodes", () => {
+    assert.deepStrictEqual(stree(["/a/b/c/d.md"]), [
+      ".                    ",
+      "└── a                ",
+      "    └── b            ",
+      "        └── c        ",
+      "            └── d.md "
+    ]);
+  });
+  it("handles multiple leaves", () => {
+    assert.deepStrictEqual(stree(["/a/b/c/a.md", "/a/b/c/b.md", "/a/b/c/c.md", "/a/b/c/d.md"]), [
+      ".                    ",
+      "└── a                ",
+      "    └── b            ",
+      "        └── c        ",
+      "            ├── a.md ",
+      "            ├── b.md ",
+      "            ├── c.md ",
+      "            └── d.md "
+    ]);
+  });
+  it("handles leaves at different levels", () => {
+    assert.deepStrictEqual(stree(["/a.md", "/a/b.md", "/a/b/c.md", "/a/b/c/d.md"]), [
+      ".                    ",
+      "├── a                ",
+      "│   ├── b            ",
+      "│   │   ├── c        ",
+      "│   │   │   └── d.md ",
+      "│   │   └── c.md     ",
+      "│   └── b.md         ",
+      "└── a.md             "
+    ]);
+  });
+  it("sorts nodes", () => {
+    assert.deepStrictEqual(stree(["/d.md", "/b.md", "/c.md", "/a.md"]), [
+      ".        ",
+      "├── a.md ",
+      "├── b.md ",
+      "├── c.md ",
+      "└── d.md "
+    ]);
+  });
+  it("sorts folders before files", () => {
+    assert.deepStrictEqual(stree(["/d/a.md", "/b.md", "/c.md", "/a.md"]), [
+      ".            ",
+      "├── d        ",
+      "│   └── a.md ",
+      "├── a.md     ",
+      "├── b.md     ",
+      "└── c.md     "
+    ]);
+  });
+  it("sorts nested folders", () => {
+    assert.deepStrictEqual(stree(["/b/b.md", "/a/b.md", "/b/a.md", "/a/a.md"]), [
+      ".            ",
+      "├── a        ",
+      "│   ├── a.md ",
+      "│   └── b.md ",
+      "└── b        ",
+      "    ├── a.md ",
+      "    └── b.md "
+    ]);
+  });
+  it("computes string width based on graphemes", () => {
+    assert.deepStrictEqual(stree(["ascii.md", "💩.md", "👩🏾‍❤️‍👨🏻.md"]), [
+      ".            ",
+      "├── ascii.md ",
+      "├── 👩🏾‍❤️‍👨🏻.md     ",
+      "└── 💩.md     "
+    ]);
+  });
+});

--- a/test/tree-test.ts
+++ b/test/tree-test.ts
@@ -2,79 +2,91 @@ import assert from "node:assert";
 import {tree} from "../src/tree.js";
 
 function stree(items: string[]): string[] {
-  return tree(items.map((item) => [item])).map(([indent, name]) => indent + name);
+  return tree(items.map((item) => [item, null])).map(([indent, name, description]) => indent + name + description);
 }
 
 describe("tree(items, options)", () => {
   it("creates implicit internal nodes", () => {
-    assert.deepStrictEqual(stree(["/a/b/c/d.md"]), [
-      ".                    ",
-      "└── a                ",
-      "    └── b            ",
-      "        └── c        ",
-      "            └── d.md "
+    assert.deepStrictEqual(stree(["/a/b/c/d"]), [
+      "┌ (1 page)             ",
+      "└── a (1 page)         ",
+      "    └── b (1 page)     ",
+      "        └── c (1 page) ",
+      "            └── d      "
+    ]);
+  });
+  it("removes the .md extension, if present", () => {
+    assert.deepStrictEqual(stree(["/a/b/c/a.md", "/a/b/c/b.md", "/a/b/c/c.md", "/a/b/c/d.md"]), [
+      "┌ (4 pages)             ",
+      "└── a (4 pages)         ",
+      "    └── b (4 pages)     ",
+      "        └── c (4 pages) ",
+      "            ├── a       ",
+      "            ├── b       ",
+      "            ├── c       ",
+      "            └── d       "
     ]);
   });
   it("handles multiple leaves", () => {
-    assert.deepStrictEqual(stree(["/a/b/c/a.md", "/a/b/c/b.md", "/a/b/c/c.md", "/a/b/c/d.md"]), [
-      ".                    ",
-      "└── a                ",
-      "    └── b            ",
-      "        └── c        ",
-      "            ├── a.md ",
-      "            ├── b.md ",
-      "            ├── c.md ",
-      "            └── d.md "
+    assert.deepStrictEqual(stree(["/a/b/c/a", "/a/b/c/b", "/a/b/c/c", "/a/b/c/d"]), [
+      "┌ (4 pages)             ",
+      "└── a (4 pages)         ",
+      "    └── b (4 pages)     ",
+      "        └── c (4 pages) ",
+      "            ├── a       ",
+      "            ├── b       ",
+      "            ├── c       ",
+      "            └── d       "
     ]);
   });
   it("handles leaves at different levels", () => {
-    assert.deepStrictEqual(stree(["/a.md", "/a/b.md", "/a/b/c.md", "/a/b/c/d.md"]), [
-      ".                    ",
-      "├── a                ",
-      "│   ├── b            ",
-      "│   │   ├── c        ",
-      "│   │   │   └── d.md ",
-      "│   │   └── c.md     ",
-      "│   └── b.md         ",
-      "└── a.md             "
+    assert.deepStrictEqual(stree(["/a", "/a/b", "/a/b/c", "/a/b/c/d"]), [
+      "┌ (4 pages)            ",
+      "├── a (3 pages)        ",
+      "│   ├── b (2 pages)    ",
+      "│   │   ├── c (1 page) ",
+      "│   │   │   └── d      ",
+      "│   │   └── c          ",
+      "│   └── b              ",
+      "└── a                  "
     ]);
   });
   it("sorts nodes", () => {
-    assert.deepStrictEqual(stree(["/d.md", "/b.md", "/c.md", "/a.md"]), [
-      ".        ",
-      "├── a.md ",
-      "├── b.md ",
-      "├── c.md ",
-      "└── d.md "
+    assert.deepStrictEqual(stree(["/d", "/b", "/c", "/a"]), [
+      "┌ (4 pages) ",
+      "├── a       ",
+      "├── b       ",
+      "├── c       ",
+      "└── d       "
     ]);
   });
   it("sorts folders before files", () => {
-    assert.deepStrictEqual(stree(["/d/a.md", "/b.md", "/c.md", "/a.md"]), [
-      ".            ",
-      "├── d        ",
-      "│   └── a.md ",
-      "├── a.md     ",
-      "├── b.md     ",
-      "└── c.md     "
+    assert.deepStrictEqual(stree(["/d/a", "/b", "/c", "/a"]), [
+      "┌ (4 pages)    ",
+      "├── d (1 page) ",
+      "│   └── a      ",
+      "├── a          ",
+      "├── b          ",
+      "└── c          "
     ]);
   });
   it("sorts nested folders", () => {
-    assert.deepStrictEqual(stree(["/b/b.md", "/a/b.md", "/b/a.md", "/a/a.md"]), [
-      ".            ",
-      "├── a        ",
-      "│   ├── a.md ",
-      "│   └── b.md ",
-      "└── b        ",
-      "    ├── a.md ",
-      "    └── b.md "
+    assert.deepStrictEqual(stree(["/b/b", "/a/b", "/b/a", "/a/a"]), [
+      "┌ (4 pages)     ",
+      "├── a (2 pages) ",
+      "│   ├── a       ",
+      "│   └── b       ",
+      "└── b (2 pages) ",
+      "    ├── a       ",
+      "    └── b       "
     ]);
   });
   it("computes string width based on graphemes", () => {
-    assert.deepStrictEqual(stree(["ascii.md", "💩.md", "👩🏾‍❤️‍👨🏻.md"]), [
-      ".            ",
-      "├── ascii.md ",
-      "├── 👩🏾‍❤️‍👨🏻.md     ",
-      "└── 💩.md     "
+    assert.deepStrictEqual(stree(["ascii", "💩", "👩🏾‍❤️‍👨🏻"]), [
+      "┌ (3 pages) ",
+      "├── ascii   ",
+      "├── 👩🏾‍❤️‍👨🏻       ",
+      "└── 💩       "
     ]);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,11 @@ d3-format@^3.1.0:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
 
+d3-hierarchy@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
 d3-require@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-1.3.0.tgz#2b97f5e2ebcb64ac0c63c11f30056aea1c74f0ec"


### PR DESCRIPTION
Fixes #1243. Supersedes #320.

<img width="891" alt="Screenshot 2024-04-28 at 1 22 16 PM" src="https://github.com/observablehq/framework/assets/230541/c5467a41-fd2f-483f-83e1-a38e267d29f2">

I find it a little hard to read the outputs since the number of fractional digits changes even within units, and the decimal points aren’t aligned. So, I’d like to make that a bit better. I’m also not counting stylesheets, but those should probably be counted too? And is it confusing that “imports” only refers to JavaScript (when you can also import CSS)?