### PR TITLE
workaround Safari loading bug

### DIFF
--- a/src/client/main.js
+++ b/src/client/main.js
@@ -27,7 +27,7 @@ export function define(cell) {
   cellsById.get(id)?.variables.forEach((v) => v.delete());
   cellsById.set(id, {cell, variables});
   const root = document.querySelector(`#cell-${id}`);
-  const loading = root.classList.contains("observablehq--loading");
+  const loading = root.querySelector(".observablehq-loading");
   const pending = () => reset(root, loading);
   const rejected = (error) => reject(root, error);
   const v = main.variable({_node: root, pending, rejected}, {shadow: {}}); // _node for visibility promise
@@ -41,7 +41,7 @@ export function define(cell) {
         let version = v._version; // capture version on input change
         return (value) => {
           if (version < displayVersion) throw new Error("stale display");
-          else if (version > displayVersion) root.classList.remove("observablehq--loading"), clear(root);
+          else if (version > displayVersion) clear(root);
           displayVersion = version;
           display(root, value);
           return value;
@@ -69,14 +69,13 @@ export function define(cell) {
 function reset(root, loading) {
   if (root.classList.contains("observablehq--error")) {
     root.classList.remove("observablehq--error");
-    root.classList.toggle("observablehq--loading", loading);
     clear(root);
+    if (loading) root.append(loading);
   }
 }
 
 function reject(root, error) {
   console.error(error);
-  root.classList.remove("observablehq--loading");
   root.classList.add("observablehq--error"); // see reset
   clear(root);
   root.append(inspectError(error));

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -107,9 +107,9 @@ function makeFenceRenderer(baseRenderer: RenderRule): RenderRule {
         // TODO const sourceLine = context.startLine + context.currentLine;
         const node = parseJavaScript(source, {path});
         context.code.push({id, node});
-        html += `<div id="cell-${id}" class="observablehq observablehq--block${
-          node.expression ? " observablehq--loading" : ""
-        }"></div>\n`;
+        html += `<div id="cell-${id}" class="observablehq observablehq--block">${
+          node.expression ? '<span class="observablehq-loading"></span>' : ""
+        }</div>\n`;
       }
     } catch (error) {
       if (!(error instanceof SyntaxError)) throw error;
@@ -262,7 +262,7 @@ function makePlaceholderRenderer(): RenderRule {
       // TODO sourceLine: context.startLine + context.currentLine
       const node = parseJavaScript(token.content, {path, inline: true});
       context.code.push({id, node});
-      return `<span id="cell-${id}" class="observablehq--loading"></span>`;
+      return `<span id="cell-${id}"><span class="observablehq-loading"></span></span>`;
     } catch (error) {
       if (!(error instanceof SyntaxError)) throw error;
       return `<span id="cell-${id}">

--- a/src/style/inspector.css
+++ b/src/style/inspector.css
@@ -1,4 +1,4 @@
-.observablehq--block:not(.observablehq--loading):empty {
+.observablehq--block:empty {
   margin: 0;
 }
 
@@ -11,8 +11,7 @@
   }
 }
 
-.observablehq--loading::before {
-  content: "↻";
+.observablehq-loading {
   font: var(--monospace-font);
   color: var(--theme-foreground-muted);
   display: inline-block;
@@ -23,7 +22,11 @@
   animation-iteration-count: infinite;
 }
 
-.observablehq--block.observablehq--loading::before {
+.observablehq-loading::before {
+  content: "↻";
+}
+
+.observablehq--block .observablehq-loading {
   display: block;
 }
 

--- a/test/output/block-expression.html
+++ b/test/output/block-expression.html
@@ -1,1 +1,1 @@
-<div><span id="cell-6212702c" class="observablehq--loading"></span></div>
+<div><span id="cell-6212702c"><span class="observablehq-loading"></span></span></div>

--- a/test/output/build/archives.posix/tar.html
+++ b/test/output/build/archives.posix/tar.html
@@ -86,13 +86,13 @@ await FileAttachment("./dynamic-tar-gz/does-not-exist.txt").text()
 <div id="observablehq-center">
 <main id="observablehq-main" class="observablehq">
 <h1 id="tar" tabindex="-1"><a class="observablehq-header-anchor" href="#tar">Tar</a></h1>
-<div id="cell-d5134368" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-a0c06958" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-d84cd7fb" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-86bd51aa" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-95938c22" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-7e5740fd" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-d0a58efd" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-d5134368" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-a0c06958" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-d84cd7fb" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-86bd51aa" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-95938c22" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-7e5740fd" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-d0a58efd" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 </main>
 <footer id="observablehq-footer">
 <nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./zip"><span>Zip</span></a></nav>

--- a/test/output/build/archives.posix/zip.html
+++ b/test/output/build/archives.posix/zip.html
@@ -69,10 +69,10 @@ define({id: "f9a513d8", body: () => {
 <div id="observablehq-center">
 <main id="observablehq-main" class="observablehq">
 <h1 id="zip" tabindex="-1"><a class="observablehq-header-anchor" href="#zip">Zip</a></h1>
-<div id="cell-d3b9d0ee" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-bab54217" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-11eec300" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-ee2310f3" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-d3b9d0ee" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-bab54217" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-11eec300" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-ee2310f3" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 <div id="cell-f9a513d8" class="observablehq observablehq--block"></div>
 </main>
 <footer id="observablehq-footer">

--- a/test/output/build/archives.win32/tar.html
+++ b/test/output/build/archives.win32/tar.html
@@ -58,9 +58,9 @@ await FileAttachment("./static-tar/does-not-exist.txt").text()
 <div id="observablehq-center">
 <main id="observablehq-main" class="observablehq">
 <h1 id="tar" tabindex="-1"><a class="observablehq-header-anchor" href="#tar">Tar</a></h1>
-<div id="cell-d5134368" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-a0c06958" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-d84cd7fb" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-d5134368" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-a0c06958" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-d84cd7fb" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 </main>
 <footer id="observablehq-footer">
 <nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./zip"><span>Zip</span></a></nav>

--- a/test/output/build/archives.win32/zip.html
+++ b/test/output/build/archives.win32/zip.html
@@ -51,8 +51,8 @@ await FileAttachment("./static/not-found.txt").text()
 <div id="observablehq-center">
 <main id="observablehq-main" class="observablehq">
 <h1 id="zip" tabindex="-1"><a class="observablehq-header-anchor" href="#zip">Zip</a></h1>
-<div id="cell-d3b9d0ee" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-bab54217" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-d3b9d0ee" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-bab54217" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 </main>
 <footer id="observablehq-footer">
 <nav><a rel="prev" href="./tar"><span>Tar</span></a></nav>

--- a/test/output/build/files/files.html
+++ b/test/output/build/files/files.html
@@ -67,10 +67,10 @@ FileAttachment("./unknown-mime-extension.really")
 <link rel="stylesheet" href="./_file/custom-styles.b072c9c8.css">
 <link rel="stylesheet" href="./_file/subsection/additional-styles.3a854b3a.css">
 <link rel="stylesheet" href="https://example.com/style.css">
-<div id="cell-10037545" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-453a8147" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-444c421e" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-cee3ab67" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-10037545" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-453a8147" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-444c421e" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-cee3ab67" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 <p><img src="./_file/observable logo small.8a915536.png" alt=""></p>
 </main>
 <footer id="observablehq-footer">

--- a/test/output/build/files/subsection/subfiles.html
+++ b/test/output/build/files/subsection/subfiles.html
@@ -52,8 +52,8 @@ FileAttachment("./file-sub.csv")
 <main id="observablehq-main" class="observablehq">
 <link rel="stylesheet" href="../_file/custom-styles.b072c9c8.css">
 <link rel="stylesheet" href="../_file/subsection/additional-styles.3a854b3a.css">
-<div id="cell-ef9a31ef" class="observablehq observablehq--block observablehq--loading"></div>
-<div id="cell-834ecf9f" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-ef9a31ef" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
+<div id="cell-834ecf9f" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 </main>
 <footer id="observablehq-footer">
 <nav><a rel="prev" href="../files"><span>Untitled</span></a></nav>

--- a/test/output/build/missing-file/index.html
+++ b/test/output/build/missing-file/index.html
@@ -31,7 +31,7 @@ FileAttachment("./does-not-exist.txt")
 <div id="observablehq-center">
 <main id="observablehq-main" class="observablehq">
 <h1 id="build-test-case" tabindex="-1"><a class="observablehq-header-anchor" href="#build-test-case">Build test case</a></h1>
-<div id="cell-5760fd93" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-5760fd93" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 </main>
 <footer id="observablehq-footer">
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>

--- a/test/output/build/missing-import/index.html
+++ b/test/output/build/missing-import/index.html
@@ -28,7 +28,7 @@ import("./does-not-exist.js")
 <div id="observablehq-center">
 <main id="observablehq-main" class="observablehq">
 <h1 id="build-test-case" tabindex="-1"><a class="observablehq-header-anchor" href="#build-test-case">Build test case</a></h1>
-<div id="cell-e0627979" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-e0627979" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 </main>
 <footer id="observablehq-footer">
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>

--- a/test/output/build/multi/index.html
+++ b/test/output/build/multi/index.html
@@ -56,7 +56,7 @@ return {f2};
 <main id="observablehq-main" class="observablehq">
 <h1 id="multi-test" tabindex="-1"><a class="observablehq-header-anchor" href="#multi-test">Multi test</a></h1>
 <div id="cell-1bcb5df5" class="observablehq observablehq--block"></div>
-<div id="cell-db071921" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-db071921" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>
 <div id="cell-494b10bd" class="observablehq observablehq--block"></div>
 </main>
 <footer id="observablehq-footer">

--- a/test/output/dollar-expression.html
+++ b/test/output/dollar-expression.html
@@ -1,1 +1,1 @@
-<p>$<span id="cell-6212702c" class="observablehq--loading"></span></p>
+<p>$<span id="cell-6212702c"><span class="observablehq-loading"></span></span></p>

--- a/test/output/dot-graphviz.html
+++ b/test/output/dot-graphviz.html
@@ -1,1 +1,1 @@
-<div id="cell-1ff1191b" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-1ff1191b" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>

--- a/test/output/double-quote-expression.html
+++ b/test/output/double-quote-expression.html
@@ -1,1 +1,1 @@
-<p><span id="cell-56e8b37a" class="observablehq--loading"></span></p>
+<p><span id="cell-56e8b37a"><span class="observablehq-loading"></span></span></p>

--- a/test/output/embedded-expression.html
+++ b/test/output/embedded-expression.html
@@ -1,2 +1,2 @@
 <h1 id="embedded-expression" tabindex="-1">Embedded expression</h1>
-<p>One plus two is <span id="cell-6212702c" class="observablehq--loading"></span>.</p>
+<p>One plus two is <span id="cell-6212702c"><span class="observablehq-loading"></span></span>.</p>

--- a/test/output/heading-expression.html
+++ b/test/output/heading-expression.html
@@ -1,1 +1,1 @@
-<h1 id="" tabindex="-1"><span id="cell-6212702c" class="observablehq--loading"></span></h1>
+<h1 id="" tabindex="-1"><span id="cell-6212702c"><span class="observablehq-loading"></span></span></h1>

--- a/test/output/inline-expression.html
+++ b/test/output/inline-expression.html
@@ -1,1 +1,1 @@
-<p><span><span id="cell-6212702c" class="observablehq--loading"></span></span></p>
+<p><span><span id="cell-6212702c"><span class="observablehq-loading"></span></span></span></p>

--- a/test/output/local-fetch.html
+++ b/test/output/local-fetch.html
@@ -1,2 +1,2 @@
 <h1 id="local-fetch" tabindex="-1">Local fetch</h1>
-<div id="cell-9c4f4e4f" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-9c4f4e4f" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>

--- a/test/output/mermaid.html
+++ b/test/output/mermaid.html
@@ -1,1 +1,1 @@
-<div id="cell-68f6d8d0" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-68f6d8d0" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>

--- a/test/output/single-quote-expression.html
+++ b/test/output/single-quote-expression.html
@@ -1,1 +1,1 @@
-<p><span id="cell-08961c06" class="observablehq--loading"></span></p>
+<p><span id="cell-08961c06"><span class="observablehq-loading"></span></span></p>

--- a/test/output/template-expression.html
+++ b/test/output/template-expression.html
@@ -1,1 +1,1 @@
-<p><span id="cell-12fd0aea" class="observablehq--loading"></span></p>
+<p><span id="cell-12fd0aea"><span class="observablehq-loading"></span></span></p>

--- a/test/output/tex-block.html
+++ b/test/output/tex-block.html
@@ -1,1 +1,1 @@
-<div id="cell-6263d163" class="observablehq observablehq--block observablehq--loading"></div>
+<div id="cell-6263d163" class="observablehq observablehq--block"><span class="observablehq-loading"></span></div>

--- a/test/output/tex-expression.html
+++ b/test/output/tex-expression.html
@@ -1,2 +1,2 @@
-<h1 id="hello%2C" tabindex="-1">Hello, <span id="cell-16447e3a" class="observablehq--loading"></span></h1>
-<p>My favorite equation is <span id="cell-828eccc1" class="observablehq--loading"></span>.</p>
+<h1 id="hello%2C" tabindex="-1">Hello, <span id="cell-16447e3a"><span class="observablehq-loading"></span></span></h1>
+<p>My favorite equation is <span id="cell-828eccc1"><span class="observablehq-loading"></span></span>.</p>


### PR DESCRIPTION
Fixes #1299. Removing the DOM element seems to avoid the bug where Safari doesn’t detect that the `:before` pseudoelement should be removed. (There are other workarounds, but this one seems to be probably the cleanest alternative approach without having to do a Safari-specific kludge.)