### PR TITLE
chaining data loaders

### DIFF
--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -317,7 +317,10 @@ class CommandLoader extends Loader {
   }
 
   async exec(output: WriteStream): Promise<void> {
-    const subprocess = spawn(this.command, this.args, {windowsHide: true, stdio: ["ignore", output, "inherit"]});
+    const address = process.env.OBSERVABLEHQ_ADDRESS;
+    if (address == null) throw new Error("chained data loaders are not implemented in this context");
+    const env = {...process.env, SERVER: `${address}_chain${this.targetPath}::`};
+    const subprocess = spawn(this.command, this.args, {windowsHide: true, stdio: ["ignore", output, "inherit"], env});
     const code = await new Promise((resolve, reject) => {
       subprocess.on("error", reject);
       subprocess.on("close", resolve);


### PR DESCRIPTION
We must use the same file server for browser preview and machine calls (i.e. chained data loaders), because concurrent requests on a same data loader must be joined.

But the paths are different. The data loader for `caller.csv` receives a `$SERVER` environment variable equal to
`http://127.0.0.1:3000/_chain/caller.csv::`, and might retrieve a dependency by concatenating that variable and the file path it needs, _e.g._ calling `http://127.0.0.1:3000/_chain/caller.csv::/dependency.zip`.

This should make it possible to derive the dependency graph, at least after we run the data loaders (not sure how to maintain state when we restart a server and we have a cache). Also, if the file is not found, we send an empty 404 instead of the decorated page intedned for the browser; this makes it a bit more foolproof.

The current server information is saved as a global (in `process.env`—should it be `globalThis`?) for now. It feels a bit wrong, but at the same time it really is a global state.

TBC…

closes #332