### PR TITLE
Update title via postDeployUploaded instead of postUpdateProject

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -321,6 +321,7 @@ export async function build(
 
   // Render pages!
   const buildManifest: BuildManifest = {pages: []};
+  if (config.title) buildManifest.title = config.title;
   for (const [path, output] of outputs) {
     effects.output.write(`${faint("render")} ${path} ${faint("→")} `);
     if (output.type === "page") {
@@ -487,5 +488,6 @@ export class FileBuildEffects implements BuildEffects {
 }
 
 export interface BuildManifest {
+  title?: string;
   pages: {path: string; title: string | null}[];
 }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -21,7 +21,6 @@ import type {
   GetCurrentUserResponse,
   GetDeployResponse,
   GetProjectResponse,
-  PostEditProjectRequest,
   WorkspaceResponse
 } from "./observableApiClient.js";
 import type {ConfigEffects, DeployConfig} from "./observableApiConfig.js";
@@ -193,18 +192,13 @@ class Deployer {
 
   private async startNewDeploy(): Promise<GetDeployResponse> {
     const deployConfig = await this.getUpdatedDeployConfig();
-    const {deployTarget, projectUpdates} = await this.getDeployTarget(deployConfig);
-
+    const deployTarget = await this.getDeployTarget(deployConfig);
     const buildFilePaths = await this.getBuildFilePaths();
-
     const deployId = await this.createNewDeploy(deployTarget);
 
     await this.uploadFiles(deployId, buildFilePaths);
     await this.markDeployUploaded(deployId);
-    const deployInfo = await this.pollForProcessingCompletion(deployId);
-    await this.maybeUpdateProject(deployTarget, projectUpdates);
-
-    return deployInfo;
+    return await this.pollForProcessingCompletion(deployId);
   }
 
   // Make sure deploy exists and has an expected status.
@@ -280,11 +274,8 @@ class Deployer {
   }
 
   // Get the deploy target, prompting the user as needed.
-  private async getDeployTarget(
-    deployConfig: DeployConfig
-  ): Promise<{deployTarget: DeployTargetInfo; projectUpdates: PostEditProjectRequest}> {
+  private async getDeployTarget(deployConfig: DeployConfig): Promise<DeployTargetInfo> {
     let deployTarget: DeployTargetInfo;
-    const projectUpdates: PostEditProjectRequest = {};
     if (deployConfig.workspaceLogin && deployConfig.projectSlug) {
       try {
         const project = await this.apiClient.getProject({
@@ -292,7 +283,6 @@ class Deployer {
           projectSlug: deployConfig.projectSlug
         });
         deployTarget = {create: false, workspace: project.owner, project};
-        if (this.deployOptions.config.title !== project.title) projectUpdates.title = this.deployOptions.config.title;
       } catch (error) {
         if (!isHttpError(error) || error.statusCode !== 404) {
           throw error;
@@ -360,10 +350,6 @@ class Deployer {
           throw new CliError("Running non-interactively, cancelling due to conflict.");
         }
       }
-
-      if (deployTarget.project.title !== this.deployOptions.config.title) {
-        projectUpdates.title = this.deployOptions.config.title;
-      }
     }
 
     if (deployTarget.create) {
@@ -409,7 +395,7 @@ class Deployer {
       this.effects
     );
 
-    return {deployTarget, projectUpdates};
+    return deployTarget;
   }
 
   // Create the new deploy on the server.
@@ -703,12 +689,6 @@ class Deployer {
 
     if (!deployInfo) throw new CliError("Deploy failed to process on server");
     return deployInfo;
-  }
-
-  private async maybeUpdateProject(deployTarget: DeployTargetInfo, projectUpdates: PostEditProjectRequest) {
-    if (!deployTarget.create && typeof projectUpdates?.title === "string") {
-      await this.apiClient.postEditProject(deployTarget.project.id, projectUpdates);
-    }
   }
 }
 

--- a/src/observableApiClient.ts
+++ b/src/observableApiClient.ts
@@ -144,14 +144,6 @@ export class ObservableApiClient {
     });
   }
 
-  async postEditProject(projectId: string, updates: PostEditProjectRequest): Promise<PostEditProjectResponse> {
-    return await this._fetch<PostEditProjectResponse>(new URL(`/cli/project/${projectId}/edit`, this._apiOrigin), {
-      method: "POST",
-      headers: {"content-type": "application/json"},
-      body: JSON.stringify({...updates})
-    });
-  }
-
   async getWorkspaceProjects(workspaceLogin: string): Promise<GetProjectResponse[]> {
     const pages = await this._fetch<PaginatedList<GetProjectResponse>>(
       new URL(`/cli/workspace/@${workspaceLogin}/projects`, this._apiOrigin),
@@ -227,10 +219,6 @@ export class ObservableApiClient {
       body: JSON.stringify({id})
     });
   }
-}
-
-export interface PostEditProjectRequest {
-  title?: string;
 }
 
 export interface PostEditProjectResponse {

--- a/test/build-test.ts
+++ b/test/build-test.ts
@@ -148,6 +148,21 @@ describe("build", () => {
 
     await Promise.all([inputDir, cacheDir, outputDir].map((dir) => rm(dir, {recursive: true}))).catch(() => {});
   });
+
+  it("should include the title in the build manifest", async () => {
+    const tmpPrefix = join(os.tmpdir(), "framework-test-");
+    const inputDir = await mkdtemp(tmpPrefix + "input-");
+    await writeFile(join(inputDir, "index.md"), "# Hello, world!");
+
+    const outputDir = await mkdtemp(tmpPrefix + "output-");
+    const cacheDir = await mkdtemp(tmpPrefix + "output-");
+    const effects = new LoggingBuildEffects(outputDir, cacheDir);
+    const config = normalizeConfig({root: inputDir, output: outputDir, title: "Project Title"}, inputDir);
+    await build({config}, effects);
+
+    assert.deepEqual(effects.buildManifest?.title, "Project Title");
+    await Promise.all([inputDir, cacheDir, outputDir].map((dir) => rm(dir, {recursive: true}))).catch(() => {});
+  });
 });
 
 function* findFiles(root: string): Iterable<string> {

--- a/test/deploy-test.ts
+++ b/test/deploy-test.ts
@@ -293,7 +293,6 @@ describe("deploy", () => {
     getCurrentObservableApi()
       .handleGetCurrentUser()
       .handleGetProject({...DEPLOY_CONFIG, title: oldTitle})
-      .handleUpdateProject({projectId: DEPLOY_CONFIG.projectId, title: TEST_CONFIG.title!})
       .handlePostDeploy({projectId: DEPLOY_CONFIG.projectId, deployId})
       .expectStandardFiles({deployId})
       .handlePostDeployUploaded({deployId})
@@ -324,7 +323,6 @@ describe("deploy", () => {
       .expectStandardFiles({deployId})
       .handlePostDeployUploaded({deployId})
       .handleGetDeploy({deployId})
-      .handleUpdateProject({projectId: DEPLOY_CONFIG.projectId, title: TEST_CONFIG.title!})
       .start();
 
     const effects = new MockDeployEffects({

--- a/test/mocks/observableApi.ts
+++ b/test/mocks/observableApi.ts
@@ -215,25 +215,6 @@ class ObservableApiMock {
     return this;
   }
 
-  handleUpdateProject({
-    projectId = "project123",
-    title,
-    status = 200
-  }: {
-    projectId?: string;
-    title?: string;
-    status?: number;
-  } = {}): ObservableApiMock {
-    const response = status == 200 ? JSON.stringify({title, slug: "bi"}) : emptyErrorBody;
-    const headers = authorizationHeader(status !== 403);
-    this.addHandler((pool) =>
-      pool
-        .intercept({path: `/cli/project/${projectId}/edit`, method: "POST", headers: headersMatcher(headers)})
-        .reply(status, response, {headers: {"content-type": "application/json"}})
-    );
-    return this;
-  }
-
   handleGetWorkspaceProjects({
     workspaceLogin,
     projects,


### PR DESCRIPTION
This uses recent updates to the server protocol to update project titles. This approach is simpler for the client, and moves more of the stateful logic to the server that has more information.
