### PR TITLE
if stdout is not a tty, replace clack.spinner by console.log

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,14 +1,13 @@
 import {existsSync} from "node:fs";
 import {utimes, writeFile} from "node:fs/promises";
 import {join} from "node:path/posix";
-import * as clack from "@clack/prompts";
 import wrapAnsi from "wrap-ansi";
 import type {ClackEffects} from "./clack.js";
 import {CliError} from "./error.js";
 import {prepareOutput} from "./files.js";
 import {getObservableUiOrigin} from "./observableApiClient.js";
 import type {TtyEffects} from "./tty.js";
-import {bold, cyan, faint, inverse, link, reset, defaultEffects as ttyEffects} from "./tty.js";
+import {bold, cyan, defaultEffects as defaultTtyEffects, faint, inverse, link, reset} from "./tty.js";
 
 export interface ConvertEffects extends TtyEffects {
   clack: ClackEffects;
@@ -19,8 +18,7 @@ export interface ConvertEffects extends TtyEffects {
 }
 
 const defaultEffects: ConvertEffects = {
-  ...ttyEffects,
-  clack,
+  ...defaultTtyEffects,
   async prepareOutput(outputPath: string): Promise<void> {
     await prepareOutput(outputPath);
   },

--- a/src/create.ts
+++ b/src/create.ts
@@ -7,7 +7,6 @@ import {basename, dirname, join, normalize} from "node:path/posix";
 import {setTimeout as sleep} from "node:timers/promises";
 import {fileURLToPath} from "node:url";
 import {promisify} from "node:util";
-import * as clack from "@clack/prompts";
 import he from "he";
 import untildify from "untildify";
 import wrapAnsi from "wrap-ansi";
@@ -25,7 +24,6 @@ export interface CreateEffects extends TtyEffects {
 
 const defaultEffects: CreateEffects = {
   ...defaultTtyEffects,
-  clack,
   sleep,
   async mkdir(outputPath: string, options): Promise<void> {
     await mkdir(outputPath, options);

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -2,7 +2,6 @@ import {createHash} from "node:crypto";
 import type {Stats} from "node:fs";
 import {readFile, stat} from "node:fs/promises";
 import {join} from "node:path/posix";
-import * as clack from "@clack/prompts";
 import wrapAnsi from "wrap-ansi";
 import type {BuildEffects, BuildManifest, BuildOptions} from "./build.js";
 import {FileBuildEffects, build} from "./build.js";
@@ -73,7 +72,6 @@ const defaultEffects: DeployEffects = {
   ...defaultAuthEffects,
   getDeployConfig,
   setDeployConfig,
-  clack,
   logger: console,
   input: process.stdin,
   output: process.stdout,

--- a/src/observableApiAuth.ts
+++ b/src/observableApiAuth.ts
@@ -1,5 +1,4 @@
 import os from "node:os";
-import * as clack from "@clack/prompts";
 import type {ClackEffects} from "./clack.js";
 import {commandInstruction, commandRequiresAuthenticationMessage} from "./commandInstruction.js";
 import {CliError, isHttpError} from "./error.js";
@@ -30,7 +29,6 @@ export interface AuthEffects extends ConfigEffects, TtyEffects {
 export const defaultEffects: AuthEffects = {
   ...defaultConfigEffects,
   ...defaultTtyEffects,
-  clack,
   getObservableApiKey,
   setObservableApiKey,
   exitSuccess: () => process.exit(0)

--- a/src/tty.ts
+++ b/src/tty.ts
@@ -1,4 +1,6 @@
 import {isatty} from "node:tty";
+import * as clack from "@clack/prompts";
+import type {ClackEffects} from "./clack.js";
 import type {Logger} from "./logger.js";
 
 export const reset = color(0, 0);
@@ -22,12 +24,26 @@ function color(code: number, reset: number): TtyColor {
 }
 
 export interface TtyEffects {
+  clack: ClackEffects;
   isTty: boolean;
   logger: Logger;
   outputColumns: number;
 }
 
+const noSpinner = () => ({
+  start(msg?: string) {
+    console.log(msg);
+  },
+  stop(msg?: string, code?: number) {
+    console.log(msg, code ?? "");
+  },
+  message(msg?: string) {
+    console.log(msg);
+  }
+});
+
 export const defaultEffects: TtyEffects = {
+  clack: process.stdout.isTTY ? clack : {...clack, spinner: noSpinner},
   isTty: isatty(process.stdin.fd),
   logger: console,
   outputColumns: Math.min(80, process.stdout.columns ?? 80)

--- a/test/tty-test.ts
+++ b/test/tty-test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import * as clack from "@clack/prompts";
 import type {TtyEffects} from "../src/tty.js";
 import {blue, bold, green, hangingIndentLog, red} from "../src/tty.js";
 
@@ -50,6 +51,7 @@ describe("hangingIndentLog", () => {
 });
 
 const noopEffects: TtyEffects = {
+  clack,
   isTty: true,
   logger: {log() {}, warn() {}, error() {}},
   outputColumns: 80


### PR DESCRIPTION
closes #1447
closes #1446

~~I'm not happy that I had to make c8 specifically ignore the non-coverage of the non-tty output tests, but I did not find a better way.~~ (solved in the new approach, see below)