### PR TITLE
Explicitly show that JSX display() must be in a jsx fenced code block

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -18,7 +18,13 @@ function Greeting({subject}) {
 
 Then call the built-in display function to render content:
 
-```jsx echo
+````md
+```jsx
+display(<Greeting subject="JSX" />);
+```
+````
+
+```jsx
 display(<Greeting subject="JSX" />);
 ```
 


### PR DESCRIPTION
I spent some time trying to understand why the simpler JSX example wasn't working in my project. It finally turned out that I was putting the `display(<Greeting subject="JSX" />)` in a `js` block instead of a `jsx` one.

I saw after that `jsx` is indicated in the right margin of the code block in the documentation, but I didn't notice at first. As I may not be the only one in this case, this PR explicitly shows the `jsx` fenced code block around the first JSX `display()`.

Many thanks for all your work on Observable framework.