### PR TITLE
fix descender clip

### DIFF
--- a/templates/default/src/index.md.tmpl
+++ b/templates/default/src/index.md.tmpl
@@ -2,48 +2,6 @@
 toc: false
 ---
 
-<style>
-
-.hero {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-family: var(--sans-serif);
-  margin: 4rem 0 8rem;
-  text-wrap: balance;
-  text-align: center;
-}
-
-.hero h1 {
-  margin: 2rem 0;
-  max-width: none;
-  font-size: 14vw;
-  font-weight: 900;
-  line-height: 1;
-  background: linear-gradient(30deg, var(--theme-foreground-focus), currentColor);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.hero h2 {
-  margin: 0;
-  max-width: 34em;
-  font-size: 20px;
-  font-style: initial;
-  font-weight: 500;
-  line-height: 1.5;
-  color: var(--theme-foreground-muted);
-}
-
-@media (min-width: 640px) {
-  .hero h1 {
-    font-size: 90px;
-  }
-}
-
-</style>
-
 <div class="hero">
   <h1>{{ projectTitleHtml }}</h1>
   <h2>Welcome to your new project! Edit&nbsp;<code style="font-size: 90%;">src/index.md</code> to change this page.</h2>
@@ -113,3 +71,46 @@ Here are some ideas of things you could try…
     Visit <a href="https://github.com/observablehq/framework">Framework on GitHub</a> and give us a star. Or file an issue if you’ve found a bug!
   </div>
 </div>
+
+<style>
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: var(--sans-serif);
+  margin: 4rem 0 8rem;
+  text-wrap: balance;
+  text-align: center;
+}
+
+.hero h1 {
+  margin: 1rem 0;
+  padding: 1rem 0;
+  max-width: none;
+  font-size: 14vw;
+  font-weight: 900;
+  line-height: 1;
+  background: linear-gradient(30deg, var(--theme-foreground-focus), currentColor);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero h2 {
+  margin: 0;
+  max-width: 34em;
+  font-size: 20px;
+  font-style: initial;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--theme-foreground-muted);
+}
+
+@media (min-width: 640px) {
+  .hero h1 {
+    font-size: 90px;
+  }
+}
+
+</style>


### PR DESCRIPTION
Applies a bit of padding (in addition to margin) so the background extends below the descenders. Also moves the styles to the end of the `index.md` so that it’s a bit friendlier to edit the example `index.md` (without getting distracted by some elaborate CSS).

Before:
<img width="1035" alt="Screenshot 2024-06-10 at 4 49 29 PM" src="https://github.com/observablehq/framework/assets/230541/4388c7c7-4315-45ce-b276-1e417bda24e2">

After:
<img width="1035" alt="Screenshot 2024-06-10 at 4 49 12 PM" src="https://github.com/observablehq/framework/assets/230541/e9a8bfa5-acb8-450c-af7d-8b05ef15599c">
