### PR TITLE
Use clack.log, and a smaller message

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -441,6 +441,7 @@ export async function deploy(
       clack.log.warn(`Could not read build manifest: ${error}`);
     }
   }
+  clack.log.info("Uploading build manifest...");
   await apiClient.postDeployUploaded(deployId, buildManifest);
 
   // Poll for processing completion

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -441,7 +441,6 @@ export async function deploy(
       clack.log.warn(`Could not read build manifest: ${error}`);
     }
   }
-  clack.log.info("Uploading build manifest...");
   await apiClient.postDeployUploaded(deployId, buildManifest);
 
   // Poll for processing completion

--- a/src/observableApiClient.ts
+++ b/src/observableApiClient.ts
@@ -205,7 +205,6 @@ export class ObservableApiClient {
   }
 
   async postDeployUploaded(deployId: string, buildManifest: PostDeployUploadedRequest | null): Promise<DeployInfo> {
-    console.log("Uploading build manifest...", buildManifest);
     return await this._fetch<DeployInfo>(new URL(`/cli/deploy/${deployId}/uploaded`, this._apiOrigin), {
       method: "POST",
       headers: {"content-type": "application/json"},


### PR DESCRIPTION
#1340 logs the contents of the new build manifest

![Capture d’écran 2024-05-27 à 08 57 40](https://github.com/observablehq/framework/assets/7001/64ded3a6-9e6c-4fec-b231-70cfb86b7916)
