### PR TITLE
Generators.dark(*element*)

### DIFF
--- a/docs/lib/generators.md
+++ b/docs/lib/generators.md
@@ -81,9 +81,9 @@ const width = Generators.width(document.querySelector("main"));
 width
 ```
 
-## dark() <a href="https://github.com/observablehq/framework/releases/tag/v1.3.0" class="observablehq-version-badge" data-version="^1.3.0" title="Added in 1.3.0"></a>
+## dark(*element*) <a href="https://github.com/observablehq/framework/releases/tag/v1.3.0" class="observablehq-version-badge" data-version="^1.3.0" title="Added in 1.3.0"></a>
 
-[Source](https://github.com/observablehq/framework/blob/main/src/client/stdlib/generators/dark.ts) · Returns an async generator that yields a boolean indicating whether the page is currently displayed with a dark [color scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme).
+[Source](https://github.com/observablehq/framework/blob/main/src/client/stdlib/generators/dark.ts) · Returns an async generator that yields a boolean indicating whether the given target *element* is currently displayed with a dark [color scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme).
 
 If the page supports both light and dark mode (as with the [default theme](../themes)), the value reflects the user’s [preferred color scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme). The generator will yield a new value if the preferred color changes — as when the user changes their system settings, or if the user’s system adapts automatically to the diurnal cycle — allowing you to update the display as needed without requiring a page reload.
 
@@ -95,7 +95,7 @@ The current theme is: *${dark ? "dark" : "light"}*.
 The current theme is: *${dark ? "dark" : "light"}*.
 ```
 
-This generator is available by default as `dark` in Markdown. It can be used to pick a [color scheme](https://observablehq.com/plot/features/scales#color-scales) for a chart, or an appropriate [mix-blend-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode):
+This generator for the document `body` is available by default as `dark` in Markdown. It can be used to pick a [color scheme](https://observablehq.com/plot/features/scales#color-scales) for a chart, or an appropriate [mix-blend-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode):
 
 ```js echo
 Plot.plot({
@@ -118,3 +118,50 @@ Plot.plot({
   ]
 })
 ```
+
+The following card uses a <em>${darkTarget ? "dark" : "light"}</em> color scheme, which slightly varies based on the page’s scheme, but is always <em>${darkTarget ? "dark" : "light"}</em>. This is reflected, for example, in the colors that the browser selects for the inputs.
+
+```js
+const target = display(html`<div id="target" class="card">
+  <div>
+    ${Inputs.range([0, 100], {step: 1, label: "What a scheme!"})}
+  </div>
+</div>`);
+
+const darkTarget = Generators.dark(target.querySelector(".card > div"));
+```
+
+```js
+const toggleCard = view(Inputs.toggle({label: "toggle card scheme"}));
+```
+
+```js
+toggleCard ? html`
+<style>
+
+#target {
+  color: #eee;
+  background-color: light-dark(#444, black);
+}
+#target > div {
+  color-scheme: dark;
+}
+
+</style>`
+: 
+html`
+<style>
+
+#target {
+  color: #333;
+  background-color: light-dark(white, #ddd);
+}
+#target > div {
+  color-scheme: light;
+}
+
+</style>`
+```
+
+
+

--- a/src/client/stdlib/generators/dark.ts
+++ b/src/client/stdlib/generators/dark.ts
@@ -6,7 +6,6 @@ export function dark(target: HTMLElement = document.body) {
     let dark: boolean | undefined;
     target.style.setProperty("transition-property", "color");
     target.style.setProperty("transition-duration", "0.001s");
-    target.style.setProperty("transition-behavior", "allow-discrete"); // TODO: not sure this is necessary
     const changed = () => {
       const d = getComputedStyle(target).getPropertyValue("color-scheme") === "dark";
       if (dark === d) return; // only notify if changed

--- a/src/client/stdlib/generators/dark.ts
+++ b/src/client/stdlib/generators/dark.ts
@@ -1,18 +1,19 @@
 import {observe} from "./observe.js";
 
 // Watches dark mode based on theme and user preference.
-// TODO: in preview, also watch for changes in the theme meta.
-export function dark() {
+export function dark(target: HTMLElement = document.body) {
   return observe((notify: (dark: boolean) => void) => {
     let dark: boolean | undefined;
-    const media = matchMedia("(prefers-color-scheme: dark)");
+    target.style.setProperty("transition-property", "color");
+    target.style.setProperty("transition-duration", "0.001s");
+    target.style.setProperty("transition-behavior", "allow-discrete"); // TODO: not sure this is necessary
     const changed = () => {
-      const d = getComputedStyle(document.body).getPropertyValue("color-scheme") === "dark";
+      const d = getComputedStyle(target).getPropertyValue("color-scheme") === "dark";
       if (dark === d) return; // only notify if changed
       notify((dark = d));
     };
     changed();
-    media.addEventListener("change", changed);
-    return () => media.removeEventListener("change", changed);
+    target.addEventListener("transitionstart", changed);
+    return () => target.removeEventListener("transitionstart", changed);
   });
 }


### PR DESCRIPTION
We add a CSS transition to the body’s `color` style and listen to `transitionstart`. (Trick found in https://github.com/bramus/style-observer.)

This enables us to listen when the actual `color` starts transitioning, and update **dark** based on the computed value of `color-scheme`.

Note that this works with any element within the body, so:

1) if we want to ensure that the user has not added their own `transition` definitions to the body, we could use another element — or even create one on purpose.

2) we can listen to dark mode changes *inside* a page, say if someone has a block that needs to be in a mode that is toggled separately from the main page, maybe for demonstration purposes. I don't know if that is useful enough in practice, but it doesn't take more code to support this, and it's more consistent with `Generators.width(*element*)`. I've added such an example in the documentation—for testing purposes (I don't plan to ship this example in any case, but it could be documented in pangea as a side show).

If we think the transition might break or not work in all cases, we could keep listening to the user preference (media).

Here is a standalone (user land) version:

~~~~
---
_theme: light
---

# dark transitions

```js
display(dark);
```

```js echo
const dark = Mutable(null);
const setDark = (value) => dark.value = value;
```

```js echo
const probe = document.body;
probe.style.setProperty("transition-property", "color");
probe.style.setProperty("transition-duration", "0.001s");
const update = () => setDark(getComputedStyle(probe)["color-scheme"]);
update();
probe.addEventListener("transitionstart", update);
invalidation.then(() => probe.removeEventListener("transitionstart", update));
```

~~~~

closes #1339