### PR TITLE
Quick fix for uncaught 409 on slug conflict.

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -330,7 +330,12 @@ export async function deploy(
         );
       } else {
         clack.log.error(
-          wrapAnsi(`Could not create project: ${error instanceof Error ? error.message : error}`, effects.outputColumns)
+          wrapAnsi(
+            `Could not create project: ${
+              (error as any)?.statusCode === 409 ? "conflicting slug." : error instanceof Error ? error.message : error
+            }`,
+            effects.outputColumns
+          )
         );
       }
       clack.outro(yellow("Deploy canceled"));


### PR DESCRIPTION
This error is raised when you have opted in to create a new project, but asked for an existing slug. I think it's fair in this case to terminate the session.

You can reuse a slug by deploying directly to the project that has that slug. (Is there a case where the slug is "taken" by a project you can't see?)

This fixes the displayed message to make it more palatable. But my code is ugly ("error as any", yuck), and maybe what we want is a clean "api error with messages", like we have just above these lines. In that case there is a bit of work to do on the platform before we would fix this in the client?

I'm putting up this "ugly" solution as a PR, but feel free to reject it in favor of a nicer approach. The workflow with this PR is:

```
◇  Which project do you want to use?
│  Create a new project
│
◇  What slug do you want to use?
│  already-taken
│
◇  Who is allowed to access your project?
│  Public
│
●  You built this project 18 minutes ago.
│
◇  Would you like to build again before deploying?
│  No, deploy as is
│
◇  What changed in this deploy?
│  Enter a deploy message (optional)
│
■  Could not create project: conflicting slug.
│
└  Deploy canceled
```

closes #909 
closes #713 
