### PR TITLE
Deploy option to enable continuous deployment

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -215,7 +215,7 @@ class Deployer {
       const {deployPollInterval: pollInterval = DEPLOY_POLL_INTERVAL_MS} = this.deployOptions;
       await this.apiClient.postProjectBuild(deployTarget.project.id);
       const spinner = this.effects.clack.spinner();
-      spinner.start("Requesting deploy…");
+      spinner.start("Requesting deploy");
       const pollExpiration = Date.now() + DEPLOY_POLL_MAX_MS;
       pollLoop: while (true) {
         if (Date.now() > pollExpiration) {

--- a/src/observableApiClient.ts
+++ b/src/observableApiClient.ts
@@ -126,6 +126,31 @@ export class ObservableApiClient {
     return await this._fetch<GetProjectResponse>(url, {method: "GET"});
   }
 
+  async getProjectEnvironment({id}: {id: string}): Promise<GetProjectEnvironmentResponse> {
+    const url = new URL(`/cli/project/${id}/environment`, this._apiOrigin);
+    return await this._fetch<GetProjectEnvironmentResponse>(url, {method: "GET"});
+  }
+
+  async getGitHubRepositories(): Promise<GetGitHubRepositoriesResponse> {
+    const url = new URL("/cli/github/repositories", this._apiOrigin);
+    return await this._fetch<GetGitHubRepositoriesResponse>(url, {method: "GET"});
+  }
+
+  async postProjectEnvironment(id, body): Promise<GetProjectEnvironmentResponse> {
+    const url = new URL(`/cli/project/${id}/environment`, this._apiOrigin);
+    return await this._fetch<GetProjectEnvironmentResponse>(url, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify(body)
+    });
+  }
+
+  async postProjectBuild(id): Promise<{id: string}> {
+    return await this._fetch<{id: string}>(new URL(`/cli/project/${id}/build`, this._apiOrigin), {
+      method: "POST"
+    });
+  }
+
   async postProject({
     title,
     slug,
@@ -264,8 +289,40 @@ export interface GetProjectResponse {
   title: string;
   owner: {id: string; login: string};
   creator: {id: string; login: string};
+  latestCreatedDeployId: string | null;
   // Available fields that we don't use
   // servingRoot: string | null;
+}
+
+export interface GetProjectEnvironmentResponse {
+  automatic_builds_enabled: boolean | null;
+  build_environment_id: string | null;
+  source: null | {
+    provider: string;
+    provider_id: string;
+    url: string;
+    branch: string | null;
+  };
+}
+
+export interface GetGitHubRepositoriesResponse {
+  installations: {
+    id: number;
+    login: string | null;
+    name: string | null;
+  }[];
+  repositories: {
+    provider: "github";
+    provider_id: string;
+    url: string;
+    default_branch: string;
+    name: string;
+    linked_projects: {
+      title: string;
+      owner_id: string;
+      owner_name: string;
+    }[];
+  }[];
 }
 
 export interface DeployInfo {

--- a/src/observableApiConfig.ts
+++ b/src/observableApiConfig.ts
@@ -36,6 +36,7 @@ export interface DeployConfig {
   projectId?: string | null;
   projectSlug: string | null;
   workspaceLogin: string | null;
+  continuousDeployment: boolean | null;
 }
 
 export type ApiKey =
@@ -87,11 +88,12 @@ export async function getDeployConfig(
     }
   }
   // normalize
-  let {projectId, projectSlug, workspaceLogin} = config ?? ({} as any);
+  let {projectId, projectSlug, workspaceLogin, continuousDeployment} = config ?? ({} as any);
   if (typeof projectId !== "string") projectId = null;
   if (typeof projectSlug !== "string") projectSlug = null;
   if (typeof workspaceLogin !== "string") workspaceLogin = null;
-  return {projectId, projectSlug, workspaceLogin};
+  if (typeof continuousDeployment !== "boolean") continuousDeployment = null;
+  return {projectId, projectSlug, workspaceLogin, continuousDeployment};
 }
 
 export async function setDeployConfig(


### PR DESCRIPTION
Notes
- Whether you build locally or in cloud, the deploy method ends with pollForProcessingCompletion. In the local case, that just means uploading files; in the cloud case, it means doing a whole cloud build. Should we have the same timeout in both cases?
- Currently this prompts you to enable continuous deployment even if your project directory is ineligible. 
- Once your continuous deployment setting is saved, do we ever prompt you about it again? Is there a command to turn it on, or do we instruct you to edit deploy.json?