### PR TITLE
use actions/setup-python

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,11 @@ jobs:
           cache-dependency-path: |
             yarn.lock
             'examples/*/yarn.lock'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: 'examples/*/requirements.txt'
       - run: yarn --frozen-lockfile
       - id: date
         run: echo "date=$(TZ=America/Los_Angeles date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -61,10 +66,7 @@ jobs:
         run: yarn --frozen-lockfile && yarn build
         working-directory: examples/mortgage-rates
       - name: Build example "penguin-classification"
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          yarn --frozen-lockfile && yarn build
+        run: pip install -r requirements.txt && yarn --frozen-lockfile && yarn build
         working-directory: examples/penguin-classification
       - name: Build example "plot"
         run: yarn --frozen-lockfile && yarn build


### PR DESCRIPTION
No idea if this will actually work until we test it in CI, but I think we should probably be using [setup-python](https://github.com/actions/setup-python?tab=readme-ov-file) to use Python in GitHub Actions. I believe this will enable better caching and be more representative of how users should do it, too.