### PR TITLE
design tweaks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,13 +11,9 @@ index: false
 
 .hero h1 {
   font-size: 56px;
-  max-width: fit-content;
+  max-width: none;
   line-height: 1;
   margin: 2rem 0;
-}
-
-.phosphate {
-  color: var(--theme-phosphate);
 }
 
 .hero h2 {
@@ -103,11 +99,11 @@ index: false
 </style>
 
 <div class="hero">
-  <h1>The best dashboards are built with <span class="phosphate">code.</span></h1>
+  <h1>The best dashboards are built with <span style="color: var(--theme-foreground-focus);">code.</span></h1>
   <h2>Create fast, beautiful data apps, dashboards, and reports from the command line. Write Markdown, JavaScript, SQL, Python, R… and any language you like. Free and open-source.</h2>
   <div class="cta">
     <pre data-copy>npx <span class="win">"</span>@observablehq/framework@latest<span class="win">"</span> create</pre>
-    <a href="./getting-started" class="small arrow" style="color: var(--theme-red);">Get started</a>
+    <a href="./getting-started" class="small arrow" style="color: var(--theme-foreground-focus);">Get started</a>
   </div>
 </div>
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -56,7 +56,6 @@
 #observablehq-main {
   font-family: var(--sans-text);
   font-size: 16px;
-  font-weight: 500;
 }
 
 #observablehq-main {

--- a/docs/style.css
+++ b/docs/style.css
@@ -3,15 +3,21 @@
 @import url("observablehq:theme-near-midnight.css") (prefers-color-scheme: dark);
 
 :root {
-  --sans-mono: "Spline Sans Mono", var(--monospace);
-  --sans-text: Inter, var(--sans-serif);
-  --theme-phosphate: #148576;
+  --sans-serif: Inter, -apple-system, BlinkMacSystemFont, "avenir next", avenir, helvetica, "helvetica neue", ubuntu, roboto,
+    noto, "segoe ui", arial, sans-serif;
+  --monospace: "Spline Sans Mono", Menlo, Consolas, monospace;
+  --theme-foreground-focus: #148576;
+}
+
+code,
+tt {
+  font-size: inherit;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --theme-foreground: #f5f5f5;
-    --theme-phosphate: #37d5be;
+    --theme-foreground-focus: #37d5be;
   }
 }
 
@@ -53,9 +59,8 @@
   color: var(--theme-foreground-focus);
 }
 
-#observablehq-main {
-  font-family: var(--sans-text);
-  font-size: 16px;
+body {
+  font: 16px/1.5 var(--sans-serif);
 }
 
 #observablehq-main {
@@ -68,7 +73,7 @@
 }
 
 h1 {
-  font-family: var(--sans-mono);
+  font-family: var(--monospace);
   font-weight: 500;
 }
 


### PR DESCRIPTION
This…

* Uses normal font-weight instead of 500 for body text (preference)
* Adopts phosphate as the focus color instead of blue (to reduce the number of accent colors)
* Adopts phosphate as the CTA color for “Get started” on the home page (ditto)
* Adopts Inter as the sans-serif font instead of San Francisco (to reduce the number of fonts)
* Adopts Spline Sans Mono as the monospace font for code instead of Menlo (ditto)
* Tweaks the font-size for code and tt elements to inherit (due to the above changes)

| before | after |
|---|---|
| <img width="1624" alt="Screenshot 2024-08-20 at 8 58 37 PM" src="https://github.com/user-attachments/assets/df092bff-1d32-4c31-8083-ddc53970eca7"> | <img width="1624" alt="Screenshot 2024-08-20 at 8 58 27 PM" src="https://github.com/user-attachments/assets/082ce433-8e21-4452-98b7-f9d4259e6d03"> |
| <img width="1624" alt="Screenshot 2024-08-20 at 8 59 48 PM" src="https://github.com/user-attachments/assets/cbaac6f9-9a87-411e-b00e-1ec3bd7afa00"> | <img width="1624" alt="Screenshot 2024-08-20 at 8 59 38 PM" src="https://github.com/user-attachments/assets/959692fc-78d9-40d5-a71e-fbfa9d2c1767"> |
| <img width="1624" alt="Screenshot 2024-08-20 at 9 00 41 PM" src="https://github.com/user-attachments/assets/85cf2c5a-f707-4adb-ad7d-72b7e7a43a7a"> | <img width="1624" alt="Screenshot 2024-08-20 at 9 00 23 PM" src="https://github.com/user-attachments/assets/bd0572b6-1e0c-42a6-b62e-63b884b04834"> |
| <img width="1624" alt="Screenshot 2024-08-20 at 9 01 36 PM" src="https://github.com/user-attachments/assets/032dd88c-6444-4fb7-aab3-3d99f368d206"> | <img width="1624" alt="Screenshot 2024-08-20 at 9 01 29 PM" src="https://github.com/user-attachments/assets/3a342387-18d3-4f60-89d7-fd8d359b8a9b"> |
