### PR TITLE
index examples

### DIFF
--- a/docs/index-examples.ts
+++ b/docs/index-examples.ts
@@ -1,0 +1,50 @@
+import {existsSync, readdirSync, statSync} from "node:fs";
+import {readFile, writeFile} from "node:fs/promises";
+import {join} from "node:path/posix";
+import he from "he";
+import {readConfig} from "../src/config.js";
+import {visitMarkdownFiles} from "../src/files.js";
+import {parseMarkdown} from "../src/markdown.js";
+
+const base = "examples";
+
+const config = await readConfig(undefined, ".");
+
+for (const entry of readdirSync("examples")) {
+  const dir = join(base, entry);
+  const src = join(dir, "src");
+  if (statSync(dir).isDirectory() && existsSync(src)) {
+    for (const file of visitMarkdownFiles(src)) {
+      const sourcePath = join(src, file);
+      const source = await readFile(sourcePath, "utf8");
+      const path = file;
+      const {body, title, data} = parseMarkdown(source, {...config, path});
+      // eslint-disable-next-line import/no-named-as-default-member
+      const text = he
+        .decode(
+          body
+            .replaceAll(/[\n\r]/g, " ")
+            .replaceAll(/<style\b.*<\/style\b[^>]*>/gi, " ")
+            .replaceAll(/<[^>]+>/g, " ")
+        )
+        .normalize("NFD")
+        .replaceAll(/[\u0300-\u036f]/g, "")
+        .replace(/[^\p{L}\p{N}]/gu, " "); // keep letters & numbers
+      console.warn({entry, file, text, title, data});
+      const url = `https://observablehq.observablehq.cloud/framework-example-${entry}/`;
+      await writeFile(
+        `docs/examples-${entry}.md`,
+        `---
+index: true
+title: ${title} (example)
+---
+
+<meta http-equiv="refresh" content="0; url=${url}">
+
+[>>](${url}).
+
+<div style="display:none">${text}</div>`
+      );
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "dev": "rimraf --glob docs/themes.md docs/theme/*.md && (tsx watch docs/theme/generate-themes.ts & tsx watch --no-warnings=ExperimentalWarning ./src/bin/observable.ts preview --no-open)",
     "docs:themes": "rimraf --glob docs/themes.md docs/theme/*.md && tsx docs/theme/generate-themes.ts",
-    "docs:build": "yarn docs:themes && rimraf docs/.observablehq/dist && tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts build",
+    "docs:index-examples": "rimraf --glob docs/examples/*.md && tsx docs/index-examples.ts",
+    "docs:build": "yarn docs:index-examples && yarn docs:themes && rimraf docs/.observablehq/dist && tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts build",
     "docs:deploy": "yarn docs:themes && tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts deploy",
     "build": "rimraf dist && node build.js --outdir=dist --outbase=src \"src/**/*.{ts,js,css}\" --ignore \"**/*.d.ts\"",
     "test": "concurrently npm:test:mocha npm:test:tsc npm:test:lint npm:test:prettier",


### PR DESCRIPTION
[This is far from ready—only sharing for discussion.] This indexes the examples together with the rest of the documentation. An issue is that the results are often too high, so before we do this we might want to add a moderator/multiplicating factor to the indexing score, and activate it for examples with a low value (_e.g._ 0.1).

![](https://github.com/observablehq/framework/assets/7001/d764e059-06dd-4977-abd7-c396da3dc041)

We also need to know what we want to index: currently it is the contents of the page itself, but do we want to include the README.md of examples? This would allow to include the data loader examples. We will have to remove the boilerplate about how to run a project.

See https://github.com/observablehq/framework/pull/1306#issuecomment-2104630355