### PR TITLE
when we search "dark" or "width" we want these pages on top

### DIFF
--- a/docs/lib/generators.md
+++ b/docs/lib/generators.md
@@ -1,3 +1,7 @@
+---
+keywords: [dark, width]
+---
+
 # Observable Generators
 
 The Observable standard library includes several generator utilities. These are available by default in Markdown as `Generators`, but you can import them explicitly:

--- a/docs/themes.md.ts
+++ b/docs/themes.md.ts
@@ -23,7 +23,11 @@ function renderThemeSection(themes: readonly string[]): string {
 }
 
 export default function render(): string {
-  return `# Themes
+  return `---
+keywords: [light, dark]
+---
+
+# Themes
 
 <style>
 


### PR DESCRIPTION
| before | after |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/6fe8cddd-4b4a-43d4-a77f-3bfb94e36bbd) | ![after](https://github.com/user-attachments/assets/e231d477-fcec-4da6-94de-7b59b8f11e6b) |
