### PR TITLE
framework example: loader-github-react

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -57,7 +57,8 @@
 - [`loader-databricks`](https://observablehq.observablehq.cloud/framework-example-loader-databricks/) - Loading data from Databricks
 - [`loader-duckdb`](https://observablehq.observablehq.cloud/framework-example-loader-duckdb/) - Processing data with DuckDB
 - [`loader-elasticsearch`](https://observablehq.observablehq.cloud/framework-example-loader-elasticsearch/) - Loading data from Elasticsearch
-- [`loader-github`](https://observablehq.observablehq.cloud/framework-example-loader-github/) - Loading data from GitHub
+- [`loader-github`](https://observablehq.observablehq.cloud/framework-example-loader-github/) - Loading data from GitHub with Octokit
+- [`loader-github-repo`](https://observablehq.observablehq.cloud/framework-example-loader-github-repo/) - Loading data from GitHub and NPM
 - [`loader-google-analytics`](https://observablehq.observablehq.cloud/framework-example-loader-google-analytics/) - Loading data from Google Analytics
 - [`loader-julia-to-txt`](https://observablehq.observablehq.cloud/framework-example-loader-julia-to-txt/) - Generating TXT from Julia
 - [`loader-parquet`](https://observablehq.observablehq.cloud/framework-example-loader-parquet/) - Generating Apache Parquet files

--- a/examples/loader-github-repo/.gitignore
+++ b/examples/loader-github-repo/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.env
+dist/
+node_modules/
+yarn-error.log
+repos/

--- a/examples/loader-github-repo/README.md
+++ b/examples/loader-github-repo/README.md
@@ -1,0 +1,46 @@
+[Framework examples →](../)
+
+# GitHub data loader
+
+This [Observable Framework](https://observablehq.com/framework) builds a complete dashboard about a GitHub repo.
+
+Our live demo shows contributors, issues, comments, commits, files… for the [facebook/react](https://github.com/facebook/react) repo.
+
+View live: <https://observablehq.observablehq.cloud/framework-example-loader-github-react/>
+
+## Configuration
+
+_To configure this project, please edit the following information in the .env file_
+
+Your GitHub access token:
+
+<kbd>GITHUB_TOKEN="ght_xxxxx"</kbd>
+
+This personal access token identifies you as a user, and allows the data loaders to make many requests on your behalf on GitHub’s API.
+
+The data loaders collect information on the repo you specify as:
+
+<kbd>GITHUB_REPO="facebook/react"</kbd>
+
+If that repo is private, make sure to grant access to it when you define your token.
+
+The package’s name — used to query the NPM downloads information — is inferred from the `name` field of the `package.json` file. When this turns out incorrect, you can specify it explicitly:
+
+<kbd>NPM_PACKAGE="react"</kbd>
+
+<div class="tip">
+
+TIP: This information is stored in the <code>.env</code> file at the root of the project. It is used by data loaders to request information from GitHub. It is _not_ shared anywhere else on the Internet. The built project is safe to deploy and share publicly.
+
+</div>
+
+## APIs used
+
+This example demonstrates the use of four distinct APIs to access the data:
+
+- GitHub’s [GraphQL API](https://docs.github.com/en/graphql) for general information about the project;
+- GitHub’s [REST API](https://docs.github.com/en/rest) for issues;
+- The `git` command to download the repos and analyze the commits;
+- NPM’s [registry API](https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md) to obtain a detailed timeline of the download counts.
+
+While this runs quickly on medium sized projects, we also tested it on large repositories containing hundreds of thousands of commits. For example, it might take about 45 minutes to download and analyze more than a million commits by running `git clone git@github.com:torvalds/linux.git`.

--- a/examples/loader-github-repo/observablehq.config.js
+++ b/examples/loader-github-repo/observablehq.config.js
@@ -1,0 +1,3 @@
+export default {
+  root: "src"
+};

--- a/examples/loader-github-repo/package.json
+++ b/examples/loader-github-repo/package.json
@@ -1,0 +1,25 @@
+{
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "clean": "rimraf src/.observablehq/cache",
+    "build": "rimraf dist && observable build",
+    "dev": "observable preview",
+    "deploy": "observable deploy",
+    "observable": "observable"
+  },
+  "dependencies": {
+    "@observablehq/framework": "latest",
+    "@octokit/graphql": "^8.1.1",
+    "d3-dsv": "^3.0.1",
+    "d3-time-format": "^4.1.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.10",
+    "rimraf": "^5.0.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/loader-github-repo/src/.gitignore
+++ b/examples/loader-github-repo/src/.gitignore
@@ -1,0 +1,1 @@
+/.observablehq/cache/

--- a/examples/loader-github-repo/src/components/bigNumber.js
+++ b/examples/loader-github-repo/src/components/bigNumber.js
@@ -1,0 +1,32 @@
+import * as d3 from "npm:d3";
+import {html} from "npm:htl";
+
+export function BigNumber(
+  number,
+  {
+    href,
+    target = "_blank",
+    title,
+    format = ",.2~f",
+    trend,
+    trendFormat = "+.1~%",
+    trendColor = trend > 0 ? "green" : trend < 0 ? "red" : "yellow",
+    trendArrow = trend > 0 ? "↗︎" : trend < 0 ? "↘︎" : "→",
+    trendDescription,
+    plot
+  } = {}
+) {
+  if (typeof format !== "function") format = typeof number === "string" ? String : d3.format(format);
+  if (typeof trendFormat !== "function") trendFormat = d3.format(trendFormat);
+  const div = html`<div style="display: flex; flex-direction: column;">
+    <h2>${title}</h2>
+    <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: baseline;">
+      <div class="big">${format(number)}</div>
+      ${trend == null
+        ? null
+        : html`<div class=${trendColor}>${trendFormat(trend)} ${trendArrow} ${trendDescription}</div>`}
+    </div>
+    ${plot}
+  </div>`;
+  return href == null ? div : html`<a href=${href} target=${target} style="color: inherit;">${div}</a>`;
+}

--- a/examples/loader-github-repo/src/components/color-legend.js
+++ b/examples/loader-github-repo/src/components/color-legend.js
@@ -1,0 +1,254 @@
+import * as d3 from "npm:d3";
+import {html} from "npm:htl";
+
+// Copyright 2021, Observable Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/color-legend
+export function Legend(
+  color,
+  {
+    title,
+    tickSize = 6,
+    width = 320,
+    height = 44 + tickSize,
+    marginTop = 18,
+    marginRight = 0,
+    marginBottom = 16 + tickSize,
+    marginLeft = 0,
+    ticks = width / 64,
+    tickFormat,
+    tickValues
+  } = {}
+) {
+  function ramp(color, n = 256) {
+    const canvas = document.createElement("canvas");
+    canvas.width = n;
+    canvas.height = 1;
+    const context = canvas.getContext("2d");
+    for (let i = 0; i < n; ++i) {
+      context.fillStyle = color(i / (n - 1));
+      context.fillRect(i, 0, 1, 1);
+    }
+    return canvas;
+  }
+
+  const svg = d3
+    .create("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .attr("viewBox", [0, 0, width, height])
+    .style("overflow", "visible")
+    .style("display", "block");
+
+  let tickAdjust = (g) => g.selectAll(".tick line").attr("y1", marginTop + marginBottom - height);
+  let x;
+
+  // Continuous
+  if (color.interpolate) {
+    const n = Math.min(color.domain().length, color.range().length);
+
+    x = color.copy().rangeRound(d3.quantize(d3.interpolate(marginLeft, width - marginRight), n));
+
+    svg
+      .append("image")
+      .attr("x", marginLeft)
+      .attr("y", marginTop)
+      .attr("width", width - marginLeft - marginRight)
+      .attr("height", height - marginTop - marginBottom)
+      .attr("preserveAspectRatio", "none")
+      .attr("xlink:href", ramp(color.copy().domain(d3.quantize(d3.interpolate(0, 1), n))).toDataURL());
+  }
+
+  // Sequential
+  else if (color.interpolator) {
+    x = Object.assign(color.copy().interpolator(d3.interpolateRound(marginLeft, width - marginRight)), {
+      range() {
+        return [marginLeft, width - marginRight];
+      }
+    });
+
+    svg
+      .append("image")
+      .attr("x", marginLeft)
+      .attr("y", marginTop)
+      .attr("width", width - marginLeft - marginRight)
+      .attr("height", height - marginTop - marginBottom)
+      .attr("preserveAspectRatio", "none")
+      .attr("xlink:href", ramp(color.interpolator()).toDataURL());
+
+    // scaleSequentialQuantile doesn’t implement ticks or tickFormat.
+    if (!x.ticks) {
+      if (tickValues === undefined) {
+        const n = Math.round(ticks + 1);
+        tickValues = d3.range(n).map((i) => d3.quantile(color.domain(), i / (n - 1)));
+      }
+      if (typeof tickFormat !== "function") {
+        tickFormat = d3.format(tickFormat === undefined ? ",f" : tickFormat);
+      }
+    }
+  }
+
+  // Threshold
+  else if (color.invertExtent) {
+    const thresholds = color.thresholds
+      ? color.thresholds() // scaleQuantize
+      : color.quantiles
+      ? color.quantiles() // scaleQuantile
+      : color.domain(); // scaleThreshold
+
+    const thresholdFormat =
+      tickFormat === undefined ? (d) => d : typeof tickFormat === "string" ? d3.format(tickFormat) : tickFormat;
+
+    x = d3
+      .scaleLinear()
+      .domain([-1, color.range().length - 1])
+      .rangeRound([marginLeft, width - marginRight]);
+
+    svg
+      .append("g")
+      .selectAll("rect")
+      .data(color.range())
+      .join("rect")
+      .attr("x", (d, i) => x(i - 1))
+      .attr("y", marginTop)
+      .attr("width", (d, i) => x(i) - x(i - 1))
+      .attr("height", height - marginTop - marginBottom)
+      .attr("fill", (d) => d);
+
+    tickValues = d3.range(thresholds.length);
+    tickFormat = (i) => thresholdFormat(thresholds[i], i);
+  }
+
+  // Ordinal
+  else {
+    x = d3
+      .scaleBand()
+      .domain(color.domain())
+      .rangeRound([marginLeft, width - marginRight]);
+
+    svg
+      .append("g")
+      .selectAll("rect")
+      .data(color.domain())
+      .join("rect")
+      .attr("x", x)
+      .attr("y", marginTop)
+      .attr("width", Math.max(0, x.bandwidth() - 1))
+      .attr("height", height - marginTop - marginBottom)
+      .attr("fill", color);
+
+    tickAdjust = () => {};
+  }
+
+  svg
+    .append("g")
+    .attr("transform", `translate(0,${height - marginBottom})`)
+    .call(
+      d3
+        .axisBottom(x)
+        .ticks(ticks, typeof tickFormat === "string" ? tickFormat : undefined)
+        .tickFormat(typeof tickFormat === "function" ? tickFormat : undefined)
+        .tickSize(tickSize)
+        .tickValues(tickValues)
+    )
+    .call(tickAdjust)
+    .call((g) => g.select(".domain").remove())
+    .call((g) =>
+      g
+        .append("text")
+        .attr("x", marginLeft)
+        .attr("y", marginTop + marginBottom - height - 6)
+        .attr("fill", "currentColor")
+        .attr("text-anchor", "start")
+        .attr("font-weight", "bold")
+        .attr("class", "title")
+        .text(title)
+    );
+
+  return svg.node();
+}
+
+// Copyright 2021, Observable Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/color-legend
+export function Swatches(
+  color,
+  {
+    columns = null,
+    format,
+    unknown: formatUnknown,
+    swatchSize = 15,
+    swatchWidth = swatchSize,
+    swatchHeight = swatchSize,
+    marginLeft = 0
+  } = {}
+) {
+  const id = `-swatches-${Math.random().toString(16).slice(2)}`;
+  const unknown = formatUnknown == null ? undefined : color.unknown();
+  const unknowns = unknown == null || unknown === d3.scaleImplicit ? [] : [unknown];
+  const domain = color.domain().concat(unknowns);
+  if (format === undefined) format = (x) => (x === unknown ? formatUnknown : x);
+
+  function entity(character) {
+    return `&#${character.charCodeAt(0).toString()};`;
+  }
+
+  if (columns !== null)
+    return html`<div
+      style="display: flex; align-items: center; margin-left: ${+marginLeft}px; min-height: 33px; font: 10px sans-serif;"
+    >
+      <style>
+        .${id}-item {
+          break-inside: avoid;
+          display: flex;
+          align-items: center;
+          padding-bottom: 1px;
+        }
+
+        .${id}-label {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          max-width: calc(100% - ${+swatchWidth}px - 0.5em);
+        }
+
+        .${id}-swatch {
+          width: ${+swatchWidth}px;
+          height: ${+swatchHeight}px;
+          margin: 0 0.5em 0 0;
+        }
+      </style>
+      <div style=${{width: "100%", columns}}>
+        ${domain.map((value) => {
+          const label = `${format(value)}`;
+          return html`<div class="${id}-item">
+            <div class="${id}-swatch" style=${{background: color(value)}}></div>
+            <div class="${id}-label" title=${label}>${label}</div>
+          </div>`;
+        })}
+      </div>
+    </div>`;
+
+  return html`<div
+    style="display: flex; align-items: center; min-height: 33px; margin-left: ${+marginLeft}px; font: 10px sans-serif;"
+  >
+    <style>
+      .${id} {
+        display: inline-flex;
+        align-items: center;
+        margin-right: 1em;
+      }
+
+      .${id}::before {
+        content: "";
+        width: ${+swatchWidth}px;
+        height: ${+swatchHeight}px;
+        margin-right: 0.5em;
+        background: var(--color);
+      }
+    </style>
+    <div>
+      ${domain.map((value) => html`<span class="${id}" style="--color: ${color(value)}">${format(value)}</span>`)}
+    </div>
+  </div>`;
+}

--- a/examples/loader-github-repo/src/components/dailyPlot.js
+++ b/examples/loader-github-repo/src/components/dailyPlot.js
@@ -1,0 +1,81 @@
+import * as d3 from "npm:d3";
+import * as Plot from "npm:@observablehq/plot";
+
+export const today = d3.utcDay(d3.utcHour.offset(d3.utcHour(), -10));
+export const start = d3.utcYear.offset(today, -2);
+
+export function DailyPlot(
+  data,
+  {
+    title,
+    label = title,
+    x = "date",
+    y = "value",
+    domain = [0, 1.2 * d3.quantile(data, 0.95, (d) => d[y])],
+    width,
+    height = 200,
+    startDate = start,
+    endDate = today,
+  } = {}
+) {
+  return Plot.plot({
+    width,
+    height,
+    round: true,
+    marginRight: 60,
+    x: {
+      domain: [startDate, endDate],
+    },
+    y: {
+      grid: true,
+      domain,
+      label: label,
+    },
+    marks: [
+      Plot.axisY({
+        anchor: "right",
+        label: `${title} (line = 28-day, blue = 7-day)`,
+      }),
+      Plot.areaY(
+        data,
+        Plot.filter((d) => d[x] >= startDate, {
+          x,
+          y,
+          curve: "step",
+          fillOpacity: 0.2,
+        })
+      ),
+      Plot.ruleY([0]),
+      Plot.lineY(
+        data,
+        Plot.filter(
+          (d) => d[x] >= startDate,
+          Plot.windowY(
+            { k: 7, anchor: "start", strict: true },
+            {
+              x,
+              y,
+              strokeWidth: 1,
+              stroke: "var(--theme-foreground-focus)",
+            }
+          )
+        )
+      ),
+      Plot.lineY(
+        data,
+        Plot.filter(
+          (d) => d[x] >= startDate,
+          Plot.windowY({ k: 28, anchor: "start", strict: true }, { x, y })
+        )
+      ),
+      Plot.tip(
+        data,
+        Plot.pointerX({
+          x,
+          y,
+          format: { y: ",.0f" },
+        })
+      ),
+    ],
+  });
+}

--- a/examples/loader-github-repo/src/components/treemap.js
+++ b/examples/loader-github-repo/src/components/treemap.js
@@ -1,0 +1,182 @@
+// Copyright 2021-2024 Observable, Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/treemap
+
+import * as d3 from "npm:d3";
+
+export function Treemap(
+  data,
+  {
+    // data is either tabular (array of objects) or hierarchy (nested objects)
+    path, // as an alternative to id and parentId, returns an array identifier, imputing internal nodes
+    id = Array.isArray(data) ? (d) => d.id : null, // if tabular data, given a d in data, returns a unique identifier (string)
+    parentId = Array.isArray(data) ? (d) => d.parentId : null, // if tabular data, given a node d, returns its parent’s identifier
+    children, // if hierarchical data, given a d in data, returns its children
+    value, // given a node d, returns a quantitative value (for area encoding; null for count)
+    sort = (a, b) => d3.descending(a.value, b.value), // how to sort nodes prior to layout
+    label, // given a leaf node d, returns the name to display on the rectangle
+    group, // given a leaf node d, returns a categorical value (for color encoding)
+    title, // given a leaf node d, returns its hover text
+    link, // given a leaf node d, its link (if any)
+    linkTarget = "_blank", // the target attribute for links (if any)
+    tile = d3.treemapBinary, // treemap strategy
+    width = 640, // outer width, in pixels
+    height = 400, // outer height, in pixels
+    margin = 0, // shorthand for margins
+    marginTop = margin, // top margin, in pixels
+    marginRight = margin, // right margin, in pixels
+    marginBottom = margin, // bottom margin, in pixels
+    marginLeft = margin, // left margin, in pixels
+    padding = 1, // shorthand for inner and outer padding
+    paddingInner = padding, // to separate a node from its adjacent siblings
+    paddingOuter = padding, // shorthand for top, right, bottom, and left padding
+    paddingTop = paddingOuter, // to separate a node’s top edge from its children
+    paddingRight = paddingOuter, // to separate a node’s right edge from its children
+    paddingBottom = paddingOuter, // to separate a node’s bottom edge from its children
+    paddingLeft = paddingOuter, // to separate a node’s left edge from its children
+    round = true, // whether to round to exact pixels
+    colors = d3.schemeObservable10, // array of colors
+    zDomain, // array of values for the color scale
+    fill = "#ccc", // fill for node rects (if no group color encoding)
+    fillOpacity = group == null ? null : 0.6, // fill opacity for node rects
+    stroke, // stroke for node rects
+    strokeWidth, // stroke width for node rects
+    strokeOpacity, // stroke opacity for node rects
+    strokeLinejoin, // stroke line join for node rects
+  } = {}
+) {
+  // If id and parentId options are specified, or the path option, use d3.stratify
+  // to convert tabular data to a hierarchy; otherwise we assume that the data is
+  // specified as an object {children} with nested objects (a.k.a. the “flare.json”
+  // format), and use d3.hierarchy.
+
+  // We take special care of any node that has both a value and children, see
+  // https://observablehq.com/@d3/treemap-parent-with-value.
+  const stratify = (data) =>
+    d3
+      .stratify()
+      .path(path)(data)
+      .each((node) => {
+        if (node.children?.length && node.data != null) {
+          const child = new d3.Node(node.data);
+          node.data = null;
+          child.depth = node.depth + 1;
+          child.height = 0;
+          child.parent = node;
+          child.id = node.id + "/";
+          node.children.unshift(child);
+        }
+      });
+  const root =
+    path != null
+      ? stratify(data)
+      : id != null || parentId != null
+      ? d3.stratify().id(id).parentId(parentId)(data)
+      : d3.hierarchy(data, children);
+
+  // Compute the values of internal nodes by aggregating from the leaves.
+  value == null
+    ? root.count()
+    : root.sum((d) => Math.max(0, d ? value(d) : null));
+
+  // Prior to sorting, if a group channel is specified, construct an ordinal color scale.
+  let leaves = root.leaves();
+  if (group != null) {
+    leaves.forEach((d) => (d.group = group(d.data, d)));
+    if (zDomain === undefined)
+      zDomain = d3
+        .groupSort(
+          leaves,
+          (V) => -d3.sum(V, (d) => d.value),
+          (d) => d.group
+        )
+        .filter((d) => d !== undefined);
+  }
+  const color =
+    group == null ? null : d3.scaleOrdinal(zDomain, colors).unknown("#333");
+
+  // Sort the leaves (typically by descending value for a pleasing layout).
+  if (sort != null) root.sort(sort);
+
+  // Compute the treemap layout.
+  d3
+    .treemap()
+    .tile(tile)
+    .size([width - marginLeft - marginRight, height - marginTop - marginBottom])
+    .paddingInner(paddingInner)
+    .paddingTop(paddingTop)
+    .paddingRight(paddingRight)
+    .paddingBottom(paddingBottom)
+    .paddingLeft(paddingLeft)
+    .round(round)(root);
+
+  // Filter out the small leaves
+  leaves = leaves.filter((d) => (d.x1 - d.x0) * (d.y1 - d.y0) > 0.5);
+
+  // Compute labels and titles.
+  leaves.forEach((d) => (d.label = label(d.data, d)));
+  if (title) leaves.forEach((d) => (d.title = title(d.data, d)));
+  else leaves.forEach((d) => (d.title = d.label));
+
+  const svg = d3
+    .create("svg")
+    .attr("viewBox", [-marginLeft, -marginTop, width, height])
+    .attr("width", width)
+    .attr("height", height)
+    .attr("style", "max-width: 100%; height: auto; height: intrinsic;")
+    .attr("font-family", "sans-serif")
+    .attr("font-size", 10);
+
+  const node = svg
+    .selectAll("a")
+    .data(leaves)
+    .join("a")
+    .attr("xlink:href", link == null ? null : (d) => link(d.data, d))
+    .attr("target", link == null ? null : linkTarget)
+    .attr("transform", (d) => `translate(${d.x0},${d.y0})`);
+
+  node
+    .append("rect")
+    .attr("fill", color ? ({ group }) => color(group) : fill)
+    .attr("fill-opacity", fillOpacity)
+    .attr("stroke", stroke)
+    .attr("stroke-width", strokeWidth)
+    .attr("stroke-opacity", strokeOpacity)
+    .attr("stroke-linejoin", strokeLinejoin)
+    .attr("width", (d) => d.x1 - d.x0)
+    .attr("height", (d) => d.y1 - d.y0);
+
+  node.append("title").text((d) => d.title);
+
+  // A unique identifier for clip paths (to avoid conflicts).
+  const uid = `O-${Math.random().toString(16).slice(2)}`;
+
+  const textnode = node.filter((d) => d.x1 - d.x0 > 7 && d.y1 - d.y0 > 4);
+
+  textnode
+    .append("clipPath")
+    .attr("id", (d, i) => `${uid}-clip-${i}`)
+    .append("rect")
+    .attr("width", (d) => d.x1 - d.x0)
+    .attr("height", (d) => d.y1 - d.y0);
+
+  textnode
+    .append("text")
+    .attr("fill", "currentColor")
+    .attr(
+      "clip-path",
+      (d, i) => `url(${new URL(`#${uid}-clip-${i}`, location)})`
+    )
+    .selectAll("tspan")
+    .data((d) => d.label.split(/\n/g))
+    .join("tspan")
+    .attr("x", 3)
+    .attr("y", (d, i, D) => `${(i === D.length - 1) * 0.3 + 1.1 + i * 0.9}em`)
+    .attr("fill-opacity", (d, i, D) => (i === D.length - 1 ? 0.7 : null))
+    .text((d) => d);
+
+  const n = svg.node();
+  if (color) Object.assign(n, { scales: { color } });
+
+  return n;
+}

--- a/examples/loader-github-repo/src/data/comments.json.ts
+++ b/examples/loader-github-repo/src/data/comments.json.ts
@@ -1,6 +1,6 @@
-import { utcDay } from "d3-time";
-import { githubList } from "./github.js";
-import { getRepo } from "./github-repo.js";
+import {utcDay} from "d3-time";
+import {githubList} from "./github.js";
+import {getRepo} from "./github-repo.js";
 
 const repo = await getRepo();
 
@@ -18,10 +18,10 @@ async function load() {
 async function* loadItems() {
   const end = utcDay();
   const start = utcDay.offset(end, -28 * 6);
-  const { nameWithOwner } = repo;
+  const {nameWithOwner} = repo;
   for await (const item of githubList(
     `/repos/${nameWithOwner}/issues/comments?since=${start.toISOString()}&until=${end.toISOString()}`,
-    { reverse: true }
+    {reverse: true}
   ))
     yield item;
 }
@@ -32,7 +32,7 @@ function redactItem(item) {
     login: item.user.login,
     date: item.created_at,
     html_url: item.html_url,
-    body: truncateBody(item.body),
+    body: truncateBody(item.body)
   };
 }
 

--- a/examples/loader-github-repo/src/data/comments.json.ts
+++ b/examples/loader-github-repo/src/data/comments.json.ts
@@ -1,0 +1,44 @@
+import { utcDay } from "d3-time";
+import { githubList } from "./github.js";
+import { getRepo } from "./github-repo.js";
+
+const repo = await getRepo();
+
+async function load() {
+  process.stdout.write("[");
+  let first = true;
+  for await (const item of loadItems()) {
+    if (first) first = false;
+    else process.stdout.write(",");
+    process.stdout.write(`\n  ${JSON.stringify(redactItem(item))}`);
+  }
+  process.stdout.write("\n]\n");
+}
+
+async function* loadItems() {
+  const end = utcDay();
+  const start = utcDay.offset(end, -28 * 6);
+  const { nameWithOwner } = repo;
+  for await (const item of githubList(
+    `/repos/${nameWithOwner}/issues/comments?since=${start.toISOString()}&until=${end.toISOString()}`,
+    { reverse: true }
+  ))
+    yield item;
+}
+
+function redactItem(item) {
+  return {
+    repo: item.repo,
+    login: item.user.login,
+    date: item.created_at,
+    html_url: item.html_url,
+    body: truncateBody(item.body),
+  };
+}
+
+function truncateBody(body) {
+  const line = body.split("\n")[0].trim();
+  return line.length > 100 ? line.slice(0, 99) + "…" : line;
+}
+
+await load();

--- a/examples/loader-github-repo/src/data/commits.parquet.sh
+++ b/examples/loader-github-repo/src/data/commits.parquet.sh
@@ -1,12 +1,12 @@
 set -a; source .env; set +a
 
-CLONE=repos/$GITHUB_REPOS
+CLONE=repos/$GITHUB_REPO
 
 if [ -d "$CLONE" ]; then
   echo "using cached clone $CLONE" >&2
 else
-  echo "cloning $GITHUB_REPOS into $CLONE" >&2
-  git clone "https://github.com/${GITHUB_REPOS}.git" "$CLONE/"
+  echo "cloning $GITHUB_REPO into $CLONE" >&2
+  git clone "https://github.com/${GITHUB_REPO}.git" "$CLONE/"
 fi
 
 cd "$CLONE/"

--- a/examples/loader-github-repo/src/data/commits.parquet.sh
+++ b/examples/loader-github-repo/src/data/commits.parquet.sh
@@ -1,0 +1,50 @@
+set -a; source .env; set +a
+
+CLONE=repos/$GITHUB_REPOS
+
+if [ -d "$CLONE" ]; then
+  echo "using cached clone $CLONE" >&2
+else
+  echo "cloning $GITHUB_REPOS into $CLONE" >&2
+  git clone "https://github.com/${GITHUB_REPOS}.git" "$CLONE/"
+fi
+
+cd "$CLONE/"
+
+TMP="../$(basename $CLONE)-commits.csv"
+
+if [ ! -f "$TMP" ]; then
+
+git log --pretty=format:'%x00%h%x00,%x00%an%x00,%x00%cI%x00' --shortstat \
+  | sed 's/"/""/g' | tr '\00' '"' \
+  | awk -F, '
+BEGIN {
+  OFS = ",";
+  comm = "hash,author,date"; files = "files"; insertions = "insertions"; deletions = "deletions";
+}
+
+/^"/ {
+  print comm, files, insertions, deletions;
+  comm = $0;
+  files = ""
+  insertions = "";
+  deletions = "";
+}
+
+/ files? changed/ {
+  if (match($0, /([0-9]+) file/)) files = substr($0, RSTART, RLENGTH - 5);
+  if (match($0, /([0-9]+) insertion/)) insertions = substr($0, RSTART, RLENGTH - 10);
+  if (match($0, /([0-9]+) deletion/)) deletions = substr($0, RSTART, RLENGTH - 9);
+}
+
+END {
+  print comm, files, insertions, deletions;
+}
+' > $TMP;
+
+fi
+
+duckdb -c "
+  COPY (FROM '$TMP' ORDER BY author, date)
+  TO STDOUT (format parquet, compression zstd)
+"

--- a/examples/loader-github-repo/src/data/config.ts
+++ b/examples/loader-github-repo/src/data/config.ts
@@ -1,10 +1,8 @@
 import "dotenv/config";
 
-const { GITHUB_REPO, GITHUB_TOKEN, NPM_PACKAGE } = process.env;
+const {GITHUB_REPO, GITHUB_TOKEN, NPM_PACKAGE} = process.env;
 
-if (GITHUB_REPO === undefined)
-  throw new Error("GITHUB_REPO must be defined in .env.");
-if (GITHUB_TOKEN === undefined)
-  throw new Error("GITHUB_TOKEN must be defined in .env.");
+if (GITHUB_REPO === undefined) throw new Error("GITHUB_REPO must be defined in .env.");
+if (GITHUB_TOKEN === undefined) throw new Error("GITHUB_TOKEN must be defined in .env.");
 
-export { GITHUB_REPO, GITHUB_TOKEN, NPM_PACKAGE };
+export {GITHUB_REPO, GITHUB_TOKEN, NPM_PACKAGE};

--- a/examples/loader-github-repo/src/data/config.ts
+++ b/examples/loader-github-repo/src/data/config.ts
@@ -1,0 +1,10 @@
+import "dotenv/config";
+
+const { GITHUB_REPO, GITHUB_TOKEN, NPM_PACKAGE } = process.env;
+
+if (GITHUB_REPO === undefined)
+  throw new Error("GITHUB_REPO must be defined in .env.");
+if (GITHUB_TOKEN === undefined)
+  throw new Error("GITHUB_TOKEN must be defined in .env.");
+
+export { GITHUB_REPO, GITHUB_TOKEN, NPM_PACKAGE };

--- a/examples/loader-github-repo/src/data/files.json.ts
+++ b/examples/loader-github-repo/src/data/files.json.ts
@@ -1,0 +1,18 @@
+import { getRepo } from "./github-repo.js";
+import { github } from "./github.js";
+
+const repo = await getRepo();
+
+const {
+  nameWithOwner,
+  defaultBranchRef: { name: branch },
+} = repo;
+console.warn("loading files for", nameWithOwner, branch);
+
+const { body } = await github(
+  `/repos/${nameWithOwner}/git/trees/${branch}?recursive=1`
+);
+
+const tree = body.tree.map(({ path, size }) => ({ path, size }));
+
+process.stdout.write(JSON.stringify(tree));

--- a/examples/loader-github-repo/src/data/files.json.ts
+++ b/examples/loader-github-repo/src/data/files.json.ts
@@ -1,18 +1,16 @@
-import { getRepo } from "./github-repo.js";
-import { github } from "./github.js";
+import {getRepo} from "./github-repo.js";
+import {github} from "./github.js";
 
 const repo = await getRepo();
 
 const {
   nameWithOwner,
-  defaultBranchRef: { name: branch },
+  defaultBranchRef: {name: branch}
 } = repo;
 console.warn("loading files for", nameWithOwner, branch);
 
-const { body } = await github(
-  `/repos/${nameWithOwner}/git/trees/${branch}?recursive=1`
-);
+const {body} = await github(`/repos/${nameWithOwner}/git/trees/${branch}?recursive=1`);
 
-const tree = body.tree.map(({ path, size }) => ({ path, size }));
+const tree = body.tree.map(({path, size}) => ({path, size}));
 
 process.stdout.write(JSON.stringify(tree));

--- a/examples/loader-github-repo/src/data/github-repo.ts
+++ b/examples/loader-github-repo/src/data/github-repo.ts
@@ -1,23 +1,22 @@
 import "dotenv/config";
-const { GITHUB_REPO, NPM_PACKAGE } = process.env;
-import { graphql } from "./github.js";
+const {GITHUB_REPO, NPM_PACKAGE} = process.env;
+import {graphql} from "./github.js";
 
 interface REPO_NODE {
   nameWithOwner: string;
   descriptionHTML: string;
   stargazerCount: number;
   diskUsage: number;
-  issues: { totalCount: number };
-  collaborators: { totalCount: number };
-  watchers: { totalCount: number };
-  defaultBranchRef: { name: string };
+  issues: {totalCount: number};
+  collaborators: {totalCount: number};
+  watchers: {totalCount: number};
+  defaultBranchRef: {name: string};
   NPM_PACKAGE: string | undefined;
 }
 
 export async function getRepo(): Promise<REPO_NODE> {
-  if (GITHUB_REPO == null)
-    throw new Error("Please specify a repository in GITHUB_REPO.");
-  const { repository }: { repository: REPO_NODE } = await graphql({
+  if (GITHUB_REPO == null) throw new Error("Please specify a repository in GITHUB_REPO.");
+  const {repository}: {repository: REPO_NODE} = await graphql({
     query: `query repo ($owner: String!, $name: String!) {
       repository(owner: $owner, name: $name) {
         nameWithOwner
@@ -34,7 +33,7 @@ export async function getRepo(): Promise<REPO_NODE> {
       }
     }`,
     owner: GITHUB_REPO.split("/")[0].replace(/^@/, ""),
-    name: GITHUB_REPO.split("/")[1],
+    name: GITHUB_REPO.split("/")[1]
   });
-  return { ...repository, NPM_PACKAGE };
+  return {...repository, NPM_PACKAGE};
 }

--- a/examples/loader-github-repo/src/data/github-repo.ts
+++ b/examples/loader-github-repo/src/data/github-repo.ts
@@ -1,0 +1,40 @@
+import "dotenv/config";
+const { GITHUB_REPO, NPM_PACKAGE } = process.env;
+import { graphql } from "./github.js";
+
+interface REPO_NODE {
+  nameWithOwner: string;
+  descriptionHTML: string;
+  stargazerCount: number;
+  diskUsage: number;
+  issues: { totalCount: number };
+  collaborators: { totalCount: number };
+  watchers: { totalCount: number };
+  defaultBranchRef: { name: string };
+  NPM_PACKAGE: string | undefined;
+}
+
+export async function getRepo(): Promise<REPO_NODE> {
+  if (GITHUB_REPO == null)
+    throw new Error("Please specify a repository in GITHUB_REPO.");
+  const { repository }: { repository: REPO_NODE } = await graphql({
+    query: `query repo ($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        nameWithOwner
+        descriptionHTML
+        archivedAt
+        stargazerCount
+        diskUsage
+        issues {totalCount}
+        watchers {totalCount}
+        defaultBranchRef {
+          name
+          target {... on Commit { history(first: 0) {totalCount} } }
+        }
+      }
+    }`,
+    owner: GITHUB_REPO.split("/")[0].replace(/^@/, ""),
+    name: GITHUB_REPO.split("/")[1],
+  });
+  return { ...repository, NPM_PACKAGE };
+}

--- a/examples/loader-github-repo/src/data/github.ts
+++ b/examples/loader-github-repo/src/data/github.ts
@@ -1,24 +1,18 @@
-import { GITHUB_TOKEN } from "./config.js";
-import { graphql as gql } from "@octokit/graphql";
+import {GITHUB_TOKEN} from "./config.js";
+import {graphql as gql} from "@octokit/graphql";
 
 export async function github(
   path: string,
-  {
-    authorization = GITHUB_TOKEN && `token ${GITHUB_TOKEN}`,
-    accept = "application/vnd.github.v3+json",
-  } = {}
+  {authorization = GITHUB_TOKEN && `token ${GITHUB_TOKEN}`, accept = "application/vnd.github.v3+json"} = {}
 ) {
   const url = new URL(path, "https://api.github.com");
-  const headers = { ...(authorization && { authorization }), accept };
-  const response = await fetch(url, { headers });
+  const headers = {...(authorization && {authorization}), accept};
+  const response = await fetch(url, {headers});
   if (!response.ok) throw new Error(`fetch error: ${response.status} ${url}`);
-  return { headers: response.headers, body: await response.json() };
+  return {headers: response.headers, body: await response.json()};
 }
 
-export async function* githubList<T = any>(
-  path: string,
-  { reverse = true, ...options }: any = {}
-): AsyncGenerator<T> {
+export async function* githubList<T = any>(path: string, {reverse = true, ...options}: any = {}): AsyncGenerator<T> {
   const url = new URL(path, "https://api.github.com");
   url.searchParams.set("per_page", "100");
   url.searchParams.set("page", "1");
@@ -56,5 +50,5 @@ function findRelLink(headers, name) {
 }
 
 export const graphql = gql.defaults({
-  headers: { authorization: `token ${GITHUB_TOKEN}` },
+  headers: {authorization: `token ${GITHUB_TOKEN}`}
 });

--- a/examples/loader-github-repo/src/data/github.ts
+++ b/examples/loader-github-repo/src/data/github.ts
@@ -1,0 +1,60 @@
+import { GITHUB_TOKEN } from "./config.js";
+import { graphql as gql } from "@octokit/graphql";
+
+export async function github(
+  path: string,
+  {
+    authorization = GITHUB_TOKEN && `token ${GITHUB_TOKEN}`,
+    accept = "application/vnd.github.v3+json",
+  } = {}
+) {
+  const url = new URL(path, "https://api.github.com");
+  const headers = { ...(authorization && { authorization }), accept };
+  const response = await fetch(url, { headers });
+  if (!response.ok) throw new Error(`fetch error: ${response.status} ${url}`);
+  return { headers: response.headers, body: await response.json() };
+}
+
+export async function* githubList<T = any>(
+  path: string,
+  { reverse = true, ...options }: any = {}
+): AsyncGenerator<T> {
+  const url = new URL(path, "https://api.github.com");
+  url.searchParams.set("per_page", "100");
+  url.searchParams.set("page", "1");
+  const first = await github(String(url), options);
+  if (reverse) {
+    let prevUrl = findRelLink(first.headers, "last");
+    if (prevUrl) {
+      do {
+        const next = await github(prevUrl, options);
+        yield* next.body.reverse(); // reverse order
+        prevUrl = findRelLink(next.headers, "prev");
+      } while (prevUrl);
+    } else {
+      yield* first.body.reverse();
+    }
+  } else {
+    yield* first.body;
+    let nextUrl = findRelLink(first.headers, "next");
+    while (nextUrl) {
+      const next = await github(nextUrl, options);
+      yield* next.body; // natural order
+      nextUrl = findRelLink(next.headers, "next");
+    }
+  }
+}
+
+function findRelLink(headers, name) {
+  return headers
+    .get("link")
+    ?.split(/,\s+/g)
+    .map((link) => link.split(/;\s+/g))
+    .find(([, rel]) => rel === `rel="${name}"`)?.[0]
+    .replace(/^</, "")
+    .replace(/>$/, "");
+}
+
+export const graphql = gql.defaults({
+  headers: { authorization: `token ${GITHUB_TOKEN}` },
+});

--- a/examples/loader-github-repo/src/data/issues.json.ts
+++ b/examples/loader-github-repo/src/data/issues.json.ts
@@ -1,0 +1,41 @@
+import { githubList } from "./github.js";
+import { getRepo } from "./github-repo.js";
+
+const repo = await getRepo();
+
+const issues: any[] = [];
+
+process.stdout.write("[\n");
+const { nameWithOwner } = repo;
+process.stderr.write(`\n${nameWithOwner}`);
+process.stderr.write("loading issues");
+
+let i = 0;
+for await (const issue of githubList(
+  `/repos/${nameWithOwner}/issues?state=all`,
+  {
+    reverse: true,
+  }
+)) {
+  process.stderr.write(i % 100 ? "+" : `${i}`);
+  if (i++) process.stdout.write("\n,");
+
+  process.stdout.write(
+    JSON.stringify({
+      id: issue.id,
+      title: issue.title,
+      user: issue.user?.login,
+      state: issue.state,
+      created_at: issue.created_at,
+      closed_at: issue.closed_at,
+      updated_at: issue.updated_at,
+      comments: issue.comments,
+      reactions: issue.reactions.total_count,
+      pull_request: issue.pull_request,
+      url: issue.html_url,
+    })
+  );
+}
+
+process.stderr.write("\n");
+process.stdout.write("\n]\n");

--- a/examples/loader-github-repo/src/data/issues.json.ts
+++ b/examples/loader-github-repo/src/data/issues.json.ts
@@ -1,22 +1,19 @@
-import { githubList } from "./github.js";
-import { getRepo } from "./github-repo.js";
+import {githubList} from "./github.js";
+import {getRepo} from "./github-repo.js";
 
 const repo = await getRepo();
 
 const issues: any[] = [];
 
 process.stdout.write("[\n");
-const { nameWithOwner } = repo;
+const {nameWithOwner} = repo;
 process.stderr.write(`\n${nameWithOwner}`);
 process.stderr.write("loading issues");
 
 let i = 0;
-for await (const issue of githubList(
-  `/repos/${nameWithOwner}/issues?state=all`,
-  {
-    reverse: true,
-  }
-)) {
+for await (const issue of githubList(`/repos/${nameWithOwner}/issues?state=all`, {
+  reverse: true
+})) {
   process.stderr.write(i % 100 ? "+" : `${i}`);
   if (i++) process.stdout.write("\n,");
 
@@ -32,7 +29,7 @@ for await (const issue of githubList(
       comments: issue.comments,
       reactions: issue.reactions.total_count,
       pull_request: issue.pull_request,
-      url: issue.html_url,
+      url: issue.html_url
     })
   );
 }

--- a/examples/loader-github-repo/src/data/npm-downloads.csv.ts
+++ b/examples/loader-github-repo/src/data/npm-downloads.csv.ts
@@ -1,11 +1,11 @@
-import { csvFormat } from "d3-dsv";
-import { timeDay, utcDay } from "d3-time";
-import { utcFormat } from "d3-time-format";
-import { github } from "./github.js";
-import { getRepo } from "./github-repo.js";
+import {csvFormat} from "d3-dsv";
+import {timeDay, utcDay} from "d3-time";
+import {utcFormat} from "d3-time-format";
+import {getRepo} from "./github-repo.js";
+import {github} from "./github.js";
 
 const repo = await getRepo();
-const { nameWithOwner, NPM_PACKAGE } = repo;
+const {nameWithOwner, NPM_PACKAGE} = repo;
 
 async function load(name) {
   const end = utcDay(timeDay()); // exclusive
@@ -18,15 +18,15 @@ async function load(name) {
     batchEnd = batchStart;
     batchStart = utcDay.offset(batchStart, -365);
     if (batchStart < min) batchStart = min;
-    const url = `https://api.npmjs.org/downloads/range/${formatDate(
-      batchStart
-    )}:${formatDate(utcDay.offset(batchEnd, -1))}/${name}`;
+    const url = `https://api.npmjs.org/downloads/range/${formatDate(batchStart)}:${formatDate(
+      utcDay.offset(batchEnd, -1)
+    )}/${name}`;
     console.warn(url);
     const response = await fetch(url);
     if (!response.ok) throw new Error(`fetch failed: ${response.status}`);
     const batch = await response.json();
-    for (const { downloads: value, day: date } of batch.downloads.reverse()) {
-      data.push({ date: new Date(date), value });
+    for (const {downloads: value, day: date} of batch.downloads.reverse()) {
+      data.push({date: new Date(date), value});
     }
   }
   for (let i = data.length - 1; i >= 0; --i) {
@@ -40,6 +40,6 @@ async function load(name) {
 let name = NPM_PACKAGE;
 if (name === undefined) {
   const pck = await github(`/repos/${nameWithOwner}/contents/package.json`);
-  ({ name } = JSON.parse(atob(pck.body.content)));
+  ({name} = JSON.parse(atob(pck.body.content)));
 }
 if (name) process.stdout.write(csvFormat(await load(name)));

--- a/examples/loader-github-repo/src/data/npm-downloads.csv.ts
+++ b/examples/loader-github-repo/src/data/npm-downloads.csv.ts
@@ -42,4 +42,4 @@ if (name === undefined) {
   const pck = await github(`/repos/${nameWithOwner}/contents/package.json`);
   ({ name } = JSON.parse(atob(pck.body.content)));
 }
-process.stdout.write(csvFormat(await load(name)));
+if (name) process.stdout.write(csvFormat(await load(name)));

--- a/examples/loader-github-repo/src/data/npm-downloads.csv.ts
+++ b/examples/loader-github-repo/src/data/npm-downloads.csv.ts
@@ -1,0 +1,45 @@
+import { csvFormat } from "d3-dsv";
+import { timeDay, utcDay } from "d3-time";
+import { utcFormat } from "d3-time-format";
+import { github } from "./github.js";
+import { getRepo } from "./github-repo.js";
+
+const repo = await getRepo();
+const { nameWithOwner, NPM_PACKAGE } = repo;
+
+async function load(name) {
+  const end = utcDay(timeDay()); // exclusive
+  const data: any[] = [];
+  const formatDate = utcFormat("%Y-%m-%d");
+  const min = new Date("2021-01-01");
+  let batchStart = end;
+  let batchEnd;
+  while (batchStart > min) {
+    batchEnd = batchStart;
+    batchStart = utcDay.offset(batchStart, -365);
+    if (batchStart < min) batchStart = min;
+    const url = `https://api.npmjs.org/downloads/range/${formatDate(
+      batchStart
+    )}:${formatDate(utcDay.offset(batchEnd, -1))}/${name}`;
+    console.warn(url);
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`fetch failed: ${response.status}`);
+    const batch = await response.json();
+    for (const { downloads: value, day: date } of batch.downloads.reverse()) {
+      data.push({ date: new Date(date), value });
+    }
+  }
+  for (let i = data.length - 1; i >= 0; --i) {
+    if (data[i].value > 0) {
+      return data.slice(data[0].value > 0 ? 0 : 1, i + 1); // ignore npm reporting zero for today
+    }
+  }
+  throw new Error("empty dataset");
+}
+
+let name = NPM_PACKAGE;
+if (name === undefined) {
+  const pck = await github(`/repos/${nameWithOwner}/contents/package.json`);
+  ({ name } = JSON.parse(atob(pck.body.content)));
+}
+process.stdout.write(csvFormat(await load(name)));

--- a/examples/loader-github-repo/src/data/repo.json.ts
+++ b/examples/loader-github-repo/src/data/repo.json.ts
@@ -1,3 +1,3 @@
-import { getRepo } from "./github-repo.js";
+import {getRepo} from "./github-repo.js";
 
 process.stdout.write(JSON.stringify(await getRepo()));

--- a/examples/loader-github-repo/src/data/repo.json.ts
+++ b/examples/loader-github-repo/src/data/repo.json.ts
@@ -1,0 +1,3 @@
+import { getRepo } from "./github-repo.js";
+
+process.stdout.write(JSON.stringify(await getRepo()));

--- a/examples/loader-github-repo/src/index.md
+++ b/examples/loader-github-repo/src/index.md
@@ -1,0 +1,443 @@
+---
+sql:
+  commits: data/commits.parquet
+---
+
+# GitHub: ${repo.nameWithOwner}
+
+This dashboard shows the structure and recent activity of the **${repo.nameWithOwner}** GitHub repository: _“${stripTags(repo.descriptionHTML)}”_
+
+## Development
+
+_Recent issues and pull requests._
+
+<div class="card grid grid-cols-1">${resize(issuesPlot)}</div>
+
+_Recent commits_
+
+<div class="card grid grid-cols-1">${commitsPlot(width, [d3.utcMonth.offset(new Date(), -12), new Date()])}</div>
+
+_Recent comments_
+
+<div class="card grid grid-cols-1">${resize(commentsPlot)}</div>
+
+## Overview
+
+<div class="grid grid-cols-2">
+  <div class="card">${BigNumber(repo.stargazerCount, {title: "stars"})}</div>
+  <div class="card if-downloads">${BigNumber(d3.sum(downloads, d => d.value), {title: "npm downloads"})}</div>
+</div>
+
+<div class="grid grid-cols-1 if-downloads" style="grid-auto-rows: calc(250px + 2rem);">
+  <div class="card">${resize((width) => DailyPlot(downloads, {width, title: "Daily npm downloads", label: "downloads"}))}</div>
+  ${downloads.length === 0 ? html`<style>.if-downloads {display: none;}</style>` : ""}
+
+</div>
+
+<div class="grid grid-cols-2">
+  <div class="card">${BigNumber(repo.defaultBranchRef?.target?.history?.totalCount ?? commits.length, {title: "commits"})}</div>
+  <div class="card">${BigNumber(authors.length, {title: "contributors"})}</div>
+</div>
+
+<div class="card grid grid-cols-1">${commitsPlot(width)}</div>
+
+<div class="card grid grid-cols-1">${impactPlot(width)}</div>
+
+## Files
+
+<div class="grid grid-cols-2">
+  <div class="card">${BigNumber(d3.count(files, (d) => d.size), {title: "Number of files"})}</div>
+  <div class="card">${BigNumber(files.size, {title: "Total bytes"})}</div>
+</div>
+
+<div class="grid grid-cols-1 card">${resize(width => filesChart(width, files))}</div>
+
+## Issues
+
+_Burndown chart._
+
+<div class="card grid grid-cols-1">${
+  resize((width) => burndownChart(width))}
+</div>
+
+_Most commented issues._
+
+<div class="grid grid-cols-1" style="grid-auto-rows: 276px;">
+    <div class="card" style="padding: 0;">${
+    Inputs.table(
+      issues
+        .filter((d) => d.state === "open" && d.reactions > 5)
+        .sort((a, b) => b.reactions - a.reactions)
+        .map((d) => ({
+          "title": {title: d.title, number: d.number},
+          "reactions": d.reactions,
+          "days old": d3.utcDay.count(new Date(d.created_at), today)
+        })),
+      {
+        format: {
+          title: (d) => html`<a href="https://github.com/observablehq/plot/issues/${d.number}""target="_blank">${d.title}</a>`
+        }
+      }
+    )
+  }</div>
+</div>
+
+<!-- DATA -->
+
+```js
+const repo = FileAttachment("data/repo.json").json();
+```
+
+```js
+const downloads = FileAttachment("data/npm-downloads.csv").csv({ typed: true });
+```
+
+```js
+const comments = await FileAttachment("data/comments.json").json();
+for (const c of comments) c.date = new Date(c.date);
+```
+
+```js
+const authors = Array.from(
+  await sql`SELECT author, COUNT() AS c FROM commits GROUP BY 1 ORDER BY 2 DESC`,
+  ({ author }) => author
+);
+const commits = sql`
+SELECT author AS author_name
+     , date
+  FROM commits
+ ORDER BY 2
+`;
+```
+
+```js
+const impact = sql`SELECT hash, author, date, files, insertions, deletions FROM commits;`;
+```
+
+```js
+const issues = await FileAttachment("data/issues.json").json();
+for (const i of issues) {
+  i.date = new Date(i.created_at);
+  i.type = i.pull_request ? "PR" : "issue";
+}
+```
+
+```js
+const span = 92; // days
+const today = d3.utcDay.offset(d3.utcDay(Date.now()), 1);
+const lastWeek = d3.utcDay.offset(today, -7);
+const start = d3.utcDay.offset(today, -span);
+```
+
+<!-- ISSUES CHART -->
+
+```js
+const recentIssues = d3.sort(
+  issues.filter((d) => d.date > start),
+  (d) => !d.closed_at
+);
+const domain = d3.groupSort(
+  recentIssues,
+  (v) => -v.length,
+  (d) => d.user
+);
+if (domain.length > 10)
+  domain.splice(9, domain.length, [`${domain.length - 9} others`]);
+const color = Plot.scale({
+  color: { domain, unknown: d3.schemeObservable10[9] },
+});
+```
+
+```js
+function issuesPlot(width) {
+  return Plot.plot({
+    width,
+    style: "overflow: visible",
+    x: { domain: [start, today], interval: "day", inset: 10 },
+    y: { axis: null },
+    color: { ...color, legend: true },
+    opacity: { label: "status" },
+    symbol: { range: ["square", "circle"], legend: true },
+    aspectRatio: 1 / (24 * 3600 * 1000),
+    marks: [
+      Plot.ruleY([0]),
+      Plot.dotX(
+        recentIssues,
+        Plot.stackY2({
+          x: "date",
+          stroke: "user",
+          fill: "user",
+          y: (d) => (d.type === "PR" ? 1 : -1),
+          symbol: "type",
+          fillOpacity: (d) => !!d.closed_at,
+          r: (width - 40) / span / 3,
+          href: "url",
+          target: "_blank",
+          tip: {
+            channels: {
+              name: "title",
+              closed: (d) => !!d.closed_at,
+            },
+            format: {
+              y: false,
+              fillOpacity: false,
+            },
+          },
+        })
+      ),
+    ],
+  });
+}
+```
+
+<!-- COMMENTS CHART -->
+
+```js
+function commentsPlot(width) {
+  const options = {
+    width,
+    height: 0,
+    x: { domain: [start, today], inset: 10 },
+    style: "overflow: hidden",
+    color,
+    marks: [
+      Plot.frame({ anchor: "bottom" }),
+      Plot.dotX(
+        comments,
+        Plot.dodgeY({
+          filter: (d) => d.date > start,
+          sort: "date",
+          x: "date",
+          fill: "login",
+          r: 2.5,
+          href: "html_url",
+          target: "_blank",
+          tip: {
+            channels: {
+              about: (d) => d.html_url.match(/((issues|pull)\/\d+)/)?.[1],
+              body: "body",
+            },
+          },
+        })
+      ),
+    ],
+  };
+  const height = Math.min(
+    500,
+    10 +
+      d3.max(
+        d3.select(Plot.plot(options)).selectAll("circle"),
+        (d) => -d.getAttribute("cy")
+      )
+  );
+  return Plot.plot({ ...options, height });
+}
+```
+
+<!-- FILES CHART -->
+
+```js
+const rawfiles = FileAttachment("data/files.json").json();
+import { Treemap } from "/components/treemap.js";
+import { Swatches } from "/components/color-legend.js";
+```
+
+```js
+const files = rawfiles;
+files.size = d3.sum(rawfiles, (d) => d.size);
+```
+
+```js
+function filesChart(width, files) {
+  const chart = Treemap(files, {
+    path: (d) => d.path,
+    width,
+    label: (d) =>
+      `${d.path.split("/").pop()}\n${d.size?.toLocaleString("en-US")}`,
+    value: (d) => d.size,
+    height: width,
+    group: (d) =>
+      `${d.path.split("/").slice(0, -1).slice(0, 2).join("/") || "/"}`,
+  });
+
+  return html`<div class="swatches">
+      ${Swatches(
+        chart.scales.color.domain(chart.scales.color.domain().slice(0, 9))
+      )}
+    </div>
+    <style>
+      .swatches span::before {
+        opacity: 0.7;
+      }
+    </style>
+    ${chart}`;
+}
+```
+
+<!-- ISSUES BURNDOWN CHART -->
+
+```js
+const cohorts = 50;
+
+const startB = d3.min(issues, (d) => new Date(d.created_at));
+
+const burndown = d3
+  .bin()
+  .thresholds(d3.utcTicks(startB, today, cohorts))
+  .value((d) => new Date(d.created_at))(issues)
+  .map((bin) =>
+    bin.map((d) => {
+      const created = new Date(d.created_at);
+      const a = { cohort: bin.x0, date: created, count: 1 };
+      const closed = new Date(d.closed_at ?? NaN);
+      return [a, { ...a, date: closed, count: -1 }];
+    })
+  )
+  .flat(2);
+
+const burndownChart = (width) =>
+  Plot.plot({
+    width,
+    marginRight: 60,
+    color: { type: "utc", legend: true, label: "date opened" },
+    x: { type: "utc", domain: [startB, today] },
+    y: { axis: "right", grid: true, label: "↑ Open issues" },
+    marks: [
+      Plot.areaY(
+        burndown,
+        Plot.mapY(
+          "cumsum",
+          Plot.binX(
+            { y: "sum", thresholds: 500, filter: null },
+            {
+              x: "date",
+              fill: "cohort",
+              stroke: "cohort",
+              strokeWidth: 0.5,
+              y: "count",
+              curve: "step-after",
+              clip: "frame",
+              // filter out shallow segments during stacking
+              offset: (I, X1, X2) =>
+                I.flat(2).forEach((i) => X2[i] === X1[i] && (X2[i] = NaN)),
+              tip: {
+                format: {
+                  y: (d) => d,
+                  x: (d) => d3.isoFormat(d).slice(0, 10),
+                  fill: (d) => d3.isoFormat(d).slice(0, 7),
+                },
+              },
+            }
+          )
+        )
+      ),
+      Plot.ruleY([0]),
+    ],
+  });
+```
+
+```js
+import { BigNumber } from "./components/bigNumber.js";
+import { DailyPlot } from "./components/dailyPlot.js";
+
+const stripTags = (html) =>
+  new DOMParser().parseFromString(html, "text/html")?.body.textContent ?? "";
+```
+
+```js
+function commitsPlot(width, domain) {
+  const top_names = new Set(authors.slice(0, 18));
+  const author_domain =
+    authors.length > 18 ? [...top_names, "Others"] : authors;
+  const range = [
+    ...d3.schemeObservable10.slice(0, 9),
+    ...d3.schemeObservable10.slice(0, 9),
+  ]
+    .slice(0, top_names.size)
+    .concat(d3.schemeObservable10[9]);
+  return Plot.plot({
+    width,
+    x: { type: "utc" },
+    color: {
+      domain: author_domain,
+      range,
+    },
+    marks: [
+      Plot.rectY(
+        commits,
+        Plot.binX(undefined, {
+          x: "date",
+          title: "author_name",
+          fill: (d) =>
+            top_names.has(d.author_name) ? d.author_name : "Others",
+          order: [...top_names],
+          domain,
+          thresholds: 70,
+          tip: true,
+        })
+      ),
+    ],
+  });
+}
+```
+
+```js
+function impactPlot(width) {
+  const cumulative = Plot.rectY(
+    impact,
+    Plot.mapY(
+      "cumsum",
+      Plot.binX(
+        { y: "sum" },
+        {
+          x: "date",
+          y: (d) => (d.insertions ?? 0) - (d.deletions ?? 0),
+          interval: "month",
+        }
+      )
+    )
+  );
+  cumulative.initialize();
+  const cumsumY = cumulative.channels.y2.value.transform();
+  const shiftY = (y) => y.map((d, i) => d + (i ? cumsumY[i - 1] : 0));
+
+  return Plot.plot({
+    width,
+    y: { tickFormat: "s", grid: true },
+    color: { legend: true, range: ["hsl(80,50%,60%)", "hsl(0,100%,70%)"] },
+    marks: [
+      Plot.ruleY([0]),
+      Plot.rectY(
+        impact,
+        Plot.map(
+          { y1: shiftY, y2: shiftY },
+          Plot.binX(
+            { y2: "sum", y1: () => 0 },
+            {
+              x: "date",
+              y: "insertions",
+              fill: () => "+ lines added",
+              interval: "month",
+            }
+          )
+        )
+      ),
+      Plot.rectY(
+        impact,
+        Plot.map(
+          { y1: shiftY, y2: shiftY },
+          Plot.binX(
+            { y2: "sum", y1: () => 0 },
+            {
+              x: "date",
+              y: (d) => -d.deletions,
+              fill: () => "− lines deleted",
+              interval: "month",
+            }
+          )
+        )
+      ),
+    ],
+  });
+}
+```


### PR DESCRIPTION
an example of querying GitHub, git, npm… to get a lot of information about a repo.

built for the [facebook/react](https://github.com/facebook/react) repo and deployed at https://observablehq.observablehq.cloud/framework-example-loader-github-react/

**facebook/react** is very interesting as it's a large, popular, collaborative project with quite a bit of history. I'm not sure that the charts are all self-explaining, and maybe it would be interesting to add some editorial content? (At the very least we could hard-code the repo name in the title before deploying.)

Also, maybe this is a showcase example… or a template as we initially thought…?

I've tested this with other repos, such as torvalds/linux and its 1.2+ million commits — and was also thinking that the deployed version could have several pages showing different source repos.