### PR TITLE
Add example of canvas to png data loader

### DIFF
--- a/examples/loader-canvas-to-png/.gitignore
+++ b/examples/loader-canvas-to-png/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/dist/
+node_modules/
+yarn-error.log
+.venv

--- a/examples/loader-canvas-to-png/README.md
+++ b/examples/loader-canvas-to-png/README.md
@@ -1,6 +1,6 @@
 [Framework examples →](../)
 
-# Python data loader to generate PNG
+# Data loader to generate PNG from canvas
 
 View live: <https://observablehq.observablehq.cloud/framework-example-loader-canvas-to-png/>
 

--- a/examples/loader-canvas-to-png/README.md
+++ b/examples/loader-canvas-to-png/README.md
@@ -4,4 +4,4 @@
 
 View live: <https://observablehq.observablehq.cloud/framework-example-loader-canvas-to-png/>
 
-This Observable Framework example demonstrates how to write a Node.js data loader that creates a canvas map using d3, and then returns the map as a PNG file to standard out. The data loader generates a map of the United States using [the official d3 example](https://observablehq.com/@d3/u-s-map-canvas). The data loader lives in [`src/data/us-map.png.js`](./src/data/us-map.png.js).
+This Observable Framework example demonstrates how to write a Node.js data loader that creates a map using [node-canvas](https://github.com/Automattic/node-canvas) and D3, then writes the map to standard out as a PNG. The data loader lives in [`src/data/us-map.png.js`](./src/data/us-map.png.js).

--- a/examples/loader-canvas-to-png/README.md
+++ b/examples/loader-canvas-to-png/README.md
@@ -1,0 +1,7 @@
+[Framework examples →](../)
+
+# Python data loader to generate PNG
+
+View live: <https://observablehq.observablehq.cloud/framework-example-loader-canvas-to-png/>
+
+This Observable Framework example demonstrates how to write a Node.js data loader that creates a canvas map using d3, and then returns the map as a PNG file to standard out. The data loader generates a map of the United States using [the official d3 example](https://observablehq.com/@d3/u-s-map-canvas). The data loader lives in [`src/data/us-map.png.js`](./src/data/us-map.png.js).

--- a/examples/loader-canvas-to-png/observablehq.config.js
+++ b/examples/loader-canvas-to-png/observablehq.config.js
@@ -1,0 +1,3 @@
+export default {
+  root: "src"
+};

--- a/examples/loader-canvas-to-png/package.json
+++ b/examples/loader-canvas-to-png/package.json
@@ -9,7 +9,7 @@
     "observable": "observable"
   },
   "dependencies": {
-    "@observablehq/framework": "^1.7.0",
+    "@observablehq/framework": "latest",
     "topojson-client": "^3.0.0",
     "d3": "^7.0.0",
     "canvas": "^2.8.0"

--- a/examples/loader-canvas-to-png/package.json
+++ b/examples/loader-canvas-to-png/package.json
@@ -1,0 +1,23 @@
+{
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "clean": "rimraf src/.observablehq/cache",
+    "build": "rimraf dist && observable build",
+    "dev": "observable preview",
+    "deploy": "observable deploy",
+    "observable": "observable"
+  },
+  "dependencies": {
+    "@observablehq/framework": "^1.7.0",
+    "topojson-client": "^3.0.0",
+    "d3": "^7.0.0",
+    "canvas": "^2.8.0"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/loader-canvas-to-png/src/.gitignore
+++ b/examples/loader-canvas-to-png/src/.gitignore
@@ -1,0 +1,1 @@
+/.observablehq/cache/

--- a/examples/loader-canvas-to-png/src/data/us-map.png.js
+++ b/examples/loader-canvas-to-png/src/data/us-map.png.js
@@ -16,6 +16,7 @@ const context = canvas.getContext("2d");
 // https://observablehq.com/@d3/u-s-map-canvas
 context.lineJoin = "round";
 context.lineCap = "round";
+// Use the null projection, since coordinates in US Atlas are already projected.
 const path = d3.geoPath(null, context);
 
 context.fillStyle = "#fff";

--- a/examples/loader-canvas-to-png/src/data/us-map.png.js
+++ b/examples/loader-canvas-to-png/src/data/us-map.png.js
@@ -11,7 +11,7 @@ const us = await fetch(url).then(response => response.json());
 const width = 975;
 const height = 610;
 const canvas = createCanvas(width, height);
-const context = cvs.getContext("2d");
+const context = canvas.getContext("2d");
 
 // Draw the map based on the official d3 example
 // https://observablehq.com/@d3/u-s-map-canvas

--- a/examples/loader-canvas-to-png/src/data/us-map.png.js
+++ b/examples/loader-canvas-to-png/src/data/us-map.png.js
@@ -1,5 +1,5 @@
-import * as canvas from 'canvas';
-import * as d3 from 'd3';
+import {createCanvas} from "canvas";
+import * as d3 from "d3";
 import * as topojson from "topojson-client";
 
 // Get the map file from the US Atlas package

--- a/examples/loader-canvas-to-png/src/data/us-map.png.js
+++ b/examples/loader-canvas-to-png/src/data/us-map.png.js
@@ -18,6 +18,9 @@ context.lineJoin = "round";
 context.lineCap = "round";
 const path = d3.geoPath(null, context);
 
+context.fillStyle = "#fff";
+context.fillRect(0, 0, width, height);
+
 context.beginPath();
 path(topojson.mesh(us, us.objects.counties, (a, b) => a !== b && (a.id / 1000 | 0) === (b.id / 1000 | 0)));
 context.lineWidth = 0.5;

--- a/examples/loader-canvas-to-png/src/data/us-map.png.js
+++ b/examples/loader-canvas-to-png/src/data/us-map.png.js
@@ -13,7 +13,6 @@ const height = 610;
 const canvas = createCanvas(width, height);
 const context = canvas.getContext("2d");
 
-// Draw the map based on the official d3 example
 // https://observablehq.com/@d3/u-s-map-canvas
 context.lineJoin = "round";
 context.lineCap = "round";

--- a/examples/loader-canvas-to-png/src/data/us-map.png.js
+++ b/examples/loader-canvas-to-png/src/data/us-map.png.js
@@ -1,0 +1,44 @@
+import * as canvas from 'canvas';
+import * as d3 from 'd3';
+import * as topojson from "topojson-client";
+
+// Get the map file from the US Atlas package
+// https://github.com/topojson/us-atlas
+const url = "https://cdn.jsdelivr.net/npm/us-atlas@3/counties-albers-10m.json";
+const us = await fetch(url).then(response => response.json());
+
+// Create and configure a canvas
+const width = 975;
+const height = 610;
+const cvs = canvas.createCanvas(width, height);
+const context = cvs.getContext("2d");
+
+// Draw the map based on the official d3 example
+// https://observablehq.com/@d3/u-s-map-canvas
+context.lineJoin = "round";
+context.lineCap = "round";
+const path = d3.geoPath(null, context);
+
+context.beginPath();
+path(topojson.mesh(us, us.objects.counties, (a, b) => a !== b && (a.id / 1000 | 0) === (b.id / 1000 | 0)));
+context.lineWidth = 0.5;
+context.strokeStyle = "#aaa";
+context.stroke();
+
+context.beginPath();
+path(topojson.mesh(us, us.objects.states, (a, b) => a !== b));
+context.lineWidth = 0.5;
+context.strokeStyle = "#000";
+context.stroke();
+
+context.beginPath();
+path(topojson.feature(us, us.objects.nation));
+context.lineWidth = 1;
+context.strokeStyle = "#000";
+context.stroke();
+
+// Write the canvas to a PNG buffer
+const buffer = cvs.toBuffer("image/png");
+
+// Pipe the buffer to process.stdout
+process.stdout.write(buffer);

--- a/examples/loader-canvas-to-png/src/data/us-map.png.js
+++ b/examples/loader-canvas-to-png/src/data/us-map.png.js
@@ -10,7 +10,7 @@ const us = await fetch(url).then(response => response.json());
 // Create and configure a canvas
 const width = 975;
 const height = 610;
-const cvs = canvas.createCanvas(width, height);
+const canvas = createCanvas(width, height);
 const context = cvs.getContext("2d");
 
 // Draw the map based on the official d3 example

--- a/examples/loader-canvas-to-png/src/index.md
+++ b/examples/loader-canvas-to-png/src/index.md
@@ -1,6 +1,6 @@
 # Data loader to generate PNG from canvas
 
-Here’s a Node.js data loader that creates a canvas map using d3, and then returns the map as a PNG file to standard out.
+Here’s a Node.js data loader that creates a map using [node-canvas](https://github.com/Automattic/node-canvas) and D3, then writes the map to standard out as a PNG.
 
 This pattern can be used to render maps that require with a large amount of data as lightweight static files.
 

--- a/examples/loader-canvas-to-png/src/index.md
+++ b/examples/loader-canvas-to-png/src/index.md
@@ -1,0 +1,66 @@
+# Data loader to generate PNG from canvas
+
+Here’s a Node.js data loader that fetches creates a canvas map using d3, and then returns the map as a PNG file to standard out.
+
+This pattern could be used to render maps that require with a large amount of data as lightweight static files.
+
+```js run=false
+import * as canvas from 'canvas';
+import * as d3 from 'd3';
+import * as topojson from "topojson-client";
+
+// Get the map file from the US Atlas package
+// https://github.com/topojson/us-atlas
+const url = "https://cdn.jsdelivr.net/npm/us-atlas@3/counties-albers-10m.json";
+const us = await fetch(url).then(response => response.json());
+
+// Create and configure a canvas
+const width = 975;
+const height = 610;
+const cvs = canvas.createCanvas(width, height);
+const context = cvs.getContext("2d");
+
+// Draw the map based on the official d3 example
+// https://observablehq.com/@d3/u-s-map-canvas
+context.lineJoin = "round";
+context.lineCap = "round";
+const path = d3.geoPath(null, context);
+
+context.beginPath();
+path(topojson.mesh(us, us.objects.counties, (a, b) => a !== b && (a.id / 1000 | 0) === (b.id / 1000 | 0)));
+context.lineWidth = 0.5;
+context.strokeStyle = "#aaa";
+context.stroke();
+
+context.beginPath();
+path(topojson.mesh(us, us.objects.states, (a, b) => a !== b));
+context.lineWidth = 0.5;
+context.strokeStyle = "#000";
+context.stroke();
+
+context.beginPath();
+path(topojson.feature(us, us.objects.nation));
+context.lineWidth = 1;
+context.strokeStyle = "#000";
+context.stroke();
+
+// Write the canvas to a PNG buffer
+const buffer = cvs.toBuffer("image/png");
+
+// Pipe the buffer to process.stdout
+process.stdout.write(buffer);
+```
+
+<div class="note">
+
+To run this data loader, you’ll need the `d3`, `topojson-client` and `canvas` libraries available on your `$PATH`.
+
+</div>
+
+The above data loader lives in `data/us-map.png.js`, so we can access the image using `data/us-map.png`:
+
+```html run=false
+<img src="data/us-map.png" style="max-width: 975px;">
+```
+
+<img src="data/us-map.png" style="max-width: 975px;">

--- a/examples/loader-canvas-to-png/src/index.md
+++ b/examples/loader-canvas-to-png/src/index.md
@@ -2,7 +2,7 @@
 
 Here’s a Node.js data loader that creates a canvas map using d3, and then returns the map as a PNG file to standard out.
 
-This pattern could be used to render maps that require with a large amount of data as lightweight static files.
+This pattern can be used to render maps that require with a large amount of data as lightweight static files.
 
 ```js run=false
 import * as canvas from 'canvas';

--- a/examples/loader-canvas-to-png/src/index.md
+++ b/examples/loader-canvas-to-png/src/index.md
@@ -1,6 +1,6 @@
 # Data loader to generate PNG from canvas
 
-Here’s a Node.js data loader that fetches creates a canvas map using d3, and then returns the map as a PNG file to standard out.
+Here’s a Node.js data loader that creates a canvas map using d3, and then returns the map as a PNG file to standard out.
 
 This pattern could be used to render maps that require with a large amount of data as lightweight static files.
 

--- a/examples/loader-canvas-to-png/src/index.md
+++ b/examples/loader-canvas-to-png/src/index.md
@@ -53,7 +53,7 @@ process.stdout.write(buffer);
 
 <div class="note">
 
-To run this data loader, you’ll need the `d3`, `topojson-client` and `canvas` libraries available on your `$PATH`.
+To run this data loader, you’ll need to add the `d3`, `topojson-client` and `canvas` libraries as dependencies with `npm add d3 topojson-client canvas` or `yarn add d3 topojson-client canvas`.
 
 </div>
 


### PR DESCRIPTION
I propose adding this example, which shows how you can use Node.JS in a data loader to serve a canvas map as a PNG. I currently use this pattern to render large amounts of data in lightweight static files.

I used [the official d3 example](https://observablehq.com/@d3/u-s-map-canvas) of how to make a canvas map to put together this demo.

![Screenshot from 2024-07-10 10-49-05](https://github.com/observablehq/framework/assets/9993/c4466ca4-29d7-4b1c-9399-882719e97389)
![Screenshot from 2024-07-10 10-49-16](https://github.com/observablehq/framework/assets/9993/ce5fa509-2b32-4157-a633-5a7702f1b77f)
