### PR TITLE
fix sidebar when no top-level pages

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -114,19 +114,18 @@ Whether to show the sidebar. Defaults to true if **pages** is not empty.
 
 An array containing pages and sections. If not specified, it defaults to all Markdown files found in the source root in directory listing order.
 
-Both pages and sections have a **name**, which typically corresponds to the page’s title. The name gets displayed in the sidebar. Clicking on a page navigates to the corresponding **path**, which should start with a leading slash and be relative to the root; the path can also be specified as a full URL to navigate to an external site. Each section must specify an array of **pages**.
+Both pages and sections have a **name**, which typically corresponds to the page’s title. The name gets displayed in the sidebar. Sections are used to group related pages; each section must specify an array of **pages**. (Sections can only contain pages; nested sections are not currently supported.)
 
-Sections may be **collapsible**. <a href="https://github.com/observablehq/framework/releases/tag/v1.6.0" class="observablehq-version-badge" data-version="^1.6.0" title="Added in 1.6.0"></a> If the **open** option is set, the **collapsible** option defaults to true; otherwise it defaults to false. If the section is not collapsible, the **open** option is ignored and the section is always open; otherwise, the **open** option defaults to true. When a section is collapsible, clicking on a section header opens or closes that section. A section will always be open if the current page belongs to that section.
+Clicking on a page in the sidebar navigates to the corresponding **path**, which should start with a leading slash and be relative to the root; the path can also be specified as a full URL to navigate to an external site. A section may specify a **path** <a href="https://github.com/observablehq/framework/pull/1383" class="observablehq-version-badge" data-version="prerelease" title="Added in #1383"></a> to navigate to when the section header is clicked; if a section does not specify a **path**, then clicking the section header toggles the section (if **collapsible**; see below).
 
-Pages and sections may also have a **pager** field <a href="https://github.com/observablehq/framework/pull/1306" class="observablehq-version-badge" data-version="prerelease" title="Added in #1306"></a> which specifies the name of the page group; this determines which pages are linked to via the previous and next pager buttons. If the **pager** field is not specified, it defaults the current section’s **pager** field, or to `main` for top-level pages and sections. (The home page is always in the `main` pager group.) The **pager** field can be also set to `null` to disable the pager on a specific page or section, causing adjacent pages to skip the page.
-
-For example, here **pages** specifies two sections and a total of four pages:
+For example, here **pages** specifies two sections and a total of five pages:
 
 ```js run=false
 export default {
   pages: [
     {
       name: "Section 1",
+      path: "/s01/",
       pages: [
         {name: "Page 1", path: "/s01/page1"},
         {name: "Page 2", path: "/s01/page2"}
@@ -143,6 +142,10 @@ export default {
   ]
 }
 ```
+
+Sections may be **collapsible**. <a href="https://github.com/observablehq/framework/releases/tag/v1.6.0" class="observablehq-version-badge" data-version="^1.6.0" title="Added in 1.6.0"></a> If the **open** option is set, the **collapsible** option defaults to true; otherwise it defaults to false. If the section is not collapsible, the **open** option is ignored and the section is always open; otherwise, the **open** option defaults to true. A section will open automatically if the current page belongs to that section.
+
+Pages and sections may also have a **pager** field <a href="https://github.com/observablehq/framework/pull/1306" class="observablehq-version-badge" data-version="prerelease" title="Added in #1306"></a> which specifies the name of the page group; this determines which pages are linked to via the previous and next pager buttons. If the **pager** field is not specified, it defaults the current section’s **pager** field, or to `main` for top-level pages and sections. (The home page is always in the `main` pager group.) The **pager** field can be also set to `null` to disable the pager on a specific page or section, causing adjacent pages to skip the page.
 
 Projects can have “unlisted” pages that are not referenced in **pages**. These pages can still be linked from other pages or visited directly, but they won’t be listed in the sidebar or linked to via the previous & next pager links.
 

