### PR TITLE
Don't use the login flow for tests that aren't testing login

### DIFF
--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -882,8 +882,6 @@ describe("deploy", () => {
   it("will re-poll for both created and pending deploy statuses", async () => {
     const deployId = "deploy456";
     getCurrentObservableApi()
-      .handlePostAuthRequest()
-      .handlePostAuthRequestPoll("accepted")
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
@@ -898,7 +896,7 @@ describe("deploy", () => {
       .handleGetDeploy({deployId, deployStatus: "uploaded"})
       .start();
 
-    const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG, apiKey: null});
+    const effects = new MockDeployEffects({deployConfig: DEPLOY_CONFIG});
     effects.clack.inputs = [
       true, // do you want to log in?
       "fix some bugs" // deploy message
@@ -989,8 +987,6 @@ describe("deploy", () => {
   it("can force a deploy", async () => {
     const deployId = "deploy456";
     getCurrentObservableApi()
-      .handlePostAuthRequest()
-      .handlePostAuthRequestPoll("accepted")
       .handleGetCurrentUser()
       .handleGetProject(DEPLOY_CONFIG)
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
@@ -1010,7 +1006,6 @@ describe("deploy", () => {
 
     const effects = new MockDeployEffects({
       deployConfig: DEPLOY_CONFIG,
-      apiKey: null,
       fixedInputStatTime: new Date("2024-03-11"), // newer source files
       fixedOutputStatTime: new Date("2024-03-10")
     });


### PR DESCRIPTION
While reviewing #1399, I was surprised the test hit used `loginInner` at all, because it wasn't testing the login flow. I changed the tests to start with an API key, instead of needing to pretend to get one from logging in.

This won't change what the test is testing or it's speed much, but it makes it a smaller, more focused test that only works on what it says it is doing.
