### PR TITLE
more precise null coalescing

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -373,16 +373,9 @@ function getHtml(
   data: FrontMatter,
   {path, [key]: defaultValue}: ParseOptions
 ): string | null {
-  return data[key] !== undefined
-    ? data[key]
-      ? String(data[key])
-      : null
-    : defaultValue != null
-    ? rewriteHtmlPaths(
-        typeof defaultValue === "function" ? defaultValue({title, data, path}) ?? "" : defaultValue,
-        path
-      )
-    : null;
+  if (data[key] !== undefined) return data[key] != null ? String(data[key]) : null;
+  const value = typeof defaultValue === "function" ? defaultValue({title, data, path}) : defaultValue;
+  return value != null ? rewriteHtmlPaths(value, path) : null;
 }
 
 function getStyle(data: FrontMatter, {path, style = null}: ParseOptions): string | null {


### PR DESCRIPTION
Doesn’t make a practical difference (at least not yet — we treat null and the empty string the same during render even though we distinguish these two types), but maintains the pedantic distinction between the empty string and null.