--- a/src/pager.ts
+++ b/src/pager.ts
@@ -58,8 +58,12 @@ function walk(pages: Config["pages"], title = "Home"): Iterable<Iterable<Page>> 
   visit({name: title, path: "/index", pager: "main"});
 
   for (const page of pageQueue) {
-    if ("pages" in page) for (const p of page.pages) pageQueue.push(p);
-    else visit(page);
+    if ("pages" in page) {
+      if (page.path !== null) visit(page as Page);
+      for (const p of page.pages) pageQueue.push(p);
+    } else {
+      visit(page);
+    }
   }
 
   return pageGroups.values();

--- a/src/render.ts
+++ b/src/render.ts
@@ -141,22 +141,21 @@ async function renderSidebar(options: RenderOptions, resolveLink: (href: string)
     (await rollupClient(getClientPath("search-init.js"), root, path, {minify: true})).trim()
   )}}</script>`
       : ""
-  }
-  <ol>${pages.map((p, i) =>
+  }${pages.map((p, i) =>
     "pages" in p
-      ? html`${i > 0 && "path" in pages[i - 1] ? html`</ol>` : ""}
-    <${p.collapsible ? (p.open || isSectionActive(p, path) ? "details open" : "details") : "section"}${
-      isSectionActive(p, path) ? html` class="observablehq-section-active"` : ""
-    }>
-      <summary>${p.name}</summary>
-      <ol>${p.pages.map((p) => renderListItem(p, path, resolveLink))}
-      </ol>
-    </${p.collapsible ? "details" : "section"}>`
+      ? html`\n  <${p.collapsible ? (p.open || isSectionActive(p, path) ? "details open" : "details") : "section"}${
+          isSectionActive(p, path) ? html` class="observablehq-section-active"` : ""
+        }>
+    <summary>${p.name}</summary>
+    <ol>${p.pages.map((p) => renderListItem(p, path, resolveLink))}
+    </ol>
+  </${p.collapsible ? "details" : "section"}>`
       : "path" in p
-      ? html`${i > 0 && "pages" in pages[i - 1] ? html`\n  </ol>\n  <ol>` : ""}${renderListItem(p, path, resolveLink)}`
+      ? html`${i === 0 || !("path" in pages[i - 1]) ? html`\n  <ol>` : ""}${renderListItem(p, path, resolveLink)}${
+          i === pages.length - 1 || !("path" in pages[i + 1]) ? html`\n  </ol>` : ""
+        }`
       : ""
   )}
-  </ol>
 </nav>
 <script>{${html.unsafe(
     (await rollupClient(getClientPath("sidebar-init.js"), root, path, {minify: true})).trim()

--- a/src/render.ts
+++ b/src/render.ts
@@ -146,15 +146,15 @@ async function renderSidebar(options: RenderOptions, resolveLink: (href: string)
       ? html`\n  <${p.collapsible ? (p.open || isSectionActive(p, path) ? "details open" : "details") : "section"}${
           isSectionActive(p, path) ? html` class="observablehq-section-active"` : ""
         }>
