### PR TITLE
Visible telemetry data types

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -8,7 +8,7 @@ You can [opt-out of telemetry](#disabling-telemetry) by setting the `OBSERVABLE_
 
 The following data is collected:
 
-```ts echo
+```ts run=false
 type TelemetryIds = {
   session: uuid; // random, held in memory for the duration of the process
   device: uuid; // persists to ~/.observablehq

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -8,7 +8,7 @@ You can [opt-out of telemetry](#disabling-telemetry) by setting the `OBSERVABLE_
 
 The following data is collected:
 
-```ts
+```ts echo
 type TelemetryIds = {
   session: uuid; // random, held in memory for the duration of the process
   device: uuid; // persists to ~/.observablehq


### PR DESCRIPTION
The ts code block wasn't displaying on the telemetry documentation.

Before
<img width="653" alt="image" src="https://github.com/user-attachments/assets/4997a4f3-38f6-4267-b94a-6866194aeec4">

After
<img width="800" alt="image" src="https://github.com/user-attachments/assets/be509db6-8fa7-4bf2-9200-042e7e44f55d">
