### PR TITLE
Default workspace selection to first value

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -735,8 +735,7 @@ export async function promptDeployTarget(
       maxItems: Math.max(process.stdout.rows - 4, 0),
       options: currentUser.workspaces
         .map((w) => ({value: w, label: formatUser(w)}))
-        .sort((a, b) => b.value.role.localeCompare(a.value.role) || a.label.localeCompare(b.label)),
-      initialValue: currentUser.workspaces[0] // the oldest workspace, maybe?
+        .sort((a, b) => b.value.role.localeCompare(a.value.role) || a.label.localeCompare(b.label))
     });
     if (effects.clack.isCancel(chosenWorkspace)) {
       throw new CliError("User canceled deploy.", {print: false, exitCode: 0});


### PR DESCRIPTION
In the workspace selection we sort workspaces by role and name, but default the selection to the first unsorted value. Example:
<img width="425" alt="image" src="https://github.com/user-attachments/assets/d61d5fed-7ee6-48f4-ac1a-7c34e76376b1">

 Because this selection may appear arbitrary to users, we should instead preselect the first option in the list.