### PR TITLE
link headings with id

### DIFF
--- a/src/client/toc.ts
+++ b/src/client/toc.ts
@@ -2,9 +2,8 @@ const toc = document.querySelector<HTMLElement>("#observablehq-toc");
 if (toc) {
   const highlight = toc.appendChild(document.createElement("div"));
   highlight.classList.add("observablehq-secondary-link-highlight");
-  const headings = Array.from(document.querySelector("#observablehq-main")!.querySelectorAll(toc.dataset.selector!))
-    .filter((e) => e.querySelector("a.observablehq-header-anchor"))
-    .reverse();
+  const main = document.querySelector("#observablehq-main")!;
+  const headings = Array.from(main.querySelectorAll(toc.dataset.selector!)).reverse();
   const links = toc.querySelectorAll<HTMLElement>(".observablehq-secondary-link");
   const relink = (): HTMLElement | undefined => {
     for (const link of links) {
@@ -13,7 +12,7 @@ if (toc) {
     // If there’s a location.hash, highlight that if it’s at the top of the viewport.
     if (location.hash) {
       for (const heading of headings) {
-        const hash = heading.querySelector<HTMLAnchorElement>("a[href]")?.hash;
+        const hash = `#${heading.id}`;
         if (hash === location.hash) {
           const top = heading.getBoundingClientRect().top;
           if (0 < top && top < 40) {

--- a/src/client/toc.ts
+++ b/src/client/toc.ts
@@ -12,7 +12,7 @@ if (toc) {
     // If there’s a location.hash, highlight that if it’s at the top of the viewport.
     if (location.hash) {
       for (const heading of headings) {
-        const hash = `#${heading.id}`;
+        const hash = encodeURI(`#${heading.id}`);
         if (hash === location.hash) {
           const top = heading.getBoundingClientRect().top;
           if (0 < top && top < 40) {

--- a/src/html.ts
+++ b/src/html.ts
@@ -172,6 +172,15 @@ export function rewriteHtml(
     code.innerHTML = html;
   }
 
+  // Wrap <h2 id> etc. elements in <a> tags for linking.
+  for (const h of document.querySelectorAll<HTMLHeadingElement>("h1[id], h2[id], h3[id], h4[id]")) {
+    const a = document.createElement("a");
+    a.className = "observablehq-header-anchor";
+    a.href = `#${h.id}`;
+    a.append(...h.childNodes);
+    h.append(a);
+  }
+
   return document.body.innerHTML;
 }
 

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -322,7 +322,7 @@ export function createMarkdownIt({
 } = {}): MarkdownIt {
   const md = MarkdownIt({html: true, linkify, typographer, quotes});
   if (linkify) md.linkify.set({fuzzyLink: false, fuzzyEmail: false});
-  md.use(MarkdownItAnchor, {permalink: MarkdownItAnchor.permalink.headerLink({class: "observablehq-header-anchor"})});
+  md.use(MarkdownItAnchor);
   md.inline.ruler.push("placeholder", transformPlaceholderInline);
   md.core.ruler.before("linkify", "placeholder", transformPlaceholderCore);
   md.renderer.rules.placeholder = makePlaceholderRenderer();

--- a/src/render.ts
+++ b/src/render.ts
@@ -177,12 +177,12 @@ interface Header {
   href: string;
 }
 
-const tocSelector = "h1:not(:first-of-type), h2:first-child, :not(h1) + h2";
+const tocSelector = "h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]";
 
 function findHeaders(page: MarkdownPage): Header[] {
   return Array.from(parseHtml(page.body).document.querySelectorAll(tocSelector))
-    .map((node) => ({label: node.textContent, href: node.firstElementChild?.getAttribute("href")}))
-    .filter((d): d is Header => !!d.label && !!d.href);
+    .map((node) => ({label: node.textContent, href: `#${node.id}`}))
+    .filter((d): d is Header => !!d.label);
 }
 
 function renderToc(headers: Header[], label: string): Html {

--- a/test/output/build/404/404.html
+++ b/test/output/build/404/404.html
@@ -24,7 +24,7 @@ if (location.pathname.endsWith("/")) {
 import "./_observablehq/client.js";
 
 </script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/archives.posix/tar.html
+++ b/test/output/build/archives.posix/tar.html
@@ -79,7 +79,7 @@ await FileAttachment("./dynamic-tar-gz/does-not-exist.txt").text()
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/archives.posix/zip.html
+++ b/test/output/build/archives.posix/zip.html
@@ -62,7 +62,7 @@ define({id: "f9a513d8", body: () => {
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/archives.win32/tar.html
+++ b/test/output/build/archives.win32/tar.html
@@ -51,7 +51,7 @@ await FileAttachment("./static-tar/does-not-exist.txt").text()
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/archives.win32/zip.html
+++ b/test/output/build/archives.win32/zip.html
@@ -44,7 +44,7 @@ await FileAttachment("./static/not-found.txt").text()
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/config/closed/page.html
+++ b/test/output/build/config/closed/page.html
@@ -35,7 +35,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/config/index.html
+++ b/test/output/build/config/index.html
@@ -35,7 +35,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/config/one.html
+++ b/test/output/build/config/one.html
@@ -35,7 +35,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/config/sub/two.html
+++ b/test/output/build/config/sub/two.html
@@ -35,7 +35,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/config/toc-override.html
+++ b/test/output/build/config/toc-override.html
@@ -35,7 +35,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 <div>dollar&amp;pound</div>
 <ol>

--- a/test/output/build/config/toc.html
+++ b/test/output/build/config/toc.html
@@ -35,7 +35,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 <div>On this page</div>
 <ol>

--- a/test/output/build/draft/index.html
+++ b/test/output/build/draft/index.html
@@ -27,7 +27,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/draft/page-published.html
+++ b/test/output/build/draft/page-published.html
@@ -27,7 +27,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/fetches/foo.html
+++ b/test/output/build/fetches/foo.html
@@ -41,7 +41,7 @@ return {fooJsonData,fooCsvData};
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/fetches/top.html
+++ b/test/output/build/fetches/top.html
@@ -46,7 +46,7 @@ return {fooCsvData,fooJsonData,topCsvData,topJsonData};
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/files/files.html
+++ b/test/output/build/files/files.html
@@ -58,7 +58,7 @@ FileAttachment("./unknown-mime-extension.really")
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/files/subsection/subfiles.html
+++ b/test/output/build/files/subsection/subfiles.html
@@ -44,7 +44,7 @@ FileAttachment("./file-sub.csv")
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/imports/foo/foo.html
+++ b/test/output/build/imports/foo/foo.html
@@ -52,7 +52,7 @@ return {foobar};
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/imports/script.html
+++ b/test/output/build/imports/script.html
@@ -29,7 +29,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/missing-file/index.html
+++ b/test/output/build/missing-file/index.html
@@ -24,7 +24,7 @@ FileAttachment("./does-not-exist.txt")
 }});
 
 </script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/missing-import/index.html
+++ b/test/output/build/missing-import/index.html
@@ -21,7 +21,7 @@ import("./does-not-exist.js")
 }});
 
 </script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/multi/index.html
+++ b/test/output/build/multi/index.html
@@ -48,7 +48,7 @@ return {f2};
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/multi/subsection/index.html
+++ b/test/output/build/multi/subsection/index.html
@@ -27,7 +27,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/index.html
+++ b/test/output/build/pager/index.html
@@ -43,7 +43,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/index.html
+++ b/test/output/build/pager/sub/index.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page0.html
+++ b/test/output/build/pager/sub/page0.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page1..10.html
+++ b/test/output/build/pager/sub/page1..10.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page1.html
+++ b/test/output/build/pager/sub/page1.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page2.html
+++ b/test/output/build/pager/sub/page2.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page3.html
+++ b/test/output/build/pager/sub/page3.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page4.html
+++ b/test/output/build/pager/sub/page4.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page5.html
+++ b/test/output/build/pager/sub/page5.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page6.html
+++ b/test/output/build/pager/sub/page6.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page7.html
+++ b/test/output/build/pager/sub/page7.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/pager/sub/page8.html
+++ b/test/output/build/pager/sub/page8.html
@@ -43,7 +43,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/scripts/index.html
+++ b/test/output/build/scripts/index.html
@@ -29,7 +29,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/scripts/sub/index.html
+++ b/test/output/build/scripts/sub/index.html
@@ -29,7 +29,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/search-public/page1.html
+++ b/test/output/build/search-public/page1.html
@@ -32,7 +32,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/search-public/page3.html
+++ b/test/output/build/search-public/page3.html
@@ -32,7 +32,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/search-public/sub/page2.html
+++ b/test/output/build/search-public/sub/page2.html
@@ -32,7 +32,7 @@ import "../_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/simple-public/index.html
+++ b/test/output/build/simple-public/index.html
@@ -15,7 +15,7 @@
 import "./_observablehq/client.js";
 
 </script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/simple/simple.html
+++ b/test/output/build/simple/simple.html
@@ -39,7 +39,7 @@ display(result);
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/space-page/a space.html
+++ b/test/output/build/space-page/a space.html
@@ -27,7 +27,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/space-page/index.html
+++ b/test/output/build/space-page/index.html
@@ -27,7 +27,7 @@ import "./_observablehq/client.js";
   </ol>
 </nav>
 <script>{/* redacted init script */}</script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 </nav>
 </aside>

--- a/test/output/build/subtitle/index.html
+++ b/test/output/build/subtitle/index.html
@@ -15,7 +15,7 @@
 import "./_observablehq/client.js";
 
 </script>
-<aside id="observablehq-toc" data-selector="h1:not(:first-of-type), h2:first-child, :not(h1) + h2">
+<aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">
 <nav>
 <div>Contents</div>
 <ol>

--- a/test/output/embedded-expression.html
+++ b/test/output/embedded-expression.html
@@ -1,2 +1,2 @@
-<h1 id="embedded-expression" tabindex="-1"><a class="observablehq-header-anchor" href="#embedded-expression">Embedded expression</a></h1>
+<h1 id="embedded-expression" tabindex="-1">Embedded expression</h1>
 <p>One plus two is <span id="cell-6212702c" class="observablehq--loading"></span>.</p>

--- a/test/output/fenced-code-options.html
+++ b/test/output/fenced-code-options.html
@@ -1,4 +1,4 @@
-<h1 id="fenced-code-options" tabindex="-1"><a class="observablehq-header-anchor" href="#fenced-code-options">Fenced code options</a></h1>
+<h1 id="fenced-code-options" tabindex="-1">Fenced code options</h1>
 <div id="cell-fe9e095e" class="observablehq observablehq--block"></div>
 <pre><code class="language-js">function add(a, b) {
   return a + b;

--- a/test/output/fenced-code.html
+++ b/test/output/fenced-code.html
@@ -1,4 +1,4 @@
-<h1 id="fenced-code" tabindex="-1"><a class="observablehq-header-anchor" href="#fenced-code">Fenced code</a></h1>
+<h1 id="fenced-code" tabindex="-1">Fenced code</h1>
 <div id="cell-fe9e095e" class="observablehq observablehq--block"></div>
 <pre><code class="language-js">function add(a, b) {
   return a + b;

--- a/test/output/fetch-parent-dir.html
+++ b/test/output/fetch-parent-dir.html
@@ -1,4 +1,4 @@
-<h1 id="parent-dir" tabindex="-1"><a class="observablehq-header-anchor" href="#parent-dir">Parent dir</a></h1>
+<h1 id="parent-dir" tabindex="-1">Parent dir</h1>
 <p>Trying to fetch from the parent directory should fail.</p>
 <div class="observablehq observablehq--block">
   <div class="observablehq--inspect observablehq--error">SyntaxError: non-local file path: ../NOENT.md (1:14)</div>

--- a/test/output/heading-expression.html
+++ b/test/output/heading-expression.html
@@ -1,1 +1,1 @@
-<h1 id="" tabindex="-1"><a class="observablehq-header-anchor" href="#"><span id="cell-6212702c" class="observablehq--loading"></span></a></h1>
+<h1 id="" tabindex="-1"><span id="cell-6212702c" class="observablehq--loading"></span></h1>

--- a/test/output/hello-world.html
+++ b/test/output/hello-world.html
@@ -1,2 +1,2 @@
-<h1 id="hello%2C-world!" tabindex="-1"><a class="observablehq-header-anchor" href="#hello%2C-world!">Hello, world!</a></h1>
+<h1 id="hello%2C-world!" tabindex="-1">Hello, world!</h1>
 <p>This is a test.</p>

--- a/test/output/linkify.html
+++ b/test/output/linkify.html
@@ -1,4 +1,4 @@
-<h1 id="linkify" tabindex="-1"><a class="observablehq-header-anchor" href="#linkify">Linkify</a></h1>
+<h1 id="linkify" tabindex="-1">Linkify</h1>
 <p><a href="https://observablehq.com/">https://observablehq.com/</a> is a link to <a href="https://observablehq.com">https://observablehq.com</a>.</p>
 <p><a href="mailto:support@observablehq.com">mailto:support@observablehq.com</a> is a link too.</p>
 <p>Observablehq.com and support@observablehq.com are not links, since by default we disable fuzzy links.</p>

--- a/test/output/local-fetch.html
+++ b/test/output/local-fetch.html
@@ -1,2 +1,2 @@
-<h1 id="local-fetch" tabindex="-1"><a class="observablehq-header-anchor" href="#local-fetch">Local fetch</a></h1>
+<h1 id="local-fetch" tabindex="-1">Local fetch</h1>
 <div id="cell-9c4f4e4f" class="observablehq observablehq--block observablehq--loading"></div>

--- a/test/output/malformed-block.html
+++ b/test/output/malformed-block.html
@@ -1,4 +1,4 @@
-<h1 id="malformed-block" tabindex="-1"><a class="observablehq-header-anchor" href="#malformed-block">Malformed block</a></h1>
+<h1 id="malformed-block" tabindex="-1">Malformed block</h1>
 <div>
   <div>content</div>
 </div>

--- a/test/output/markdown-in-html.html
+++ b/test/output/markdown-in-html.html
@@ -1,4 +1,4 @@
-<h1 id="markdown-in-html" tabindex="-1"><a class="observablehq-header-anchor" href="#markdown-in-html">Markdown in HTML</a></h1>
+<h1 id="markdown-in-html" tabindex="-1">Markdown in HTML</h1>
 <div>
   # Hello
 </div>

--- a/test/output/script-expression.html
+++ b/test/output/script-expression.html
@@ -1,4 +1,4 @@
-<h1 id="script-expression" tabindex="-1"><a class="observablehq-header-anchor" href="#script-expression">Script expression</a></h1>
+<h1 id="script-expression" tabindex="-1">Script expression</h1>
 <script type="module">
 
 const subject = "world";

--- a/test/output/tex-expression.html
+++ b/test/output/tex-expression.html
@@ -1,2 +1,2 @@
-<h1 id="hello%2C" tabindex="-1"><a class="observablehq-header-anchor" href="#hello%2C">Hello, <span id="cell-16447e3a" class="observablehq--loading"></span></a></h1>
+<h1 id="hello%2C" tabindex="-1">Hello, <span id="cell-16447e3a" class="observablehq--loading"></span></h1>
 <p>My favorite equation is <span id="cell-828eccc1" class="observablehq--loading"></span>.</p>

--- a/test/output/wellformed-block.html
+++ b/test/output/wellformed-block.html
@@ -1,4 +1,4 @@
-<h1 id="well-formed-block" tabindex="-1"><a class="observablehq-header-anchor" href="#well-formed-block">Well-formed block</a></h1>
+<h1 id="well-formed-block" tabindex="-1">Well-formed block</h1>
 <div>
   <div>content</div>
 </div>

--- a/test/output/yaml-frontmatter.html
+++ b/test/output/yaml-frontmatter.html
@@ -1,2 +1,2 @@
-<h1 id="yaml-frontmatter" tabindex="-1"><a class="observablehq-header-anchor" href="#yaml-frontmatter">YAML frontmatter</a></h1>
+<h1 id="yaml-frontmatter" tabindex="-1">YAML frontmatter</h1>
 <p>This page has some YAML configuration.</p>


### PR DESCRIPTION
Fixes #1292. Instead of relying on markdown-it-anchor to create permalinks, do it in HTML when the heading has an `id` attribute. This means you still have to specify the `id` attribute manually to enable linking (and appear in the TOC), but that seems reasonable to me and gives more control.