### PR TITLE
include pages in default paths

### DIFF
--- a/observablehq.config.ts
+++ b/observablehq.config.ts
@@ -89,14 +89,12 @@ export default {
     {name: "Contributing", path: "/contributing", pager: false}
   ],
   dynamicPaths: [
-    "/page-loaders",
     "/theme/dark",
     "/theme/dark-alt",
     "/theme/dashboard",
     "/theme/light",
     "/theme/light-alt",
     "/theme/wide",
-    "/themes",
     ...themes.dark.map((theme) => `/theme/${theme}`),
     ...themes.light.map((theme) => `/theme/${theme}`)
   ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -258,6 +258,7 @@ export function normalizeConfig(spec: ConfigSpec = {}, defaultRoot?: string, wat
   // end of the path. Otherwise, remove the .html extension (we use clean
   // paths as the internal canonical representation; see normalizePage).
   function normalizePagePath(pathname: string): string {
+    ({pathname} = parseRelativeUrl(pathname)); // ignore query & anchor
     pathname = normalizePath(pathname);
     if (pathname.endsWith("/")) pathname = join(pathname, "index");
     else pathname = pathname.replace(/\.html$/, "");
@@ -283,7 +284,7 @@ export function normalizeConfig(spec: ConfigSpec = {}, defaultRoot?: string, wat
       for (const path of getDefaultPaths(root)) {
         yield* visit(path);
       }
-      for (const path of getPagePaths(this.pages)) {
+      for (const path of getPagePaths(this)) {
         yield* visit(path);
       }
       for await (const path of dynamicPaths()) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ import {formatIsoDate, formatLocaleDate} from "./format.js";
 import type {FrontMatter} from "./frontMatter.js";
 import {LoaderResolver} from "./loader.js";
 import {createMarkdownIt, parseMarkdownMetadata} from "./markdown.js";
-import {walk} from "./pager.js";
+import {getPagePaths} from "./pager.js";
 import {isAssetPath, parseRelativeUrl, resolvePath} from "./path.js";
 import {isParameterizedPath} from "./route.js";
 import {resolveTheme} from "./theme.js";
@@ -283,10 +283,8 @@ export function normalizeConfig(spec: ConfigSpec = {}, defaultRoot?: string, wat
       for (const path of getDefaultPaths(root)) {
         yield* visit(path);
       }
-      for (const pages of walk(this.pages)) {
-        for (const page of pages) {
-          yield* visit(page.path);
-        }
+      for (const path of getPagePaths(this.pages)) {
+        yield* visit(path);
       }
       for await (const path of dynamicPaths()) {
         yield* visit(path);

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -87,7 +87,7 @@ export class LoaderResolver {
    * page object.
    */
   async loadPage(path: string, options: LoadOptions & ParseOptions, effects?: LoadEffects): Promise<MarkdownPage> {
-    const loader = this.find(`${path}.md`);
+    const loader = this.findPage(path, options);
     if (!loader) throw enoent(path);
     const source = await readFile(join(this.root, await loader.load(effects)), "utf8");
     return parseMarkdown(source, {params: loader.params, ...options});
@@ -100,6 +100,14 @@ export class LoaderResolver {
     const loader = this.find(`${path}.md`);
     if (!loader) throw enoent(path);
     return watch(join(this.root, loader.path), listener);
+  }
+
+  /**
+   * Finds the page loader for the specified target path, relative to the source
+   * root, if the loader exists. If there is no such loader, returns undefined.
+   */
+  findPage(path: string, options?: LoadOptions): Loader | undefined {
+    return this.find(`${path}.md`, options);
   }
 
   /**

--- a/src/pager.ts
+++ b/src/pager.ts
@@ -40,9 +40,11 @@ export function findLink(path: string, options: Pick<Config, "pages" | "title"> 
   return links.get(path);
 }
 
-// Walks the unique pages in the site so as to avoid creating cycles. Implicitly
-// adds a link at the beginning to the home page (/index).
-function walk(pages: Config["pages"], title = "Home"): Iterable<Iterable<Page>> {
+/**
+ * Walks the unique pages in the site so as to avoid creating cycles. Implicitly
+ * adds a link at the beginning to the home page (/index).
+ */
+export function walk(pages: Config["pages"], title = "Home"): Iterable<Iterable<Page>> {
   const pageGroups = new Map<string, Page[]>();
   const visited = new Set<string>();
 

--- a/src/pager.ts
+++ b/src/pager.ts
@@ -44,7 +44,7 @@ export function findLink(path: string, options: Pick<Config, "pages" | "title"> 
  * Walks the unique pages in the site so as to avoid creating cycles. Implicitly
  * adds a link at the beginning to the home page (/index).
  */
-export function walk(pages: Config["pages"], title = "Home"): Iterable<Iterable<Page>> {
+function walk(pages: Config["pages"], title = "Home"): Iterable<Iterable<Page>> {
   const pageGroups = new Map<string, Page[]>();
   const visited = new Set<string>();
 
@@ -64,4 +64,12 @@ export function walk(pages: Config["pages"], title = "Home"): Iterable<Iterable<
   }
 
   return pageGroups.values();
+}
+
+export function* getPagePaths(pages: Config["pages"]): Generator<string> {
+  for (const pageGroup of walk(pages)) {
+    for (const page of pageGroup) {
+      yield page.path;
+    }
+  }
 }

--- a/test/output/build/archives.posix/tar.html
+++ b/test/output/build/archives.posix/tar.html
@@ -96,7 +96,7 @@ await FileAttachment("./dynamic-tar-gz/does-not-exist.txt").text()
 <div class="observablehq observablehq--block"><observablehq-loading></observablehq-loading><!--:d0a58efd:--></div>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./zip"><span>Zip</span></a></nav>
+<nav><a rel="next" href="./zip"><span>Zip</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/archives.win32/tar.html
+++ b/test/output/build/archives.win32/tar.html
@@ -64,7 +64,7 @@ await FileAttachment("./static-tar/does-not-exist.txt").text()
 <div class="observablehq observablehq--block"><observablehq-loading></observablehq-loading><!--:d84cd7fb:--></div>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./zip"><span>Zip</span></a></nav>
+<nav><a rel="next" href="./zip"><span>Zip</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/fetches/foo.html
+++ b/test/output/build/fetches/foo.html
@@ -52,7 +52,7 @@ return {fooJsonData,fooCsvData};
 <div class="observablehq observablehq--block"><!--:47a695da:--></div>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./top"><span>Top</span></a></nav>
+<nav><a rel="next" href="./top"><span>Top</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/files/files.html
+++ b/test/output/build/files/files.html
@@ -75,7 +75,7 @@ FileAttachment("./unknown-mime-extension.really")
 <p><img src="./_file/observable%20logo%20small.8a915536.png" alt=""></p>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./subsection/subfiles"><span>Untitled</span></a></nav>
+<nav><a rel="next" href="./subsection/subfiles"><span>Untitled</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/imports/script.html
+++ b/test/output/build/imports/script.html
@@ -41,7 +41,7 @@ import "./_observablehq/client.00000001.js";
 <script src="./_file/top.a53c5d5b.js" type="other"></script>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./foo/foo"><span>Foo</span></a></nav>
+<nav><a rel="next" href="./foo/foo"><span>Foo</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/search-public/page1.html
+++ b/test/output/build/search-public/page1.html
@@ -52,7 +52,7 @@ import "./_observablehq/client.00000001.js";
 <p><ignore> <me also="ignore"> </me></ignore></p>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="./"><span>Home</span></a><a rel="next" href="./page3"><span>This page is not indexable</span></a></nav>
+<nav><a rel="next" href="./page3"><span>This page is not indexable</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/output/build/simple/simple.html
+++ b/test/output/build/simple/simple.html
@@ -51,7 +51,6 @@ display(result);
 <div class="observablehq observablehq--block"><!--:815178e4:--></div>
 </main>
 <footer id="observablehq-footer">
-<nav><a rel="prev" href="./"><span>Home</span></a></nav>
 <div>Built with <a href="https://observablehq.com/" target="_blank" rel="noopener noreferrer">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.</div>
 </footer>
 </div>

--- a/test/pager-test.ts
+++ b/test/pager-test.ts
@@ -1,78 +1,81 @@
 import assert from "node:assert";
 import {normalizeConfig} from "../src/config.js";
-import {findLink as pager} from "../src/pager.js";
+import {findLink} from "../src/pager.js";
 
 describe("findLink(path, options)", () => {
   it("returns the previous and next links for three pages", () => {
     const a = {name: "a", path: "/a", pager: "main"};
     const b = {name: "b", path: "/b", pager: "main"};
     const c = {name: "c", path: "/c", pager: "main"};
-    const config = {pages: [a, b, c]};
-    assert.deepStrictEqual(pager("/index", config), {prev: undefined, next: a});
-    assert.deepStrictEqual(pager("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
-    assert.deepStrictEqual(pager("/b", config), {prev: a, next: c});
-    assert.deepStrictEqual(pager("/c", config), {prev: b, next: undefined});
+    const config = normalizeConfig({pages: [a, b, c]});
+    assert.deepStrictEqual(findLink("/index", config), {prev: undefined, next: a});
+    assert.deepStrictEqual(findLink("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
+    assert.deepStrictEqual(findLink("/b", config), {prev: a, next: c});
+    assert.deepStrictEqual(findLink("/c", config), {prev: b, next: undefined});
   });
   it("returns the previous and next links for three pages with sections", () => {
     const a = {name: "a", path: "/a", pager: "main"};
     const b = {name: "b", path: "/b", pager: "main"};
     const c = {name: "c", path: "/c", pager: "main"};
     const section = {name: "section", collapsible: true, open: true, path: null, pager: null, pages: [a, b, c]};
-    const config = {pages: [section]};
-    assert.deepStrictEqual(pager("/index", config), {prev: undefined, next: a});
-    assert.deepStrictEqual(pager("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
-    assert.deepStrictEqual(pager("/b", config), {prev: a, next: c});
-    assert.deepStrictEqual(pager("/c", config), {prev: b, next: undefined});
+    const config = normalizeConfig({pages: [section]});
+    assert.deepStrictEqual(findLink("/index", config), {prev: undefined, next: a});
+    assert.deepStrictEqual(findLink("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
+    assert.deepStrictEqual(findLink("/b", config), {prev: a, next: c});
+    assert.deepStrictEqual(findLink("/c", config), {prev: b, next: undefined});
   });
   it("returns the previous and next links for two pages", () => {
     const a = {name: "a", path: "/a", pager: "main"};
     const b = {name: "b", path: "/b", pager: "main"};
-    const config = {pages: [a, b]};
-    assert.deepStrictEqual(pager("/index", config), {prev: undefined, next: a});
-    assert.deepStrictEqual(pager("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
-    assert.deepStrictEqual(pager("/b", config), {prev: a, next: undefined});
+    const config = normalizeConfig({pages: [a, b]});
+    assert.deepStrictEqual(findLink("/index", config), {prev: undefined, next: a});
+    assert.deepStrictEqual(findLink("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
+    assert.deepStrictEqual(findLink("/b", config), {prev: a, next: undefined});
   });
   it("returns the previous and next links for one pages", () => {
     const a = {name: "a", path: "/a", pager: "main"};
-    const config = {pages: [a]};
-    assert.deepStrictEqual(pager("/index", config), {prev: undefined, next: a});
-    assert.deepStrictEqual(pager("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: undefined});
+    const config = normalizeConfig({pages: [a]});
+    assert.deepStrictEqual(findLink("/index", config), {prev: undefined, next: a});
+    assert.deepStrictEqual(findLink("/a", config), {
+      prev: {name: "Home", path: "/index", pager: "main"},
+      next: undefined
+    });
   });
   it("returns undefined for zero pages", () => {
-    const config = {pages: []};
-    assert.deepStrictEqual(pager("/index", config), undefined);
+    const config = normalizeConfig({pages: []});
+    assert.deepStrictEqual(findLink("/index", config), undefined);
   });
   it("returns undefined for non-referenced pages", () => {
     const a = {name: "a", path: "/a", pager: "main"};
     const b = {name: "b", path: "/b", pager: "main"};
     const c = {name: "c", path: "/c", pager: "main"};
-    const config = {pages: [a, b, c]};
-    assert.deepStrictEqual(pager("/d", config), undefined);
+    const config = normalizeConfig({pages: [a, b, c]});
+    assert.deepStrictEqual(findLink("/d", config), undefined);
   });
   it("avoids cycles when a path is listed multiple times", () => {
     const a = {name: "a", path: "/a", pager: "main"};
     const b = {name: "b", path: "/b", pager: "main"};
     const c = {name: "c", path: "/c", pager: "main"};
-    const config = {pages: [a, b, a, c]};
-    assert.deepStrictEqual(pager("/index", config), {prev: undefined, next: a});
-    assert.deepStrictEqual(pager("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
-    assert.deepStrictEqual(pager("/b", config), {prev: a, next: c});
-    assert.deepStrictEqual(pager("/c", config), {prev: b, next: undefined});
+    const config = normalizeConfig({pages: [a, b, a, c]});
+    assert.deepStrictEqual(findLink("/index", config), {prev: undefined, next: a});
+    assert.deepStrictEqual(findLink("/a", config), {prev: {name: "Home", path: "/index", pager: "main"}, next: b});
+    assert.deepStrictEqual(findLink("/b", config), {prev: a, next: c});
+    assert.deepStrictEqual(findLink("/c", config), {prev: b, next: undefined});
   });
   it("implicitly includes the index page if there is a title", () => {
     const a = {name: "a", path: "/a", pager: "main"};
     const b = {name: "b", path: "/b", pager: "main"};
     const c = {name: "c", path: "/c", pager: "main"};
-    const config = {title: "Test", pages: [a, b, c]};
-    assert.deepStrictEqual(pager("/index", config), {prev: undefined, next: a});
-    assert.deepStrictEqual(pager("/a", config), {prev: {name: "Test", path: "/index", pager: "main"}, next: b});
-    assert.deepStrictEqual(pager("/b", config), {prev: a, next: c});
-    assert.deepStrictEqual(pager("/c", config), {prev: b, next: undefined});
+    const config = normalizeConfig({title: "Test", pages: [a, b, c]});
+    assert.deepStrictEqual(findLink("/index", config), {prev: undefined, next: a});
+    assert.deepStrictEqual(findLink("/a", config), {prev: {name: "Test", path: "/index", pager: "main"}, next: b});
+    assert.deepStrictEqual(findLink("/b", config), {prev: a, next: c});
+    assert.deepStrictEqual(findLink("/c", config), {prev: b, next: undefined});
   });
   it("normalizes / to /index", async () => {
     const config = normalizeConfig({pages: [{name: "Home", path: "/", pager: "main"}]});
-    assert.strictEqual(pager("/index", config), undefined);
-    assert.strictEqual(pager("/", config), undefined);
+    assert.strictEqual(findLink("/index", config), undefined);
+    assert.strictEqual(findLink("/", config), undefined);
   });
   it("normalizes / to /index (2)", async () => {
     const config = normalizeConfig({
@@ -81,15 +84,15 @@ describe("findLink(path, options)", () => {
         {name: "Second Home", path: "/second"}
       ]
     });
-    assert.deepStrictEqual(pager("/second", config), {
+    assert.deepStrictEqual(findLink("/second", config), {
       next: undefined,
       prev: {name: "Home", path: "/index", pager: "main"}
     });
-    assert.deepStrictEqual(pager("/index", config), {
+    assert.deepStrictEqual(findLink("/index", config), {
       next: {name: "Second Home", path: "/second", pager: "main"},
       prev: undefined
     });
-    assert.strictEqual(pager("/", config), undefined);
+    assert.strictEqual(findLink("/", config), undefined);
   });
   it("normalizes / to /index (3)", async () => {
     const config = normalizeConfig({
@@ -99,14 +102,14 @@ describe("findLink(path, options)", () => {
         {name: "By The Sea", path: "/by-the-sea"}
       ]
     });
-    assert.deepStrictEqual(pager("/second", config), {
+    assert.deepStrictEqual(findLink("/second", config), {
       next: {name: "By The Sea", path: "/by-the-sea", pager: "main"},
       prev: {name: "Home", path: "/index", pager: "main"}
     });
-    assert.deepStrictEqual(pager("/index", config), {
+    assert.deepStrictEqual(findLink("/index", config), {
       next: {name: "Second Home", path: "/second", pager: "main"},
       prev: undefined
     });
-    assert.strictEqual(pager("/", config), undefined);
+    assert.strictEqual(findLink("/", config), undefined);
   });
 });


### PR DESCRIPTION
If a page is listed in the **pages** config option, we should build it even if it’s not listed in **dynamicPaths**. Also, we shouldn’t build a page more than once.