### PR TITLE
recommend npx

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,11 +89,7 @@ Framework includes a helper script (`observable create`) for creating new projec
 
 To create a new project with npm, run:
 
-<pre data-copy>npm init <span class="win">"</span>@observablehq<span class="win">"</span></pre>
-
-If you prefer Yarn, run:
-
-<pre data-copy>yarn create <span class="win">"</span>@observablehq<span class="win">"</span></pre>
+<pre data-copy>npx <span class="win">"</span>@observablehq/framework@latest<span class="win">"</span> create</pre>
 
 You can run the above command anywhere, but you may want to `cd` to your `~/Development` directory first (or wherever you do local development).
 
@@ -133,14 +129,6 @@ This command will ask you a series of questions in order to initialize your new 
 <span class="muted">└</span>  Problems? <u><a href="https://github.com/observablehq/framework/discussions" style="color: inherit;">https://github.com/observablehq/framework/discussions</a></u></pre>
 
 And that’s it! Your new project is ready to go. 🎉
-
-<div class="note">
-
-Under the hood, this command installs the `@observablehq/framework` package and runs:
-
-<pre>npm exec <span class="win">"</span>@observablehq/framework<span class="win">"</span> -- create</pre>
-
-</div>
 
 ## 2. Develop
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,7 @@ index: false
   <h1>The best dashboards are built with <em class="red">code.</em></h1>
   <h2>Create fast, beautiful data apps, dashboards, and reports from the command line. Write Markdown, JavaScript, SQL, Python, R… and any language you like. Free and open-source.</h2>
   <div class="cta">
-    <pre data-copy>npm init <span class="win">"</span>@observablehq<span class="win">"</span></pre>
+    <pre data-copy>npx <span class="win">"</span>@observablehq/framework@latest<span class="win">"</span> create</pre>
     <a href="./getting-started" class="small arrow" style="color: var(--theme-red);">Get started</a>
   </div>
 </div>


### PR DESCRIPTION
By using `npx` directly, we can specify the latest version of Framework (rather than whatever was cached the first time you run `npm init`). Also it makes it more obvious which package is being run. It is slightly longer though, and there’s no yarn equivalent (but you can still pick Yarn when installing via `npx` if you want).