### PR TITLE
support view(jsx)

### DIFF
--- a/src/client/main.js
+++ b/src/client/main.js
@@ -101,6 +101,7 @@ function displayJsx(root, value) {
       root.parentNode.insertBefore(node, root);
     }
     client.render(value);
+    if (typeof value?.props?.onMount === "function") requestAnimationFrame(() => value.props.onMount(node.firstChild));
   });
 }
 

--- a/src/client/stdlib/generators/input.js
+++ b/src/client/stdlib/generators/input.js
@@ -1,6 +1,19 @@
 import {observe} from "./observe.js";
 
 export function input(element) {
+  // JSX?
+  if (element["$$typeof"] === Symbol.for("react.element")) {
+    return observe((change) => {
+      const event = eventof(element);
+      const onEvent = `on${event[0].toUpperCase()}${event.slice(1)}`;
+      element.props[onEvent] = ({nativeEvent}) => change(valueof(nativeEvent.target));
+      element.props["onMount"] = function (element) {
+        const value = valueof(element);
+        if (value !== undefined) change(value);
+      };
+      return () => delete element.props[onEvent];
+    });
+  }
   return observe((change) => {
     const event = eventof(element);
     let value = valueof(element);


### PR DESCRIPTION
probably not the correct solution (?). Creates a "fake" `onMount` event and runs it after the jsx component is rendered into the DOM.

it works for the basic example:

~~~~
```jsx echo
const a = view(<input type="range"></input>);
```

${a}
~~~~

The main difficulty is that `jsx` cannot return its DOM node because it's creating it asynchronously, and `view` expects it synchronously. The second difficulty is that I don't know if we should `useRef`, `onMount`, or something else instead. 

closes #1503