### PR TITLE
file.size

### DIFF
--- a/docs/convert.md
+++ b/docs/convert.md
@@ -341,6 +341,7 @@ The Framework standard library also includes several new methods that are not av
 Framework’s [`FileAttachment`](./files) includes a few new features:
 
 - `file.href`
+- `file.size`
 - `file.lastModified`
 - `file.mimeType` is always defined
 - `file.text` now supports an `encoding` option

--- a/docs/files.md
+++ b/docs/files.md
@@ -10,7 +10,7 @@ Load files — whether static or generated dynamically by a [data loader](./load
 import {FileAttachment} from "npm:@observablehq/stdlib";
 ```
 
-The `FileAttachment` function takes a path and returns a file handle. This handle exposes the file’s name, [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), and modification time <a href="https://github.com/observablehq/framework/releases/tag/v1.4.0" class="observablehq-version-badge" data-version="^1.4.0" title="Added in 1.4.0"></a> (represented as the number of milliseconds since UNIX epoch).
+The `FileAttachment` function takes a path and returns a file handle. This handle exposes the file’s name, [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), size in bytes <a href="https://github.com/observablehq/framework/pulls/1608" class="observablehq-version-badge" data-version="prerelease" title="Added in #1608"></a>, and modification time <a href="https://github.com/observablehq/framework/releases/tag/v1.4.0" class="observablehq-version-badge" data-version="^1.4.0" title="Added in 1.4.0"></a> (represented as the number of milliseconds since UNIX epoch).
 
 ```js echo
 FileAttachment("volcano.json")
@@ -52,7 +52,7 @@ const frames = [
 
 None of the files in `frames` above are loaded until a [content method](#supported-formats) is invoked, for example by saying `frames[0].image()`.
 
-For missing files, `file.lastModified` is undefined. The `file.mimeType` is determined by checking the file extension against the [`mime-db` media type database](https://github.com/jshttp/mime-db); it defaults to `application/octet-stream`.
+For missing files, `file.size` and `file.lastModified` are undefined. The `file.mimeType` is determined by checking the file extension against the [`mime-db` media type database](https://github.com/jshttp/mime-db); it defaults to `application/octet-stream`.
 
 ## Supported formats
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",
-    "@observablehq/inputs": "^0.11.0",
+    "@observablehq/inputs": "^0.12.0",
     "@observablehq/runtime": "^5.9.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.1.0",

--- a/src/client/stdlib/fileAttachment.js
+++ b/src/client/stdlib/fileAttachment.js
@@ -5,8 +5,14 @@ export function registerFile(name, info) {
   if (info == null) {
     files.delete(href);
   } else {
-    const {path, mimeType, lastModified} = info;
-    const file = new FileAttachmentImpl(new URL(path, location).href, name.split("/").pop(), mimeType, lastModified);
+    const {path, mimeType, lastModified, size} = info;
+    const file = new FileAttachmentImpl(
+      new URL(path, location).href,
+      name.split("/").pop(),
+      mimeType,
+      lastModified,
+      size
+    );
     files.set(href, file);
   }
 }
@@ -25,11 +31,12 @@ async function remote_fetch(file) {
 }
 
 export class AbstractFile {
-  constructor(name, mimeType = "application/octet-stream", lastModified) {
+  constructor(name, mimeType = "application/octet-stream", lastModified, size) {
     Object.defineProperties(this, {
       name: {value: `${name}`, enumerable: true},
       mimeType: {value: `${mimeType}`, enumerable: true},
-      lastModified: {value: +lastModified, enumerable: true}
+      lastModified: {value: +lastModified, enumerable: true},
+      size: {value: +size, enumerable: true}
     });
   }
   async blob() {
@@ -131,8 +138,8 @@ export class AbstractFile {
 }
 
 class FileAttachmentImpl extends AbstractFile {
-  constructor(href, name, mimeType, lastModified) {
-    super(name, mimeType, lastModified);
+  constructor(href, name, mimeType, lastModified, size) {
+    super(name, mimeType, lastModified, size);
     Object.defineProperty(this, "href", {value: href});
   }
   async url() {

--- a/src/client/stdlib/inputs.js
+++ b/src/client/stdlib/inputs.js
@@ -1,5 +1,60 @@
-import {fileOf} from "@observablehq/inputs";
+import {file as _file} from "@observablehq/inputs";
 import {AbstractFile} from "npm:@observablehq/stdlib";
 
-export * from "@observablehq/inputs";
-export const file = fileOf(AbstractFile);
+export {
+  button,
+  checkbox,
+  radio,
+  toggle,
+  color,
+  date,
+  datetime,
+  form,
+  range,
+  number,
+  search,
+  searchFilter,
+  select,
+  table,
+  text,
+  email,
+  tel,
+  url,
+  password,
+  textarea,
+  input,
+  bind,
+  disposal,
+  formatDate,
+  formatLocaleAuto,
+  formatLocaleNumber,
+  formatTrim,
+  formatAuto,
+  formatNumber
+} from "@observablehq/inputs";
+
+export const file = (options) => _file({...options, transform: localFile});
+
+function localFile(file) {
+  return new LocalFile(file);
+}
+
+class LocalFile extends AbstractFile {
+  constructor(file) {
+    super(file.name, file.type, file.lastModified, file.size);
+    Object.defineProperty(this, "_", {value: file});
+    Object.defineProperty(this, "_url", {writable: true});
+  }
+  get href() {
+    return (this._url ??= URL.createObjectURL(this._));
+  }
+  async url() {
+    return this.href;
+  }
+  async blob() {
+    return this._;
+  }
+  async stream() {
+    return this._.stream();
+  }
+}

--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -183,9 +183,19 @@ export class LoaderResolver {
     return entry && Math.floor(entry.mtimeMs);
   }
 
+  getSourceSize(name: string): number | undefined {
+    const entry = getFileInfo(this.root, this.getSourceFilePath(name));
+    return entry && Math.floor(entry.size);
+  }
+
   getOutputLastModified(name: string): number | undefined {
     const entry = getFileInfo(this.root, this.getOutputFilePath(name));
     return entry && Math.floor(entry.mtimeMs);
+  }
+
+  getOutputSize(name: string): number | undefined {
+    const entry = getFileInfo(this.root, this.getOutputFilePath(name));
+    return entry && Math.floor(entry.size);
   }
 
   resolveFilePath(path: string): string {

--- a/src/dataloader.ts
+++ b/src/dataloader.ts
@@ -10,6 +10,7 @@ import {extract} from "tar-stream";
 import {maybeStat, prepareOutput} from "./files.js";
 import {FileWatchers} from "./fileWatchers.js";
 import {formatByteSize} from "./format.js";
+import type {FileInfo} from "./javascript/module.js";
 import {getFileInfo} from "./javascript/module.js";
 import type {Logger, Writer} from "./logger.js";
 import {cyan, faint, green, red, yellow} from "./tty.js";
@@ -178,24 +179,12 @@ export class LoaderResolver {
     return path === name ? hash : createHash("sha256").update(hash).update(String(info.mtimeMs)).digest("hex");
   }
 
-  getSourceLastModified(name: string): number | undefined {
-    const entry = getFileInfo(this.root, this.getSourceFilePath(name));
-    return entry && Math.floor(entry.mtimeMs);
+  getSourceInfo(name: string): FileInfo | undefined {
+    return getFileInfo(this.root, this.getSourceFilePath(name));
   }
 
-  getSourceSize(name: string): number | undefined {
-    const entry = getFileInfo(this.root, this.getSourceFilePath(name));
-    return entry && Math.floor(entry.size);
-  }
-
-  getOutputLastModified(name: string): number | undefined {
-    const entry = getFileInfo(this.root, this.getOutputFilePath(name));
-    return entry && Math.floor(entry.mtimeMs);
-  }
-
-  getOutputSize(name: string): number | undefined {
-    const entry = getFileInfo(this.root, this.getOutputFilePath(name));
-    return entry && Math.floor(entry.size);
+  getOutputInfo(name: string): FileInfo | undefined {
+    return getFileInfo(this.root, this.getOutputFilePath(name));
   }
 
   resolveFilePath(path: string): string {

--- a/src/javascript/module.ts
+++ b/src/javascript/module.ts
@@ -121,7 +121,7 @@ export function getModuleInfo(root: string, path: string): ModuleInfo | undefine
   const key = join(root, path);
   let mtimeMs: number;
   try {
-    ({mtimeMs} = statSync(resolveJsx(key) ?? key));
+    mtimeMs = Math.floor(statSync(resolveJsx(key) ?? key).mtimeMs);
   } catch {
     moduleInfoCache.delete(key); // delete stale entry
     return; // ignore missing file
@@ -193,7 +193,8 @@ export function getFileInfo(root: string, path: string): FileInfo | undefined {
     const stat = statSync(key);
     if (!stat.isFile()) return; // ignore non-files
     accessSync(key, constants.R_OK); // verify that file is readable
-    ({mtimeMs, size} = stat);
+    mtimeMs = Math.floor(stat.mtimeMs);
+    size = stat.size;
   } catch {
     fileInfoCache.delete(key); // delete stale entry
     return; // ignore missing, non-readable file

--- a/src/render.ts
+++ b/src/render.ts
@@ -69,7 +69,10 @@ import ${preview || page.code.length ? `{${preview ? "open, " : ""}define} from 
           resolveFile,
           preview
             ? (name) => loaders.getSourceLastModified(resolvePath(path, name))
-            : (name) => loaders.getOutputLastModified(resolvePath(path, name))
+            : (name) => loaders.getOutputLastModified(resolvePath(path, name)),
+          preview
+            ? (name) => loaders.getSourceSize(resolvePath(path, name))
+            : (name) => loaders.getOutputSize(resolvePath(path, name))
         )}`
       : ""
   }${data?.sql ? `\n${registerTables(data.sql, options)}` : ""}
@@ -103,24 +106,27 @@ function registerTable(name: string, source: string, {path}: RenderOptions): str
 function registerFiles(
   files: Iterable<string>,
   resolve: (name: string) => string,
-  getLastModified: (name: string) => number | undefined
+  getLastModified: (name: string) => number | undefined,
+  getSize: (name: string) => number | undefined
 ): string {
   return Array.from(files)
     .sort()
-    .map((f) => registerFile(f, resolve, getLastModified))
+    .map((f) => registerFile(f, resolve, getLastModified, getSize))
     .join("");
 }
 
 function registerFile(
   name: string,
   resolve: (name: string) => string,
-  getLastModified: (name: string) => number | undefined
+  getLastModified: (name: string) => number | undefined,
+  getSize: (name: string) => number | undefined
 ): string {
   return `\nregisterFile(${JSON.stringify(name)}, ${JSON.stringify({
     name,
     mimeType: mime.getType(name) ?? undefined,
     path: resolve(name),
-    lastModified: getLastModified(name)
+    lastModified: getLastModified(name),
+    size: getSize(name)
   })});`;
 }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -5,6 +5,7 @@ import {getClientPath} from "./files.js";
 import type {Html, HtmlResolvers} from "./html.js";
 import {html, parseHtml, rewriteHtml} from "./html.js";
 import {isJavaScript} from "./javascript/imports.js";
+import type {FileInfo} from "./javascript/module.js";
 import {transpileJavaScript} from "./javascript/transpile.js";
 import type {MarkdownPage} from "./markdown.js";
 import type {PageLink} from "./pager.js";
@@ -68,11 +69,8 @@ import ${preview || page.code.length ? `{${preview ? "open, " : ""}define} from 
           files,
           resolveFile,
           preview
-            ? (name) => loaders.getSourceLastModified(resolvePath(path, name))
-            : (name) => loaders.getOutputLastModified(resolvePath(path, name)),
-          preview
-            ? (name) => loaders.getSourceSize(resolvePath(path, name))
-            : (name) => loaders.getOutputSize(resolvePath(path, name))
+            ? (name) => loaders.getSourceInfo(resolvePath(path, name))
+            : (name) => loaders.getOutputInfo(resolvePath(path, name))
         )}`
       : ""
   }${data?.sql ? `\n${registerTables(data.sql, options)}` : ""}
@@ -106,27 +104,26 @@ function registerTable(name: string, source: string, {path}: RenderOptions): str
 function registerFiles(
   files: Iterable<string>,
   resolve: (name: string) => string,
-  getLastModified: (name: string) => number | undefined,
-  getSize: (name: string) => number | undefined
+  getInfo: (name: string) => FileInfo | undefined
 ): string {
   return Array.from(files)
     .sort()
-    .map((f) => registerFile(f, resolve, getLastModified, getSize))
+    .map((f) => registerFile(f, resolve, getInfo))
     .join("");
 }
 
 function registerFile(
   name: string,
   resolve: (name: string) => string,
-  getLastModified: (name: string) => number | undefined,
-  getSize: (name: string) => number | undefined
+  getInfo: (name: string) => FileInfo | undefined
 ): string {
+  const info = getInfo(name);
   return `\nregisterFile(${JSON.stringify(name)}, ${JSON.stringify({
     name,
     mimeType: mime.getType(name) ?? undefined,
     path: resolve(name),
-    lastModified: getLastModified(name),
-    size: getSize(name)
+    lastModified: info?.mtimeMs,
+    size: info?.size
   })});`;
 }
 

--- a/test/build-test.ts
+++ b/test/build-test.ts
@@ -162,7 +162,7 @@ class TestEffects extends FileBuildEffects {
   async writeFile(outputPath: string, contents: string | Buffer): Promise<void> {
     if (typeof contents === "string" && outputPath.endsWith(".html")) {
       contents = contents.replace(/^(\s*<script>\{).*(\}<\/script>)$/gm, "$1/* redacted init script */$2");
-      contents = contents.replace(/^(registerFile\(.*,"lastModified":)\d+(\}\);)$/gm, "$1/* ts */1706742000000$2");
+      contents = contents.replace(/^(registerFile\(.*,"lastModified":)\d+(,"size":\d+\}\);)$/gm, "$1/* ts */1706742000000$2"); // prettier-ignore
     }
     return super.writeFile(outputPath, contents);
   }

--- a/test/dataloaders-test.ts
+++ b/test/dataloaders-test.ts
@@ -117,26 +117,26 @@ describe("LoaderResolver.getSourceFileHash(path)", () => {
   });
 });
 
-describe("LoaderResolver.get{Source,Output}LastModified(path)", () => {
+describe("LoaderResolver.get{Source,Output}Info(path)", () => {
   const time1 = new Date(Date.UTC(2023, 11, 1));
   const time2 = new Date(Date.UTC(2024, 2, 1));
   const loaders = new LoaderResolver({root: "test"});
   it("both return the last modification time for a simple file", async () => {
     await utimes("test/input/loader/simple.txt", time1, time1);
-    assert.strictEqual(loaders.getSourceLastModified("input/loader/simple.txt"), +time1);
-    assert.strictEqual(loaders.getOutputLastModified("input/loader/simple.txt"), +time1);
+    assert.deepStrictEqual(loaders.getSourceInfo("input/loader/simple.txt"), {hash: "3b09aeb6f5f5336beb205d7f720371bc927cd46c21922e334d47ba264acb5ba4", mtimeMs: +time1, size: 6}); // prettier-ignore
+    assert.deepStrictEqual(loaders.getOutputInfo("input/loader/simple.txt"), {hash: "3b09aeb6f5f5336beb205d7f720371bc927cd46c21922e334d47ba264acb5ba4", mtimeMs: +time1, size: 6}); // prettier-ignore
   });
   it("both return an undefined last modification time for a missing file", async () => {
-    assert.strictEqual(loaders.getSourceLastModified("input/loader/missing.txt"), undefined);
-    assert.strictEqual(loaders.getOutputLastModified("input/loader/missing.txt"), undefined);
+    assert.deepStrictEqual(loaders.getSourceInfo("input/loader/missing.txt"), undefined);
+    assert.deepStrictEqual(loaders.getOutputInfo("input/loader/missing.txt"), undefined);
   });
   it("returns the last modification time of the loader in preview, and of the cache, on build", async () => {
     await utimes("test/input/loader/cached.txt.sh", time1, time1);
     await mkdir("test/.observablehq/cache/input/loader/", {recursive: true});
     await writeFile("test/.observablehq/cache/input/loader/cached.txt", "2024-03-01 00:00:00");
     await utimes("test/.observablehq/cache/input/loader/cached.txt", time2, time2);
-    assert.strictEqual(loaders.getSourceLastModified("input/loader/cached.txt"), +time1);
-    assert.strictEqual(loaders.getOutputLastModified("input/loader/cached.txt"), +time2);
+    assert.deepStrictEqual(loaders.getSourceInfo("input/loader/cached.txt"), {hash: "6493b08929c0ff92d9cf9ea9a03a2c8c74b03800f63c1ec986c40c8bd9a48405", mtimeMs: +time1, size: 29}); // prettier-ignore
+    assert.deepStrictEqual(loaders.getOutputInfo("input/loader/cached.txt"), {hash: "1174b3f8f206b9be09f89eceea3799f60389d7d62897e8b2767847b2bc259a8c", mtimeMs: +time2, size: 19}); // prettier-ignore
     // clean up
     try {
       await unlink("test/.observablehq/cache/input/loader/cached.txt");
@@ -147,7 +147,7 @@ describe("LoaderResolver.get{Source,Output}LastModified(path)", () => {
   });
   it("returns the last modification time of the data loader in preview, and null in build, when there is no cache", async () => {
     await utimes("test/input/loader/not-cached.txt.sh", time1, time1);
-    assert.strictEqual(loaders.getSourceLastModified("input/loader/not-cached.txt"), +time1);
-    assert.strictEqual(loaders.getOutputLastModified("input/loader/not-cached.txt"), undefined);
+    assert.deepStrictEqual(loaders.getSourceInfo("input/loader/not-cached.txt"), {hash: "6493b08929c0ff92d9cf9ea9a03a2c8c74b03800f63c1ec986c40c8bd9a48405", mtimeMs: +time1, size: 29}); // prettier-ignore
+    assert.deepStrictEqual(loaders.getOutputInfo("input/loader/not-cached.txt"), undefined);
   });
 });

--- a/test/javascript/module-test.ts
+++ b/test/javascript/module-test.ts
@@ -116,9 +116,9 @@ describe("getFileHash(root, path)", () => {
 
 describe("getFileInfo(root, path)", () => {
   it("returns the info for the specified file", () => {
-    assert.deepStrictEqual(redactFileInfo("test/input/build/files", "file-top.csv"), {hash: "01a7ce0aea79f9cddb22e772b2cc9a9f3229a64a5fd941eec8d8ddc41fb07c34"}); // prettier-ignore
-    assert.deepStrictEqual(redactFileInfo("test/input/build/archives.posix", "dynamic.zip.sh"), {hash: "516cec2431ce8f1181a7a2a161db8bdfcaea132d3b2c37f863ea6f05d64d1d10"}); // prettier-ignore
-    assert.deepStrictEqual(redactFileInfo("test/input/build/archives.posix", "static.zip"), {hash: "e6afff224da77b900cfe3ab8789f2283883300e1497548c30af66dfe4c29b429"}); // prettier-ignore
+    assert.deepStrictEqual(redactFileInfo("test/input/build/files", "file-top.csv"), {hash: "01a7ce0aea79f9cddb22e772b2cc9a9f3229a64a5fd941eec8d8ddc41fb07c34", size: 16}); // prettier-ignore
+    assert.deepStrictEqual(redactFileInfo("test/input/build/archives.posix", "dynamic.zip.sh"), {hash: "516cec2431ce8f1181a7a2a161db8bdfcaea132d3b2c37f863ea6f05d64d1d10", size: 51}); // prettier-ignore
+    assert.deepStrictEqual(redactFileInfo("test/input/build/archives.posix", "static.zip"), {hash: "e6afff224da77b900cfe3ab8789f2283883300e1497548c30af66dfe4c29b429", size: 180}); // prettier-ignore
   });
   it("returns undefined if the specified file is created by a data loader", () => {
     assert.strictEqual(getFileInfo("test/input/build/archives.posix", "dynamic.zip"), undefined);

--- a/test/output/build/archives.posix/tar.html
+++ b/test/output/build/archives.posix/tar.html
@@ -16,12 +16,12 @@ import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
 registerFile("./dynamic-tar-gz/does-not-exist.txt", {"name":"./dynamic-tar-gz/does-not-exist.txt","mimeType":"text/plain","path":"./dynamic-tar-gz/does-not-exist.txt"});
-registerFile("./dynamic-tar-gz/file.txt", {"name":"./dynamic-tar-gz/file.txt","mimeType":"text/plain","path":"./_file/dynamic-tar-gz/file.c93138d8.txt","lastModified":/* ts */1706742000000});
+registerFile("./dynamic-tar-gz/file.txt", {"name":"./dynamic-tar-gz/file.txt","mimeType":"text/plain","path":"./_file/dynamic-tar-gz/file.c93138d8.txt","lastModified":/* ts */1706742000000,"size":21});
 registerFile("./dynamic-tar/does-not-exist.txt", {"name":"./dynamic-tar/does-not-exist.txt","mimeType":"text/plain","path":"./dynamic-tar/does-not-exist.txt"});
-registerFile("./dynamic-tar/file.txt", {"name":"./dynamic-tar/file.txt","mimeType":"text/plain","path":"./_file/dynamic-tar/file.c93138d8.txt","lastModified":/* ts */1706742000000});
+registerFile("./dynamic-tar/file.txt", {"name":"./dynamic-tar/file.txt","mimeType":"text/plain","path":"./_file/dynamic-tar/file.c93138d8.txt","lastModified":/* ts */1706742000000,"size":21});
 registerFile("./static-tar/does-not-exist.txt", {"name":"./static-tar/does-not-exist.txt","mimeType":"text/plain","path":"./static-tar/does-not-exist.txt"});
-registerFile("./static-tar/file.txt", {"name":"./static-tar/file.txt","mimeType":"text/plain","path":"./_file/static-tar/file.c93138d8.txt","lastModified":/* ts */1706742000000});
-registerFile("./static-tgz/file.txt", {"name":"./static-tgz/file.txt","mimeType":"text/plain","path":"./_file/static-tgz/file.c93138d8.txt","lastModified":/* ts */1706742000000});
+registerFile("./static-tar/file.txt", {"name":"./static-tar/file.txt","mimeType":"text/plain","path":"./_file/static-tar/file.c93138d8.txt","lastModified":/* ts */1706742000000,"size":21});
+registerFile("./static-tgz/file.txt", {"name":"./static-tgz/file.txt","mimeType":"text/plain","path":"./_file/static-tgz/file.c93138d8.txt","lastModified":/* ts */1706742000000,"size":21});
 
 define({id: "d5134368", inputs: ["FileAttachment","display"], body: async (FileAttachment,display) => {
 display(await(

--- a/test/output/build/archives.posix/zip.html
+++ b/test/output/build/archives.posix/zip.html
@@ -15,9 +15,9 @@
 import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
-registerFile("./dynamic/file.txt", {"name":"./dynamic/file.txt","mimeType":"text/plain","path":"./_file/dynamic/file.c93138d8.txt","lastModified":/* ts */1706742000000});
+registerFile("./dynamic/file.txt", {"name":"./dynamic/file.txt","mimeType":"text/plain","path":"./_file/dynamic/file.c93138d8.txt","lastModified":/* ts */1706742000000,"size":21});
 registerFile("./dynamic/not-found.txt", {"name":"./dynamic/not-found.txt","mimeType":"text/plain","path":"./dynamic/not-found.txt"});
-registerFile("./static/file.txt", {"name":"./static/file.txt","mimeType":"text/plain","path":"./_file/static/file.d9014c46.txt","lastModified":/* ts */1706742000000});
+registerFile("./static/file.txt", {"name":"./static/file.txt","mimeType":"text/plain","path":"./_file/static/file.d9014c46.txt","lastModified":/* ts */1706742000000,"size":14});
 registerFile("./static/not-found.txt", {"name":"./static/not-found.txt","mimeType":"text/plain","path":"./static/not-found.txt"});
 
 define({id: "d3b9d0ee", inputs: ["FileAttachment","display"], body: async (FileAttachment,display) => {

--- a/test/output/build/archives.win32/tar.html
+++ b/test/output/build/archives.win32/tar.html
@@ -17,8 +17,8 @@ import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
 registerFile("./static-tar/does-not-exist.txt", {"name":"./static-tar/does-not-exist.txt","mimeType":"text/plain","path":"./static-tar/does-not-exist.txt"});
-registerFile("./static-tar/file.txt", {"name":"./static-tar/file.txt","mimeType":"text/plain","path":"./_file/static-tar/file.c93138d8.txt","lastModified":/* ts */1706742000000});
-registerFile("./static-tgz/file.txt", {"name":"./static-tgz/file.txt","mimeType":"text/plain","path":"./_file/static-tgz/file.c93138d8.txt","lastModified":/* ts */1706742000000});
+registerFile("./static-tar/file.txt", {"name":"./static-tar/file.txt","mimeType":"text/plain","path":"./_file/static-tar/file.c93138d8.txt","lastModified":/* ts */1706742000000,"size":21});
+registerFile("./static-tgz/file.txt", {"name":"./static-tgz/file.txt","mimeType":"text/plain","path":"./_file/static-tgz/file.c93138d8.txt","lastModified":/* ts */1706742000000,"size":21});
 
 define({id: "d5134368", inputs: ["FileAttachment","display"], body: async (FileAttachment,display) => {
 display(await(

--- a/test/output/build/archives.win32/zip.html
+++ b/test/output/build/archives.win32/zip.html
@@ -16,7 +16,7 @@
 import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
-registerFile("./static/file.txt", {"name":"./static/file.txt","mimeType":"text/plain","path":"./_file/static/file.d9014c46.txt","lastModified":/* ts */1706742000000,"size":21});
+registerFile("./static/file.txt", {"name":"./static/file.txt","mimeType":"text/plain","path":"./_file/static/file.d9014c46.txt","lastModified":/* ts */1706742000000,"size":14});
 registerFile("./static/not-found.txt", {"name":"./static/not-found.txt","mimeType":"text/plain","path":"./static/not-found.txt"});
 
 define({id: "d3b9d0ee", inputs: ["FileAttachment","display"], body: async (FileAttachment,display) => {

--- a/test/output/build/archives.win32/zip.html
+++ b/test/output/build/archives.win32/zip.html
@@ -16,7 +16,7 @@
 import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
-registerFile("./static/file.txt", {"name":"./static/file.txt","mimeType":"text/plain","path":"./_file/static/file.d9014c46.txt","lastModified":/* ts */1706742000000});
+registerFile("./static/file.txt", {"name":"./static/file.txt","mimeType":"text/plain","path":"./_file/static/file.d9014c46.txt","lastModified":/* ts */1706742000000,"size":21});
 registerFile("./static/not-found.txt", {"name":"./static/not-found.txt","mimeType":"text/plain","path":"./static/not-found.txt"});
 
 define({id: "d3b9d0ee", inputs: ["FileAttachment","display"], body: async (FileAttachment,display) => {

--- a/test/output/build/fetches/foo.html
+++ b/test/output/build/fetches/foo.html
@@ -16,8 +16,8 @@
 import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
-registerFile("./foo/foo-data.csv", {"name":"./foo/foo-data.csv","mimeType":"text/csv","path":"./_file/foo/foo-data.24ef4634.csv","lastModified":/* ts */1706742000000});
-registerFile("./foo/foo-data.json", {"name":"./foo/foo-data.json","mimeType":"application/json","path":"./_file/foo/foo-data.67358ed8.json","lastModified":/* ts */1706742000000});
+registerFile("./foo/foo-data.csv", {"name":"./foo/foo-data.csv","mimeType":"text/csv","path":"./_file/foo/foo-data.24ef4634.csv","lastModified":/* ts */1706742000000,"size":72});
+registerFile("./foo/foo-data.json", {"name":"./foo/foo-data.json","mimeType":"application/json","path":"./_file/foo/foo-data.67358ed8.json","lastModified":/* ts */1706742000000,"size":10});
 
 define({id: "47a695da", inputs: ["display"], outputs: ["fooJsonData","fooCsvData"], body: async (display) => {
 const {fooJsonData, fooCsvData} = await import("./_import/foo/foo.6fd063d5.js");

--- a/test/output/build/fetches/top.html
+++ b/test/output/build/fetches/top.html
@@ -17,10 +17,10 @@
 import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
-registerFile("./foo/foo-data.csv", {"name":"./foo/foo-data.csv","mimeType":"text/csv","path":"./_file/foo/foo-data.24ef4634.csv","lastModified":/* ts */1706742000000});
-registerFile("./foo/foo-data.json", {"name":"./foo/foo-data.json","mimeType":"application/json","path":"./_file/foo/foo-data.67358ed8.json","lastModified":/* ts */1706742000000});
-registerFile("./top-data.csv", {"name":"./top-data.csv","mimeType":"text/csv","path":"./_file/top-data.24ef4634.csv","lastModified":/* ts */1706742000000});
-registerFile("./top-data.json", {"name":"./top-data.json","mimeType":"application/json","path":"./_file/top-data.67358ed8.json","lastModified":/* ts */1706742000000});
+registerFile("./foo/foo-data.csv", {"name":"./foo/foo-data.csv","mimeType":"text/csv","path":"./_file/foo/foo-data.24ef4634.csv","lastModified":/* ts */1706742000000,"size":72});
+registerFile("./foo/foo-data.json", {"name":"./foo/foo-data.json","mimeType":"application/json","path":"./_file/foo/foo-data.67358ed8.json","lastModified":/* ts */1706742000000,"size":10});
+registerFile("./top-data.csv", {"name":"./top-data.csv","mimeType":"text/csv","path":"./_file/top-data.24ef4634.csv","lastModified":/* ts */1706742000000,"size":72});
+registerFile("./top-data.json", {"name":"./top-data.json","mimeType":"application/json","path":"./_file/top-data.67358ed8.json","lastModified":/* ts */1706742000000,"size":10});
 
 define({id: "cb908c08", inputs: ["display"], outputs: ["fooCsvData","fooJsonData","topCsvData","topJsonData"], body: async (display) => {
 const {fooCsvData, fooJsonData, topCsvData, topJsonData} = await import("./_import/top.d8f5cc36.js");

--- a/test/output/build/files/files.html
+++ b/test/output/build/files/files.html
@@ -15,9 +15,9 @@
 import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
-registerFile("./file-top.csv", {"name":"./file-top.csv","mimeType":"text/csv","path":"./_file/file-top.01a7ce0a.csv","lastModified":/* ts */1706742000000});
-registerFile("./observable logo.png", {"name":"./observable logo.png","mimeType":"image/png","path":"./_file/observable logo.b620bd08.png","lastModified":/* ts */1706742000000});
-registerFile("./subsection/file-sub.csv", {"name":"./subsection/file-sub.csv","mimeType":"text/csv","path":"./_file/subsection/file-sub.72c2c61c.csv","lastModified":/* ts */1706742000000});
+registerFile("./file-top.csv", {"name":"./file-top.csv","mimeType":"text/csv","path":"./_file/file-top.01a7ce0a.csv","lastModified":/* ts */1706742000000,"size":16});
+registerFile("./observable logo.png", {"name":"./observable logo.png","mimeType":"image/png","path":"./_file/observable logo.b620bd08.png","lastModified":/* ts */1706742000000,"size":3401});
+registerFile("./subsection/file-sub.csv", {"name":"./subsection/file-sub.csv","mimeType":"text/csv","path":"./_file/subsection/file-sub.72c2c61c.csv","lastModified":/* ts */1706742000000,"size":18});
 registerFile("./unknown-mime-extension.really", {"name":"./unknown-mime-extension.really","path":"./unknown-mime-extension.really"});
 
 define({id: "10037545", inputs: ["FileAttachment","display"], body: async (FileAttachment,display) => {

--- a/test/output/build/files/subsection/subfiles.html
+++ b/test/output/build/files/subsection/subfiles.html
@@ -15,8 +15,8 @@
 import {define} from "../_observablehq/client.00000001.js";
 import {registerFile} from "../_observablehq/stdlib.00000003.js";
 
-registerFile("../file-top.csv", {"name":"../file-top.csv","mimeType":"text/csv","path":"../_file/file-top.01a7ce0a.csv","lastModified":/* ts */1706742000000});
-registerFile("./file-sub.csv", {"name":"./file-sub.csv","mimeType":"text/csv","path":"../_file/subsection/file-sub.72c2c61c.csv","lastModified":/* ts */1706742000000});
+registerFile("../file-top.csv", {"name":"../file-top.csv","mimeType":"text/csv","path":"../_file/file-top.01a7ce0a.csv","lastModified":/* ts */1706742000000,"size":16});
+registerFile("./file-sub.csv", {"name":"./file-sub.csv","mimeType":"text/csv","path":"../_file/subsection/file-sub.72c2c61c.csv","lastModified":/* ts */1706742000000,"size":18});
 
 define({id: "ef9a31ef", inputs: ["FileAttachment","display"], body: async (FileAttachment,display) => {
 display(await(

--- a/test/output/build/imports/foo/foo.html
+++ b/test/output/build/imports/foo/foo.html
@@ -21,7 +21,7 @@
 import {define} from "../_observablehq/client.00000001.js";
 import {registerFile} from "../_observablehq/stdlib.00000003.js";
 
-registerFile("../top.js", {"name":"../top.js","mimeType":"text/javascript","path":"../_file/top.a53c5d5b.js","lastModified":/* ts */1706742000000});
+registerFile("../top.js", {"name":"../top.js","mimeType":"text/javascript","path":"../_file/top.a53c5d5b.js","lastModified":/* ts */1706742000000,"size":26});
 
 define({id: "261e010e", inputs: ["display","FileAttachment"], outputs: ["d3","bar","top"], body: async (display,FileAttachment) => {
 const [d3, {bar}, {top}] = await Promise.all([import("../_npm/d3@7.8.5/cd372fb8.js"), import("../_import/bar/bar.13bb8056.js"), import("../_import/top.160847a6.js")]);

--- a/test/output/build/multi/index.html
+++ b/test/output/build/multi/index.html
@@ -16,8 +16,8 @@
 import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
-registerFile("./file1.csv", {"name":"./file1.csv","mimeType":"text/csv","path":"./_file/file1.259f3fd9.csv","lastModified":/* ts */1706742000000});
-registerFile("./file2.csv", {"name":"./file2.csv","mimeType":"text/csv","path":"./_file/file2.c70f7d51.csv","lastModified":/* ts */1706742000000});
+registerFile("./file1.csv", {"name":"./file1.csv","mimeType":"text/csv","path":"./_file/file1.259f3fd9.csv","lastModified":/* ts */1706742000000,"size":16});
+registerFile("./file2.csv", {"name":"./file2.csv","mimeType":"text/csv","path":"./_file/file2.c70f7d51.csv","lastModified":/* ts */1706742000000,"size":11});
 
 define({id: "1bcb5df5", inputs: ["FileAttachment"], outputs: ["f1"], body: (FileAttachment) => {
 const f1 = FileAttachment("./file1.csv").csv();

--- a/test/output/build/simple/simple.html
+++ b/test/output/build/simple/simple.html
@@ -15,7 +15,7 @@
 import {define} from "./_observablehq/client.00000001.js";
 import {registerFile} from "./_observablehq/stdlib.00000003.js";
 
-registerFile("./data.txt", {"name":"./data.txt","mimeType":"text/plain","path":"./_file/data.9d63c3b5.txt","lastModified":/* ts */1706742000000});
+registerFile("./data.txt", {"name":"./data.txt","mimeType":"text/plain","path":"./_file/data.9d63c3b5.txt","lastModified":/* ts */1706742000000,"size":15});
 
 define({id: "115586ff", inputs: ["FileAttachment"], outputs: ["result"], body: (FileAttachment) => {
 let result = FileAttachment("./data.txt").text();

--- a/yarn.lock
+++ b/yarn.lock
@@ -377,10 +377,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@observablehq/inputs@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@observablehq/inputs/-/inputs-0.11.0.tgz#930f5c16eef8e0d14f0e6fc3e5f2c7589b38ecd0"
-  integrity sha512-af8H7Ncg+B+5t9MVKA/GiR2oG1nK7P4g36a92jkgIaBSUDLcmta/FDiJKIyjJ3Pc+FNOGkfRcPCRWEgqVl+Q9A==
+"@observablehq/inputs@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@observablehq/inputs/-/inputs-0.12.0.tgz#865acb8f3292efdfedfdd5291e69dd88f7086ef3"
+  integrity sha512-1ln7+PYe31cMx00K9awVbiCscQM0THnXRJ/AEzd+FfTA25Gu3KRWknAGECxU49QzHyKqiXpLl5LCg3XtYm70eQ==
   dependencies:
     htl "^0.3.1"
     isoformat "^0.2.0"


### PR DESCRIPTION
~~Marking as draft until https://github.com/observablehq/inputs/pull/266 is merged and Inputs 0.12.0 is released.~~ Done. ~~Also, I think I can clean up the implementation slightly (like maybe consolidating `getSourceLastModified` and `getSourceSize` into `getSourceInfo`).~~ Done. Also fixes an unfiled bug where `file.href` didn’t work for `Inputs.file`.