### PR TITLE
deploy to observable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,4 +33,4 @@ jobs:
       - run: yarn docs:build
       - run: yarn docs:deploy
         env:
-          OBSERVABLE_TOKEN: ${{ secrets.OBSERVABLE_TOKEN }}
+          OBSERVABLE_TOKEN: ${{ secrets.OBSERVABLE_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,10 +31,6 @@ jobs:
           key: data-${{ hashFiles('docs/data/*') }}-${{ steps.date.outputs.date }}
       - run: yarn build
       - run: yarn docs:build
-      - uses: cloudflare/pages-action@1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: framework
-          directory: docs/.observablehq/dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn docs:deploy
+        env:
+          OBSERVABLE_TOKEN: ${{ secrets.OBSERVABLE_TOKEN }}

--- a/docs/.observablehq/deploy.json
+++ b/docs/.observablehq/deploy.json
@@ -1,5 +1,5 @@
 {
-  "projectId": "497663d656fa5557",
-  "workspaceLogin": "observablehq",
-  "projectSlug": "cli"
+  "projectId": "b385d10b723e37b6",
+  "projectSlug": "framework",
+  "workspaceLogin": "observablehq"
 }

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -37,8 +37,8 @@ The contents of the deploy config file look like this:
 ```json run=false
 {
   "projectId": "0123456789abcdef",
-  "workspaceLogin": "acme",
-  "projectSlug": "hello-framework"
+  "projectSlug": "hello-framework",
+  "workspaceLogin": "acme"
 }
 ```
 

--- a/examples/observablehq.config.js
+++ b/examples/observablehq.config.js
@@ -12,10 +12,7 @@ export default {
   sidebar: false,
   ...baseConfig,
   title: "Observable Framework",
-  head:
-    process.env.CI &&
-    `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
+  head: `<script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>
 

--- a/observablehq.config.ts
+++ b/observablehq.config.ts
@@ -89,7 +89,6 @@ export default {
 <link rel="icon" type="image/png" href="/observable.png" sizes="32x32">${
     process.env.CI
       ? `
-<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`
       : ""


### PR DESCRIPTION
Switches Framework’s docs to be hosted on Observable Cloud instead of Cloudflare Pages.