### PR TITLE
mod-enter to open in new tab

### DIFF
--- a/src/client/search.js
+++ b/src/client/search.js
@@ -83,7 +83,12 @@ input.addEventListener("keydown", (event) => {
     const results = resultsContainer.querySelector("ol");
     if (!results) return;
     let activeResult = results.querySelector(`.${activeClass}`);
-    if (code === "Enter") return activeResult.querySelector("a").click();
+    if (code === "Enter") {
+      const a = activeResult.querySelector("a");
+      if (/Mac|iPhone/.test(navigator.platform) ? event.metaKey : event.ctrlKey) open(a.href, "_blank");
+      else a.click();
+      return;
+    }
     activeResult.classList.remove(activeClass);
     if (code === "ArrowUp") activeResult = activeResult.previousElementSibling ?? results.lastElementChild;
     else activeResult = activeResult.nextElementSibling ?? results.firstElementChild;


### PR DESCRIPTION
This allows the Mod-Enter keyboard shortcut to open search results in a new tab, making it much easier browse through the results (without needing to restore the search query as in #897 — though we could still do that) as long as you don’t mind having more than one tab open.