### PR TITLE
fix spawn stdout

### DIFF
--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -312,8 +312,7 @@ class CommandLoader extends Loader {
   }
 
   async exec(output: WriteStream): Promise<void> {
-    const subprocess = spawn(this.command, this.args, {windowsHide: true, stdio: ["ignore", "pipe", "inherit"]});
-    subprocess.stdout.pipe(output);
+    const subprocess = spawn(this.command, this.args, {windowsHide: true, stdio: ["ignore", output, "inherit"]});
     const code = await new Promise((resolve, reject) => {
       subprocess.on("error", reject);
       subprocess.on("close", resolve);


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/10849.

Test data loader:

```sh
duckdb :memory: <<EOF
copy (select * from range(10) tbl(i)) to '/dev/stdout' (format parquet, codec zstd)
EOF
```