### PR TITLE
ignore inline expressions in HTML rawtext and comment blocks

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -184,7 +184,6 @@ function parsePlaceholder(content: string, replacer: (i: number, j: number) => v
 
 function transformPlaceholderBlock(token) {
   const input = token.content;
-  if (/^\s*<script[\s>]/.test(input)) return [token]; // ignore <script> elements
   const output: any[] = [];
   let i = 0;
   parsePlaceholder(input, (j, k) => {
@@ -242,7 +241,11 @@ const transformPlaceholderCore: RuleCore = (state) => {
   for (const token of input) {
     switch (token.type) {
       case "html_block":
-        output.push(...transformPlaceholderBlock(token));
+        if (/^\s*<(!--|script|style|textarea|title)[\s>]/.test(token.content)) {
+          output.push(token);
+        } else {
+          output.push(...transformPlaceholderBlock(token));
+        }
         break;
       default:
         output.push(token);


### PR DESCRIPTION
Fixes #375. We were ignoring script elements already, but we need to ignore all rawtext elements and we also need to ignore comments. Technically we might also want to ignore cdata and other weird things, but those are extremely rare so I didn’t bother.

Ref. https://spec.commonmark.org/0.31.2/#html-blocks
Ref. https://github.com/observablehq/htl/blob/e3e9777d09f7b5aea3ebc52e73b86a1246dcab7e/src/index.js#L631-L637