### PR TITLE
no poll delay for deploy tests

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -145,7 +145,7 @@ class Deployer {
       if (this.effects.clack.isCancel(choice) || !choice)
         throw new CliError("User canceled deploy", {print: false, exitCode: 0});
 
-      ({currentUser, apiKey} = await loginInner(this.effects));
+      ({currentUser, apiKey} = await loginInner(this.effects, {pollTime: this.deployOptions.deployPollInterval}));
       apiClient.setApiKey(apiKey);
     }
 
@@ -619,7 +619,7 @@ class Deployer {
   }
 
   private async pollForProcessingCompletion(deployId: string): Promise<GetDeployResponse> {
-    const pollInterval = this.deployOptions.deployPollInterval || DEPLOY_POLL_INTERVAL_MS;
+    const {deployPollInterval: pollInterval = DEPLOY_POLL_INTERVAL_MS} = this.deployOptions;
 
     // Poll for processing completion
     const spinner = this.effects.clack.spinner();


### PR DESCRIPTION
The `deployPollInterval` was set to zero, but the `deploy` command wasn’t respecting this due to a logical error (`||`). Also, the `deployPollInterval` needs to be passed through to the `loginInner` method’s `pollTime` option to avoid polling there, too. If desired, we could make this latter polling interval a separate option for the deploy command, but it seems reasonable to have the same option apply to both. (And maybe in the future we could avoid polling entirely with server-sent events or some such?)

On my computer, this makes the tests take 4.9 seconds, down from 15.5 seconds.