### PR TITLE
review port documentation; add EACCES as an acceptable error 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -173,7 +173,7 @@ For security, the preview server is by default only accessible on your local mac
 
 Port numbers below 1024 are usually protected and might need admin priviledges. For example, to share your preview server on the default http port:
 
-> `sudo yarn dev --host 0.0.0.0 --port 80`
+> `sudo npm run dev -- --host 0.0.0.0 --port 80`
 
 </div>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,7 +167,9 @@ You should see something like this:
 
 If port 3000 is in use, the preview server will choose the next available port, so your actual port may vary. To specify a different port, use <nobr>`--port`</nobr>. For example, to run the preview server with npm on port 4321:
 
-> `npm run dev -- --port 4321`
+```sh
+npm run dev -- --port 4321
+```
 
 For security, the preview server is by default only accessible on your local machine using the [loopback address](https://en.wikipedia.org/wiki/Localhost) 127.0.0.1. To allow remote connections, use <nobr>`--host 0.0.0.0`</nobr>.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,7 +171,7 @@ If port 3000 is in use, the preview server will choose the next available port, 
 
 For security, the preview server is by default only accessible on your local machine using the [loopback address](https://en.wikipedia.org/wiki/Localhost) 127.0.0.1. To allow remote connections, use <nobr>`--host 0.0.0.0`</nobr>.
 
-Port numbers below 1024 are usually protected and might need admin priviledges. For example, to share your preview server on the default http port:
+Port numbers below 1024 may need admin privileges. For example, to share your preview server on the default HTTP port 80:
 
 > `sudo npm run dev -- --host 0.0.0.0 --port 80`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -164,8 +164,17 @@ You should see something like this:
 ↳ <u><a href="http://127.0.0.1:3000/" style="color: inherit;">http://127.0.0.1:3000/</a></u></pre>
 
 <div class="note">
-  <p>If port 3000 is in use, the preview server will choose the next available port, so your actual port may vary. To specify port 4321 (and similarly for any other port), use <nobr><code>--port 4321</code></nobr>.</p>
-  <p>For security, the preview server is by default only accessible on your local machine using the <a href="https://en.wikipedia.org/wiki/Localhost">loopback address</a> 127.0.0.1. To allow remote connections, use <nobr><code>--host 0.0.0.0</code></nobr>.</p>
+
+If port 3000 is in use, the preview server will choose the next available port, so your actual port may vary. To specify a different port, use <nobr>`--port`</nobr>. For example, to run the preview server with npm on port 4321:
+
+> `npm run dev -- --port 4321`
+
+For security, the preview server is by default only accessible on your local machine using the [loopback address](https://en.wikipedia.org/wiki/Localhost) 127.0.0.1. To allow remote connections, use <nobr>`--host 0.0.0.0`</nobr>.
+
+Port numbers below 1024 are usually protected and might need admin priviledges. For example, to share your preview server on the default http port:
+
+> `sudo yarn dev --host 0.0.0.0 --port 80`
+
 </div>
 
 Now visit <http://127.0.0.1:3000> in your browser, which should look like:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -175,7 +175,9 @@ For security, the preview server is by default only accessible on your local mac
 
 Port numbers below 1024 may need admin privileges. For example, to share your preview server on the default HTTP port 80:
 
-> `sudo npm run dev -- --host 0.0.0.0 --port 80`
+```sh
+sudo npm run dev -- --host 0.0.0.0 --port 80
+```
 
 </div>
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -77,7 +77,8 @@ export class PreviewServer {
     Telemetry.record({event: "preview", step: "start"});
     const server = createServer();
     if (port === undefined) {
-      for (port = 3000; port < 49152; ++port) {
+      const MAX_PORT = 49152;
+      for (port = 3000; port < MAX_PORT; ++port) {
         try {
           await new Promise<void>((resolve, reject) => {
             server.once("error", reject);
@@ -88,7 +89,7 @@ export class PreviewServer {
           if (!isSystemError(error) || error.code !== "EADDRINUSE") throw error;
         }
       }
-      if (port === 49152) throw new Error(`Couldn’t connect to any port on ${hostname}`);
+      if (port === MAX_PORT) throw new Error(`Couldn’t connect to any port on ${hostname}`);
     } else {
       await new Promise<void>((resolve) => server.listen(port, hostname, resolve));
     }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -77,7 +77,7 @@ export class PreviewServer {
     Telemetry.record({event: "preview", step: "start"});
     const server = createServer();
     if (port === undefined) {
-      const MAX_PORT = 49152;
+      const MAX_PORT = 49152; // https://en.wikipedia.org/wiki/Registered_port
       for (port = 3000; port < MAX_PORT; ++port) {
         try {
           await new Promise<void>((resolve, reject) => {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -85,7 +85,7 @@ export class PreviewServer {
           });
           break;
         } catch (error) {
-          if (!isSystemError(error) || (error.code !== "EADDRINUSE" && error.code !== "EACCES")) throw error;
+          if (!isSystemError(error) || error.code !== "EADDRINUSE") throw error;
         }
       }
       if (port === 49152) throw new Error(`Couldn’t connect to any port on ${hostname}`);

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -77,7 +77,7 @@ export class PreviewServer {
     Telemetry.record({event: "preview", step: "start"});
     const server = createServer();
     if (port === undefined) {
-      for (port = 3000; true; ++port) {
+      for (port = 3000; port < 49152; ++port) {
         try {
           await new Promise<void>((resolve, reject) => {
             server.once("error", reject);
@@ -85,9 +85,10 @@ export class PreviewServer {
           });
           break;
         } catch (error) {
-          if (!isSystemError(error) || error.code !== "EADDRINUSE") throw error;
+          if (!isSystemError(error) || (error.code !== "EADDRINUSE" && error.code !== "EACCES")) throw error;
         }
       }
+      if (port === 49152) throw new Error(`Couldn’t connect to any port on ${hostname}`);
     } else {
       await new Promise<void>((resolve) => server.listen(port, hostname, resolve));
     }


### PR DESCRIPTION
* review port documentation
* add EACCES as an acceptable error to continue port hopping
* avoid out of memory error if no registered port is reachable, and throw an explicit error instead

closes #1355 