### PR TITLE
fix error on failed deploy

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -688,9 +688,12 @@ class Deployer {
         case "uploaded":
           spinner.stop("Deploy complete");
           break pollLoop;
-        case "error":
+        case "failed":
           spinner.stop("Deploy failed");
           throw new CliError("Deploy failed to process on server");
+        case "canceled":
+          spinner.stop("Deploy canceled");
+          throw new CliError("Deploy canceled");
         default:
           spinner.stop("Unknown status");
           throw new CliError(`Unknown deploy status: ${deployInfo.status}`);


### PR DESCRIPTION
The server uses `failed` when the deploy fails, not `error`. Also, we should handle the `canceled` status. Any other status should be considered unexpected. Fixes https://github.com/observablehq/observablehq/issues/18081.