### PR TITLE
watch assets, too

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -271,6 +271,9 @@ function getWatchFiles(resolvers: Resolvers): Iterable<string> {
       files.add(specifier);
     }
   }
+  for (const specifier of resolvers.assets) {
+    files.add(specifier);
+  }
   for (const specifier of resolvers.files) {
     files.add(specifier);
   }


### PR DESCRIPTION
Fixes a bug where 

```html
<link rel="stylesheet" type="text/css" href="test.css">
```

wouldn’t update when you edit `test.css`. Now it does.