### PR TITLE
restore Source Serif 4 for theme previews

### DIFF
--- a/docs/theme/[theme].md.ts
+++ b/docs/theme/[theme].md.ts
@@ -10,6 +10,8 @@ header: false
 sidebar: false
 ---
 
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap">
+
 ~~~js
 const subset = new Set(["Transportation and Utilities", "Mining and Extraction", "Finance", "Agriculture", "Information"]);
 const industriesSubset = industries.filter(d => subset.has(d.industry));


### PR DESCRIPTION
Fixes #1615. Maybe not the best fix since this still loads Inter and Spline Sans Mono even though they are unused. That’s because the **globalStylesheets** option applies to the theme previews even though they don’t use our custom stylesheet. Maybe we should have a **stylesheets** front matter option that allows us to override the global stylesheets from the config, so we can restore it back to the default here?