### PR TITLE
fix hero title

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,8 @@ index: false
 }
 
 .hero h1 {
-  font-size: 64px;
+  font-size: 56px;
+  max-width: fit-content;
   line-height: 1;
   margin: 2rem 0;
 }


### PR DESCRIPTION
I just realized that the title was much larger than on the home page, and resulted in poor alignment

| before | after |
| - | - |
| ![before](https://github.com/user-attachments/assets/a9a27a7b-2312-4314-9f12-bd1b8874986c) | ![after](https://github.com/user-attachments/assets/8c8e7791-cf18-4cc0-95a7-6a9c44bee65a) |
