### PR TITLE
fix responsive chart dimensions on the EIA example

### DIFF
--- a/examples/eia/src/components/charts.js
+++ b/examples/eia/src/components/charts.js
@@ -16,9 +16,10 @@ function friendlyTypeName(d) {
 export function top5BalancingAuthoritiesChart(width, height, top5Demand, maxDemand) {
   return Plot.plot({
     marginTop: 8,
-    marginLeft: 250,
+    marginLeft: Math.min(width/2, 250),
     height: height - 4,
     width,
+    style: "overflow: hidden;",
     y: {label: null, tickSize: 0},
     x: {label: null, grid: true, tickSize: 0, tickPadding: 2, domain: [0, maxDemand / 1000], nice: true},
     marks: [

--- a/examples/eia/src/components/map.js
+++ b/examples/eia/src/components/map.js
@@ -25,7 +25,7 @@ export function balancingAuthoritiesMap({
 }) {
   return Plot.plot({
     width,
-    height: width * 0.6,
+    height: width * 0.67,
     color: {
       ...color,
       transform: (d) => d / 100,
@@ -33,6 +33,7 @@ export function balancingAuthoritiesMap({
     },
     projection: {
       type: "albers",
+      domain: nation,
       insetTop: 15
     },
     r: {
@@ -122,9 +123,10 @@ export function balancingAuthoritiesMap({
 export function balancingAuthoritiesLegend(width) {
   return Plot.plot({
     marginTop: 15,
-    width: Math.min(width - 30, 400),
+    marginRight: 80,
+    width,
     height: 60,
-    y: {axis: null},
+    y: {axis: null, domain: [0, 1]},
     marks: [
       Plot.raster({
         y1: 0,
@@ -136,14 +138,16 @@ export function balancingAuthoritiesLegend(width) {
       Plot.ruleX([-0.15, 0, 0.15], {insetBottom: -5}),
       Plot.axisX([-0.15, 0, 0.15], {tickFormat: format("+.0%"), tickSize: 0}),
       Plot.dot(["Generating only", "Unavailable"], {
-        x: [0.23, 0.4],
+        x: [0.26, 0.26],
+        y: [0.75, -.25],
         r: 5,
         dx: -8,
         fill: [colorGenerating, colorUnavailable],
         stroke: "grey"
       }),
       Plot.text(["Generating only", "Unavailable"], {
-        x: [0.23, 0.4],
+        x: [0.26, 0.26],
+        y: [0.75, -.25],
         textAnchor: "start"
       })
     ]

--- a/examples/eia/src/index.md
+++ b/examples/eia/src/index.md
@@ -1,5 +1,6 @@
 ---
 theme: dashboard
+toc: false
 ---
 
 # U.S. electricity grid
@@ -136,7 +137,7 @@ function centerResize(render) {
   <div class="card grid-colspan-2 grid-rowspan-3">
     <h2>Change in demand by balancing authority</h2>
     <h3>Percent change in electricity demand from previous hour</h3>
-    <figure style="max-width: none; min-height: 490px;">
+    <figure style="max-width: none;">
       <div style="display: flex; flex-direction: column; align-items: center;">
         <h1 style="margin-top: 0.5rem;">${hourFormat(currentHour)}</h1>
         <div>${currentDate} </div>
@@ -170,7 +171,7 @@ function centerResize(render) {
     <h2>US electricity generation demand vs. day-ahead forecast (GWh)</h2>
     ${resize((width, height) => usGenDemandForecastChart(width, height, usDemandGenForecast, currentHour))}
   </div>
-  <div class="card grid-colspan-2">
+  <div class="card grid-colspan-2" style="min-height: 160px;">
     <h2>Neighboring country interchange (GWh)</h2>
     ${resize((width, height) => countryInterchangeChart(width, height, usDemandGenForecast, countryInterchangeSeries, currentHour))}
   </div>

--- a/examples/eia/src/index.md
+++ b/examples/eia/src/index.md
@@ -136,7 +136,7 @@ function centerResize(render) {
   <div class="card grid-colspan-2 grid-rowspan-3">
     <h2>Change in demand by balancing authority</h2>
     <h3>Percent change in electricity demand from previous hour</h3>
-    <figure style="max-width: none;">
+    <figure style="max-width: none; min-height: 490px;">
       <div style="display: flex; flex-direction: column; align-items: center;">
         <h1 style="margin-top: 0.5rem;">${hourFormat(currentHour)}</h1>
         <div>${currentDate} </div>


### PR DESCRIPTION
This was a transient warning, due to the fact that the charts run independently. The height of the interchange chart was negative when the map had not yet been inserted in the DOM. By setting a min-height in css, we avoid the warning and more importantly only compute the charts once.

<img width="688" alt="warning" src="https://github.com/user-attachments/assets/72dac450-bb4f-4517-affd-9fa2dcbfba49">

Thanks @mootari for reporting.

In addition, I fixed the display for small screens.

redeployed at https://observablehq.observablehq.cloud/framework-example-eia/