### PR TITLE
fix modulepreload in preview

### DIFF
--- a/src/javascript/imports.ts
+++ b/src/javascript/imports.ts
@@ -120,7 +120,7 @@ export function isImportMetaResolve(node: CallExpression): boolean {
 }
 
 export function isJavaScript(path: string): boolean {
-  return /\.(m|c)?js$/i.test(path);
+  return /\.(m|c)?js(\?|$)/i.test(path);
 }
 
 const parseImportsCache = new Map<string, Promise<ImportReference[]>>();


### PR DESCRIPTION
I noticed a small bug in preview, which is that `modulepreload` links weren’t being generated for local components. That was because the `isJavaScript` test was failing due to the trailing `?sha=…`.