### PR TITLE
fix search result url

### DIFF
--- a/src/client/search.js
+++ b/src/client/search.js
@@ -56,7 +56,7 @@ function renderResult({id, score, title}, i) {
   const external = /^\w+:/.test(id);
   return `<li data-score="${Math.min(5, Math.round(0.6 * score))}" class="observablehq-link${
     i === 0 ? ` ${activeClass}` : ""
-  }"><a href="${escapeDoubleQuote(external ? id : import.meta.resolve(`../${id}`))}"${
+  }"><a href="${escapeDoubleQuote(external ? id : import.meta.resolve(`..${id}`))}"${
     external ? ' target="_blank"' : ""
   }><span>${escapeText(String(title ?? "—"))}</span></a></li>`;
 }


### PR DESCRIPTION
I think the difference is that we indexed an id that didn't start with a slash, and now a path that does start with a slash.

<img width="1084" alt="the buglet" src="https://github.com/observablehq/framework/assets/7001/bec22b3e-c641-4924-9889-6812beca3329">

An alternative would be to go back to indexing a path without the leading slash?

fixes https://github.com/observablehq/framework/pull/1401#issuecomment-2138405008