### PR TITLE
Increase the required version of send from 0.0.18 to 0.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "rollup": "^4.6.0",
     "rollup-plugin-esbuild": "^6.1.0",
     "semver": "^7.5.4",
-    "send": "^0.18.0",
+    "send": "^0.19.0",
     "tar": "^6.2.0",
     "tar-stream": "^3.1.6",
     "tsx": "^4.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,10 +3481,10 @@ semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
-send@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
-  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
+send@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"
+  integrity sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==
   dependencies:
     debug "2.6.9"
     depd "2.0.0"


### PR DESCRIPTION
The version of send 0.0.18 has a published vulnerability that is fixed in 0.0.19, see https://github.com/advisories/GHSA-m6fv-jmcg-4jfg. However, the version specifier of "^0.0.18" in package.json does not allow projects to use 0.0.19.

This changes the specifier to "^0.0.19" which allows (and requires) Observable Framework projects to use 0.0.19 to avoid the vulnerability.

Note that the vulnerability https://github.com/advisories/GHSA-m6fv-jmcg-4jfg has been public for over 2 weeks at this point, and so this isn't disclosing anything new.