### PR TITLE
collapse only child

### DIFF
--- a/src/tree.ts
+++ b/src/tree.ts
@@ -25,6 +25,22 @@ export function tree<T>(
     )([...items, ["/"]]) // add root to avoid implicit truncation
     .sort(treeOrder)
     .count()
+    .eachAfter((node: TreeNode<T>) => {
+      const children = node.children;
+      if (!children) return;
+      let height = 0;
+      for (let i = 0; i < children.length; ++i) {
+        let child = children[i];
+        if (child.children?.length === 1) {
+          child = child.children![0];
+          children[i] = child;
+          child.parent = node;
+          --child.depth;
+        }
+        height = Math.max(height, child.height + 1);
+      }
+      node.height = height;
+    })
     .eachBefore((node: TreeNode<T>) => {
       let p = node;
       let indent = "";
@@ -36,7 +52,7 @@ export function tree<T>(
       }
       lines.push([
         indent || "┌",
-        `${node.id.split("/").pop()?.replace(/\?$/, "")}`,
+        node.id.slice(node.parent?.id === "/" ? 1 : (node.parent?.id.length ?? 0) + 1).replace(/\?$/, ""),
         node.height ? ` (${node.value.toLocaleString("en-US")} page${node.value === 1 ? "" : "s"})` : "",
         node
       ]);

--- a/test/tree-test.ts
+++ b/test/tree-test.ts
@@ -6,49 +6,55 @@ function stree(items: string[]): string[] {
 }
 
 describe("tree(items, options)", () => {
+  it("collapses single-child nodes", () => {
+    assert.deepStrictEqual(stree(["/a/b/c/d"]), [
+      "┌ (1 page)  ",
+      "└── a/b/c/d "
+    ]); // prettier-ignore
+  });
+  it("collapses single-child nodes", () => {
+    assert.deepStrictEqual(stree(["/a/b/c/d", "/a/b/c/e"]), [
+      "┌ (2 pages)         ",
+      "└── a/b/c (2 pages) ",
+      "    ├── d           ",
+      "    └── e           "
+    ]);
+  });
   it("creates implicit internal nodes", () => {
     assert.deepStrictEqual(stree(["/a/b/c/d"]), [
-      "┌ (1 page)             ",
-      "└── a (1 page)         ",
-      "    └── b (1 page)     ",
-      "        └── c (1 page) ",
-      "            └── d      "
-    ]);
+      "┌ (1 page)  ",
+      "└── a/b/c/d "
+    ]); // prettier-ignore
   });
   it("removes the .md extension, if present", () => {
     assert.deepStrictEqual(stree(["/a/b/c/a.md", "/a/b/c/b.md", "/a/b/c/c.md", "/a/b/c/d.md"]), [
-      "┌ (4 pages)             ",
-      "└── a (4 pages)         ",
-      "    └── b (4 pages)     ",
-      "        └── c (4 pages) ",
-      "            ├── a       ",
-      "            ├── b       ",
-      "            ├── c       ",
-      "            └── d       "
+      "┌ (4 pages)         ",
+      "└── a/b/c (4 pages) ",
+      "    ├── a           ",
+      "    ├── b           ",
+      "    ├── c           ",
+      "    └── d           "
     ]);
   });
   it("handles multiple leaves", () => {
     assert.deepStrictEqual(stree(["/a/b/c/a", "/a/b/c/b", "/a/b/c/c", "/a/b/c/d"]), [
-      "┌ (4 pages)             ",
-      "└── a (4 pages)         ",
-      "    └── b (4 pages)     ",
-      "        └── c (4 pages) ",
-      "            ├── a       ",
-      "            ├── b       ",
-      "            ├── c       ",
-      "            └── d       "
+      "┌ (4 pages)         ",
+      "└── a/b/c (4 pages) ",
+      "    ├── a           ",
+      "    ├── b           ",
+      "    ├── c           ",
+      "    └── d           "
     ]);
   });
   it("handles leaves at different levels", () => {
     assert.deepStrictEqual(stree(["/a", "/a/b", "/a/b/c", "/a/b/c/d"]), [
-      "┌ (4 pages)            ",
-      "├── a (3 pages)        ",
-      "│   ├── b (2 pages)    ",
-      "│   │   ├── c (1 page) ",
-      "│   │   │   └── d      ",
-      "│   │   └── c          ",
-      "│   └── b              ",
-      "└── a                  "
+      "┌ (4 pages)         ",
+      "├── a (3 pages)     ",
+      "│   ├── b (2 pages) ",
+      "│   │   ├── c/d     ",
+      "│   │   └── c       ",
+      "│   └── b           ",
+      "└── a               "
     ]);
   });
   it("sorts nodes", () => {
@@ -62,12 +68,11 @@ describe("tree(items, options)", () => {
   });
   it("sorts folders before files", () => {
     assert.deepStrictEqual(stree(["/d/a", "/b", "/c", "/a"]), [
-      "┌ (4 pages)    ",
-      "├── d (1 page) ",
-      "│   └── a      ",
-      "├── a          ",
-      "├── b          ",
-      "└── c          "
+      "┌ (4 pages) ",
+      "├── d/a     ",
+      "├── a       ",
+      "├── b       ",
+      "└── c       "
     ]);
   });
   it("sorts nested folders", () => {


### PR DESCRIPTION
Produces a more compact display when a folder contains only a single page. Redacted example:

```
┌ (7 pages)                       Page      Imports        Files
├── ███████ (4 pages)
│   ├── ██████████/index         32 kB       587 kB     4.794 MB
│   ├── ██████████/index         24 kB       577 kB     1.736 MB
│   ├── ██████████/index         30 kB       587 kB        76 kB
│   └── ██████████/index         24 kB       584 kB       970 kB
├── ███                          16 kB       790 kB    12.522 MB
├── █████████                    32 kB       614 kB       997 kB
└── ██████                       31 kB       610 kB       634 kB
```