### PR TITLE
bug in sql.md: fix the query to ignore nulls

### DIFF
--- a/docs/sql.md
+++ b/docs/sql.md
@@ -174,11 +174,12 @@ Plot.plot({
   marks: [
     Plot.axisY({tickFormat: (d) => d / 1000, label: "count (thousands)"}),
     Plot.rectY(await sql`
-      SELECT
-        FLOOR(phot_g_mean_mag / 0.2) * 0.2 AS mag1
-      , mag1 + 0.2 AS mag2
-      , COUNT() AS count
-      FROM gaia GROUP BY 1
+      SELECT FLOOR(phot_g_mean_mag / 0.2) * 0.2 AS mag1
+           , mag1 + 0.2 AS mag2
+           , COUNT() AS count
+        FROM gaia
+       WHERE phot_g_mean_mag IS NOT NULL
+       GROUP BY 1
     `, {x1: "mag1", x2: "mag2", y: "count", tip: true})
   ]
 })


### PR DESCRIPTION
I see this bug in the last chart of https://observablehq.com/framework/sql

![spurious-rect](https://github.com/user-attachments/assets/808a0106-cfa3-4eea-bde1-58edc740aee2)

this spurious rect corresponds to datum 34 which has mag1 = mag2 = null. Plot does not handle correctly the `null`s in arrow vectors.

<del>It's still unclear to me why it does not happen all the time, and why it happens at all.</del>