### PR TITLE
remove redirects

### DIFF
--- a/docs/css/card.md
+++ b/docs/css/card.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../markdown#cards">
-
-Moved to [Layout: Cards](../markdown#cards).

--- a/docs/css/color.md
+++ b/docs/css/color.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../themes#colors">
-
-Moved to [Themes: Colors](../themes#colors).

--- a/docs/css/grid.md
+++ b/docs/css/grid.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../markdown#grids">
-
-Moved to [Markdown: Grids](../markdown#grids).

--- a/docs/css/note.md
+++ b/docs/css/note.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../markdown#notes">
-
-Moved to [Layout: Notes](../markdown#notes).

--- a/docs/javascript/display.md
+++ b/docs/javascript/display.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../javascript#explicit-display">
-
-Moved to [JavaScript: Explicit display](../javascript#explicit-display).

--- a/docs/javascript/files.md
+++ b/docs/javascript/files.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../files">
-
-Moved to [Files](../files).

--- a/docs/javascript/generators.md
+++ b/docs/javascript/generators.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../reactivity#generators">
-
-Moved to [Reactivity: Generators](../reactivity#generators).

--- a/docs/javascript/imports.md
+++ b/docs/javascript/imports.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../imports">
-
-Moved to [Imports](../imports).

--- a/docs/javascript/inputs.md
+++ b/docs/javascript/inputs.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../reactivity#inputs">
-
-Moved to [Reactivity: Inputs](../reactivity#inputs).

--- a/docs/javascript/mutables.md
+++ b/docs/javascript/mutables.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../reactivity#mutables">
-
-Moved to [Reactivity: Mutables](../reactivity#mutables).

--- a/docs/javascript/promises.md
+++ b/docs/javascript/promises.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../reactivity#promises">
-
-Moved to [Reactivity: Promises](../reactivity#promises).

--- a/docs/javascript/reactivity.md
+++ b/docs/javascript/reactivity.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=../reactivity">
-
-Moved to [Reactivity](../reactivity).

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=./project-structure">
-
-Moved to [Project structure](./project-structure).


### PR DESCRIPTION
I’ve implemented these redirects through Cloudflare, so we no longer need (or want) client-side redirects. You can test these redirects to confirm:

https://observablehq.com/framework/css/card
https://observablehq.com/framework/css/color
https://observablehq.com/framework/css/grid
https://observablehq.com/framework/css/note
https://observablehq.com/framework/javascript/display
https://observablehq.com/framework/javascript/files
https://observablehq.com/framework/javascript/generators
https://observablehq.com/framework/javascript/imports
https://observablehq.com/framework/javascript/inputs
https://observablehq.com/framework/javascript/mutables
https://observablehq.com/framework/javascript/promises
https://observablehq.com/framework/javascript/reactivity
https://observablehq.com/framework/routing