### PR TITLE
removes the selection UI on sql code block displays

### DIFF
--- a/src/sql.ts
+++ b/src/sql.ts
@@ -9,10 +9,10 @@ export function transpileSql(content: string, {id, display}: Record<string, stri
   return id === undefined
     ? display === "false"
       ? `${sql};`
-      : `display(Inputs.table(await ${sql}));`
+      : `display(Inputs.table(await ${sql}, {select: false}));`
     : display === "false"
     ? `const ${id} = await ${sql};`
-    : `const ${id} = ((_) => (display(Inputs.table(_)), _))(await ${sql});`;
+    : `const ${id} = ((_) => (display(Inputs.table(_, {select: false})), _))(await ${sql});`;
 }
 
 function isValidBinding(input: string): boolean {

--- a/test/sql-test.ts
+++ b/test/sql-test.ts
@@ -3,7 +3,7 @@ import {transpileSql} from "../src/sql.js";
 
 describe("transpileSql(content, attributes)", () => {
   it("compiles a sql expression", () => {
-    assert.strictEqual(transpileSql("SELECT 1 + 2"), "display(Inputs.table(await sql`SELECT 1 + 2`));");
+    assert.strictEqual(transpileSql("SELECT 1 + 2"), "display(Inputs.table(await sql`SELECT 1 + 2`, {select: false}));");
   });
   it("compiles a sql expression with id", () => {
     assert.strictEqual(transpileSql("SELECT 1 + 2", {id: "foo"}), "const foo = await sql`SELECT 1 + 2`;");
@@ -22,13 +22,13 @@ describe("transpileSql(content, attributes)", () => {
     assert.throws(() => transpileSql("SELECT 1 + 2", {id: "([foo])"}), /invalid binding/);
   });
   it("compiles a sql expression with id and display", () => {
-    assert.strictEqual(transpileSql("SELECT 1 + 2", {id: "foo", display: ""}), "const foo = ((_) => (display(Inputs.table(_)), _))(await sql`SELECT 1 + 2`);"); // prettier-ignore
+    assert.strictEqual(transpileSql("SELECT 1 + 2", {id: "foo", display: ""}), "const foo = ((_) => (display(Inputs.table(_, {select: false})), _))(await sql`SELECT 1 + 2`);"); // prettier-ignore
   });
   it("ignores display if display is implicit", () => {
-    assert.strictEqual(transpileSql("SELECT 1 + 2", {display: ""}), "display(Inputs.table(await sql`SELECT 1 + 2`));"); // prettier-ignore
-    assert.strictEqual(transpileSql("SELECT 1 + 2", {display: "t"}), "display(Inputs.table(await sql`SELECT 1 + 2`));"); // prettier-ignore
-    assert.strictEqual(transpileSql("SELECT 1 + 2", {display: "f"}), "display(Inputs.table(await sql`SELECT 1 + 2`));"); // prettier-ignore
-    assert.strictEqual(transpileSql("SELECT 1 + 2", {display: "true"}), "display(Inputs.table(await sql`SELECT 1 + 2`));"); // prettier-ignore
+    assert.strictEqual(transpileSql("SELECT 1 + 2", {display: ""}), "display(Inputs.table(await sql`SELECT 1 + 2`, {select: false}));"); // prettier-ignore
+    assert.strictEqual(transpileSql("SELECT 1 + 2", {display: "t"}), "display(Inputs.table(await sql`SELECT 1 + 2`, {select: false}));"); // prettier-ignore
+    assert.strictEqual(transpileSql("SELECT 1 + 2", {display: "f"}), "display(Inputs.table(await sql`SELECT 1 + 2`, {select: false}));"); // prettier-ignore
+    assert.strictEqual(transpileSql("SELECT 1 + 2", {display: "true"}), "display(Inputs.table(await sql`SELECT 1 + 2`, {select: false}));"); // prettier-ignore
   });
   it("compiles a sql expression with display=false", () => {
     assert.strictEqual(transpileSql("SELECT 1 + 2", {display: "false"}), "sql`SELECT 1 + 2`;");

--- a/test/sql-test.ts
+++ b/test/sql-test.ts
@@ -3,7 +3,7 @@ import {transpileSql} from "../src/sql.js";
 
 describe("transpileSql(content, attributes)", () => {
   it("compiles a sql expression", () => {
-    assert.strictEqual(transpileSql("SELECT 1 + 2"), "display(Inputs.table(await sql`SELECT 1 + 2`, {select: false}));");
+    assert.strictEqual(transpileSql("SELECT 1 + 2"), "display(Inputs.table(await sql`SELECT 1 + 2`, {select: false}));"); // prettier-ignore
   });
   it("compiles a sql expression with id", () => {
     assert.strictEqual(transpileSql("SELECT 1 + 2", {id: "foo"}), "const foo = await sql`SELECT 1 + 2`;");


### PR DESCRIPTION
Removes the selection column UI on the displayed result of a `sql` code block, since this interaction is not operational.

In the case of a named block, we could imagine reenabling it if it would drive changes to the values passed to id; but it's not the case at the moment (and I'm not sure it would be the best UX anyway).