### PR TITLE
Fix for broken link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Please [open a discussion](https://github.com/observablehq/framework/discussions
 
 ## Contributing 🙏
 
-See [`docs/contributing.md`](./docs/contributing.md).
+See [Contributing](https://observablehq.com/framework/contributing).

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Please [open a discussion](https://github.com/observablehq/framework/discussions
 
 ## Contributing 🙏
 
-See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+See [`docs/contributing.md`](./docs/contributing.md).


### PR DESCRIPTION
`README.md` currently links to `./CONTRIBUTING.md` which does not exist. This updates the link to `./docs/contributing.md`.