-    <summary>${p.name}</summary>
+    ${renderSectionHeader(p, path, resolveLink)}
     <ol>${p.pages.map((p) => renderListItem(p, path, resolveLink))}
     </ol>
   </${p.collapsible ? "details" : "section"}>`
-      : "path" in p
-      ? html`${i === 0 || !("path" in pages[i - 1]) ? html`\n  <ol>` : ""}${renderListItem(p, path, resolveLink)}${
-          i === pages.length - 1 || !("path" in pages[i + 1]) ? html`\n  </ol>` : ""
+      : "pages" in p
+      ? ""
+      : html`${i === 0 || "pages" in pages[i - 1] ? html`\n  <ol>` : ""}${renderListItem(p, path, resolveLink)}${
+          i === pages.length - 1 || "pages" in pages[i + 1] ? html`\n  </ol>` : ""
         }`
-      : ""
   )}
 </nav>
 <script>{${html.unsafe(
@@ -163,7 +163,7 @@ async function renderSidebar(options: RenderOptions, resolveLink: (href: string)
 }
 
 function isSectionActive(s: Section<Page>, path: string): boolean {
-  return s.pages.some((p) => normalizePath(p.path) === path);
+  return s.pages.some((p) => normalizePath(p.path) === path) || (s.path !== null && normalizePath(s.path) === path);
 }
 
 interface Header {
@@ -193,6 +193,16 @@ function renderToc(headers: Header[], label: string): Html {
   }
 </nav>
 </aside>`;
+}
+
+function renderSectionHeader(section: Section<Page>, path: string, resolveLink: (href: string) => string): Html {
+  if (section.path === null) return html`<summary>${section.name}</summary>`;
+  const external = !isAssetPath(section.path);
+  return html`<summary class="observablehq-link${
+    normalizePath(section.path) === path ? " observablehq-link-active" : ""
+  }"><a href="${encodeURI(resolveLink(section.path))}"${external ? html` target="_blank"` : null}>${
+    external ? html`<span>${section.name}</span>` : section.name
+  }</a></summary>`;
 }
 
 function renderListItem(page: Page, path: string, resolveLink: (href: string) => string): Html {

--- a/src/search.ts
+++ b/src/search.ts
@@ -35,8 +35,8 @@ export async function searchIndex(config: Config, effects = defaultEffects): Pro
   // Get all the listed pages (which are indexed by default)
   const pagePaths = new Set(["/index"]);
   for (const p of pages) {
-    if ("path" in p) pagePaths.add(p.path);
-    else for (const {path} of p.pages) pagePaths.add(path);
+    if (p.path !== null) pagePaths.add(p.path);
+    if ("pages" in p) for (const {path} of p.pages) pagePaths.add(path);
   }
 
   // Index the pages

--- a/src/style/layout.css
+++ b/src/style/layout.css
@@ -219,6 +219,16 @@
   align-items: center;
 }
 
+#observablehq-sidebar summary a {
+  flex-grow: 1;
+  color: inherit;
+}
+
+#observablehq-sidebar summary.observablehq-link {
+  padding: 0;
+  margin-left: 0;
+}
+
 #observablehq-sidebar details summary:hover,
 .observablehq-link-active a,
 .observablehq-link a:hover {

--- a/test/config-test.ts
+++ b/test/config-test.ts
@@ -25,6 +25,8 @@ describe("readConfig(undefined, root)", () => {
           name: "Closed subsection",
           collapsible: true,
           open: false,
+          path: null,
+          pager: "main",
           pages: [{name: "Closed page", path: "/closed/page", pager: "main"}]
         }
       ],
@@ -139,7 +141,14 @@ describe("normalizeConfig(spec, root)", () => {
   it("coerces sections", () => {
     const inpages = [{name: 42, pages: new Set([{name: null, path: {toString: () => "yes"}}])}];
     const outpages = [
-      {name: "42", collapsible: false, open: true, pages: [{name: "null", path: "/yes", pager: "main"}]}
+      {
+        name: "42",
+        collapsible: false,
+        open: true,
+        path: null,
+        pager: "main",
+        pages: [{name: "null", path: "/yes", pager: "main"}]
+      }
     ];
     assert.deepStrictEqual(config({pages: inpages}, root).pages, outpages);
   });

--- a/test/input/build/pager/observablehq.config.js
+++ b/test/input/build/pager/observablehq.config.js
@@ -3,6 +3,7 @@ export default {
     {
       name: "Sub",
       open: false,
+      path: "/sub/",
       pages: [
         {name: "Page 0", path: "/sub/page0"},
         {name: "Page 1 ?x=1", path: "/sub/page1?x=1"},

--- a/test/output/build/config/closed/page.html
+++ b/test/output/build/config/closed/page.html
@@ -25,14 +25,14 @@ import "../_observablehq/client.js";
   <ol>
     <li class="observablehq-link"><a href="../">Index</a></li>
     <li class="observablehq-link"><a href="../one">One&lt;Two</a></li>
-    <li class="observablehq-link"><a href="../sub/two">Two</a></li></ol>
-    <details open class="observablehq-section-active">
-      <summary>Closed subsection</summary>
-      <ol>
-    <li class="observablehq-link observablehq-link-active"><a href="./page">Closed page</a></li>
-      </ol>
-    </details>
+    <li class="observablehq-link"><a href="../sub/two">Two</a></li>
   </ol>
+  <details open class="observablehq-section-active">
+    <summary>Closed subsection</summary>
+    <ol>
+    <li class="observablehq-link observablehq-link-active"><a href="./page">Closed page</a></li>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/config/index.html
+++ b/test/output/build/config/index.html
@@ -25,14 +25,14 @@ import "./_observablehq/client.js";
   <ol>
     <li class="observablehq-link observablehq-link-active"><a href="./">Index</a></li>
     <li class="observablehq-link"><a href="./one">One&lt;Two</a></li>
-    <li class="observablehq-link"><a href="./sub/two">Two</a></li></ol>
-    <details>
-      <summary>Closed subsection</summary>
-      <ol>
-    <li class="observablehq-link"><a href="./closed/page">Closed page</a></li>
-      </ol>
-    </details>
+    <li class="observablehq-link"><a href="./sub/two">Two</a></li>
   </ol>
+  <details>
+    <summary>Closed subsection</summary>
+    <ol>
+    <li class="observablehq-link"><a href="./closed/page">Closed page</a></li>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/config/one.html
+++ b/test/output/build/config/one.html
@@ -25,14 +25,14 @@ import "./_observablehq/client.js";
   <ol>
     <li class="observablehq-link"><a href="./">Index</a></li>
     <li class="observablehq-link observablehq-link-active"><a href="./one">One&lt;Two</a></li>
-    <li class="observablehq-link"><a href="./sub/two">Two</a></li></ol>
-    <details>
-      <summary>Closed subsection</summary>
-      <ol>
-    <li class="observablehq-link"><a href="./closed/page">Closed page</a></li>
-      </ol>
-    </details>
+    <li class="observablehq-link"><a href="./sub/two">Two</a></li>
   </ol>
+  <details>
+    <summary>Closed subsection</summary>
+    <ol>
+    <li class="observablehq-link"><a href="./closed/page">Closed page</a></li>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/config/sub/two.html
+++ b/test/output/build/config/sub/two.html
@@ -25,14 +25,14 @@ import "../_observablehq/client.js";
   <ol>
     <li class="observablehq-link"><a href="../">Index</a></li>
     <li class="observablehq-link"><a href="../one">One&lt;Two</a></li>
-    <li class="observablehq-link observablehq-link-active"><a href="./two">Two</a></li></ol>
-    <details>
-      <summary>Closed subsection</summary>
-      <ol>
-    <li class="observablehq-link"><a href="../closed/page">Closed page</a></li>
-      </ol>
-    </details>
+    <li class="observablehq-link observablehq-link-active"><a href="./two">Two</a></li>
   </ol>
+  <details>
+    <summary>Closed subsection</summary>
+    <ol>
+    <li class="observablehq-link"><a href="../closed/page">Closed page</a></li>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/config/toc-override.html
+++ b/test/output/build/config/toc-override.html
@@ -25,14 +25,14 @@ import "./_observablehq/client.js";
   <ol>
     <li class="observablehq-link"><a href="./">Index</a></li>
     <li class="observablehq-link"><a href="./one">One&lt;Two</a></li>
-    <li class="observablehq-link"><a href="./sub/two">Two</a></li></ol>
-    <details>
-      <summary>Closed subsection</summary>
-      <ol>
-    <li class="observablehq-link"><a href="./closed/page">Closed page</a></li>
-      </ol>
-    </details>
+    <li class="observablehq-link"><a href="./sub/two">Two</a></li>
   </ol>
+  <details>
+    <summary>Closed subsection</summary>
+    <ol>
+    <li class="observablehq-link"><a href="./closed/page">Closed page</a></li>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/config/toc.html
+++ b/test/output/build/config/toc.html
@@ -25,14 +25,14 @@ import "./_observablehq/client.js";
   <ol>
     <li class="observablehq-link"><a href="./">Index</a></li>
     <li class="observablehq-link"><a href="./one">One&lt;Two</a></li>
-    <li class="observablehq-link"><a href="./sub/two">Two</a></li></ol>
-    <details>
-      <summary>Closed subsection</summary>
-      <ol>
-    <li class="observablehq-link"><a href="./closed/page">Closed page</a></li>
-      </ol>
-    </details>
+    <li class="observablehq-link"><a href="./sub/two">Two</a></li>
   </ol>
+  <details>
+    <summary>Closed subsection</summary>
+    <ol>
+    <li class="observablehq-link"><a href="./closed/page">Closed page</a></li>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/index.html
+++ b/test/output/build/pager/index.html
@@ -23,7 +23,7 @@ import "./_observablehq/client.js";
     <li class="observablehq-link observablehq-link-active"><a href="./">Home</a></li>
   </ol>
   <details>
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./sub/">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./sub/page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./sub/page1?x=1">Page 1 ?x=1</a></li>
@@ -50,7 +50,7 @@ import "./_observablehq/client.js";
 <h1 id="index" tabindex="-1"><a class="observablehq-header-anchor" href="#index">index</a></h1>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="next" href="./sub/page0"><span>Page 0</span></a></nav>
+<nav><a rel="next" href="./sub/"><span>Sub</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/pager/index.html
+++ b/test/output/build/pager/index.html
@@ -22,10 +22,9 @@ import "./_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link observablehq-link-active"><a href="./">Home</a></li>
   </ol>
-  <ol>
-    <details>
-      <summary>Sub</summary>
-      <ol>
+  <details>
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./sub/page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./sub/page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./sub/page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "./_observablehq/client.js";
     <li class="observablehq-link"><a href="./sub/page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./sub/page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./sub/page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/index.html
+++ b/test/output/build/pager/sub/index.html
@@ -22,8 +22,8 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <details>
-    <summary>Sub</summary>
+  <details open class="observablehq-section-active">
+    <summary class="observablehq-link observablehq-link-active"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
@@ -50,6 +50,7 @@ import "../_observablehq/client.js";
 <h1 id="subindex" tabindex="-1"><a class="observablehq-header-anchor" href="#subindex">subindex</a></h1>
 </main>
 <footer id="observablehq-footer">
+<nav><a rel="prev" href="../"><span>Home</span></a><a rel="next" href="./page0"><span>Page 0</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/pager/sub/index.html
+++ b/test/output/build/pager/sub/index.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details>
-      <summary>Sub</summary>
-      <ol>
+  <details>
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page0.html
+++ b/test/output/build/pager/sub/page0.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link observablehq-link-active"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page0.html
+++ b/test/output/build/pager/sub/page0.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link observablehq-link-active"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
@@ -50,7 +50,7 @@ import "../_observablehq/client.js";
 <h1 id="page-0" tabindex="-1"><a class="observablehq-header-anchor" href="#page-0">page 0</a></h1>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="../"><span>Home</span></a><a rel="next" href="./page1?x=1"><span>Page 1 ?x=1</span></a></nav>
+<nav><a rel="prev" href="./"><span>Sub</span></a><a rel="next" href="./page1?x=1"><span>Page 1 ?x=1</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/pager/sub/page1..10.html
+++ b/test/output/build/pager/sub/page1..10.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details>
-      <summary>Sub</summary>
-      <ol>
+  <details>
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page1..10.html
+++ b/test/output/build/pager/sub/page1..10.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details>
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/output/build/pager/sub/page1.html
+++ b/test/output/build/pager/sub/page1.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link observablehq-link-active"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page1.html
+++ b/test/output/build/pager/sub/page1.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link observablehq-link-active"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/output/build/pager/sub/page2.html
+++ b/test/output/build/pager/sub/page2.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link observablehq-link-active"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page2.html
+++ b/test/output/build/pager/sub/page2.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/output/build/pager/sub/page3.html
+++ b/test/output/build/pager/sub/page3.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/output/build/pager/sub/page3.html
+++ b/test/output/build/pager/sub/page3.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page4.html
+++ b/test/output/build/pager/sub/page4.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/output/build/pager/sub/page4.html
+++ b/test/output/build/pager/sub/page4.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page5.html
+++ b/test/output/build/pager/sub/page5.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/output/build/pager/sub/page5.html
+++ b/test/output/build/pager/sub/page5.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page6.html
+++ b/test/output/build/pager/sub/page6.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/output/build/pager/sub/page6.html
+++ b/test/output/build/pager/sub/page6.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page7.html
+++ b/test/output/build/pager/sub/page7.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/output/build/pager/sub/page7.html
+++ b/test/output/build/pager/sub/page7.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link observablehq-link-active"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link observablehq-link-active"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page8.html
+++ b/test/output/build/pager/sub/page8.html
@@ -22,10 +22,9 @@ import "../_observablehq/client.js";
     <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
-  <ol>
-    <details open class="observablehq-section-active">
-      <summary>Sub</summary>
-      <ol>
+  <details open class="observablehq-section-active">
+    <summary>Sub</summary>
+    <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>
     <li class="observablehq-link"><a href="./page2">Page 2</a></li>
@@ -38,9 +37,8 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="./page7#hello">Page 7 #hello</a></li>
     <li class="observablehq-link"><a href="./page7#world">Page 7 #world</a></li>
     <li class="observablehq-link observablehq-link-active"><a href="./page8">Page 8</a></li>
-      </ol>
-    </details>
-  </ol>
+    </ol>
+  </details>
 </nav>
 <script>{/* redacted init script */}</script>
 <aside id="observablehq-toc" data-selector="h1:not(:first-of-type)[id], h2:first-child[id], :not(h1) + h2[id]">

--- a/test/output/build/pager/sub/page8.html
+++ b/test/output/build/pager/sub/page8.html
@@ -23,7 +23,7 @@ import "../_observablehq/client.js";
     <li class="observablehq-link"><a href="../">Home</a></li>
   </ol>
   <details open class="observablehq-section-active">
-    <summary>Sub</summary>
+    <summary class="observablehq-link"><a href="./">Sub</a></summary>
     <ol>
     <li class="observablehq-link"><a href="./page0">Page 0</a></li>
     <li class="observablehq-link"><a href="./page1?x=1">Page 1 ?x=1</a></li>

--- a/test/pager-test.ts
+++ b/test/pager-test.ts
@@ -17,7 +17,8 @@ describe("findLink(path, options)", () => {
     const a = {name: "a", path: "/a", pager: "main"};
     const b = {name: "b", path: "/b", pager: "main"};
     const c = {name: "c", path: "/c", pager: "main"};
-    const config = {pages: [{name: "section", collapsible: true, open: true, pages: [a, b, c]}]};
+    const section = {name: "section", collapsible: true, open: true, path: null, pager: null, pages: [a, b, c]};
+    const config = {pages: [section]};
     assert.deepStrictEqual(pager("/index", config), {prev: undefined, next: a});
     assert.deepStrictEqual(pager("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
     assert.deepStrictEqual(pager("/b", config), {prev: a, next: c});


### PR DESCRIPTION
Fixes a bug where the sidebar wouldn’t render correctly if there were only top-level sections and not any top-level pages.

Before:
<img width="1326" alt="Screenshot 2024-05-22 at 10 00 10 AM" src="https://github.com/observablehq/framework/assets/230541/ffa235d6-ee8d-4db1-9838-ca3b1960b1d6">

After:
<img width="1326" alt="Screenshot 2024-05-22 at 10 00 30 AM" src="https://github.com/observablehq/framework/assets/230541/32af904c-cc89-4a21-ad26-76d5e1b71c7f">
