### PR TITLE
fix inspector cleanup

### DIFF
--- a/src/client/inspect.js
+++ b/src/client/inspect.js
@@ -1,15 +1,14 @@
 import {Inspector} from "observablehq:runtime";
 
 export function inspect(value) {
-  const inspector = new Inspector(document.createElement("div"));
-  inspector.fulfilled(value);
-  return inspector._node.firstChild;
+  const node = document.createElement("div");
+  new Inspector(node).fulfilled(value);
+  return node;
 }
 
 export function inspectError(value) {
-  const inspector = new Inspector(document.createElement("div"));
-  inspector.rejected(value);
-  const node = inspector._node.firstChild;
+  const node = document.createElement("div");
+  new Inspector(node).rejected(value);
   node.classList.add("observablehq--error");
   return node;
 }


### PR DESCRIPTION
The inspector replaces its contents when objects are expanded; this prevents `display` from being able to cleanup. To fix this, we retain the wrapper DIV element around the inspector contents. Fixes #1456.