### PR TITLE
don't explicitly write "no detail" when there is no instructions.detail

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -391,7 +391,7 @@ export async function deploy(
     );
   }
   if (instructions.status === "error" || fileErrors.length) {
-    throw new CliError(`Server rejected deploy manifest: ${instructions.detail ?? "no details"}`);
+    throw new CliError(`Server rejected deploy manifest${instructions.detail ? `: ${instructions.detail}` : ""}`);
   }
   const filesToUpload: string[] = instructions.files
     .filter((instruction) => instruction.status === "upload")


### PR DESCRIPTION
See https://github.com/observablehq/framework/issues/718; one of the files might have enough details already.

In the case of a large file, this changes:

```
◐  Sending file manifest to server│
■  The server rejected some files from the upload:
│
│    - _file/bigfile.60fafc9d.mp4 - (File size of 984 MB exceeds maximum of 50.0 MB)
│
■  Error: Server rejected deploy manifest: no details
```

to 

```
◐  Sending file manifest to server│
■  The server rejected some files from the upload:
│
│    - _file/bigfile.60fafc9d.mp4 - (File size of 984 MB exceeds maximum of 50.0 MB)
│
■  Error: Server rejected deploy manifest
```