### PR TITLE
Revert "fix auth-in-url (#576)"

### DIFF
--- a/src/client/sidebar-init.ts
+++ b/src/client/sidebar-init.ts
@@ -1,6 +1,3 @@
-// Remove basic authentication in the URL, if any (to fix file attachments).
-if (Object.assign(document.createElement("a"), {href: ""}).password) location.replace(location.href);
-
 const sidebar = document.querySelector<HTMLElement>("#observablehq-sidebar")!;
 const toggle = document.querySelector<HTMLInputElement>("#observablehq-sidebar-toggle")!;
 


### PR DESCRIPTION
This reverts commit fca687cf98ce88815a654ba24c06e7a785f7a063. I think this was a holdover from when we used basic auth for the beta documentation. We shouldn’t need this now.