### PR TITLE
handle absolute global imports

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -237,7 +237,7 @@ export async function build(
     if (!path.endsWith(".js")) continue;
     const sourcePath = join(cacheRoot, path);
     effects.output.write(`${faint("build")} ${path} ${faint("→")} `);
-    const resolveImport = (i: string) => relativePath(path, aliases.get((i = resolvePath(path, i))) ?? i);
+    const resolveImport = (i: string) => isPathImport(i) ? relativePath(path, aliases.get((i = resolvePath(path, i))) ?? i) : i; // prettier-ignore
     await effects.writeFile(aliases.get(path)!, rewriteNpmImports(await readFile(sourcePath, "utf-8"), resolveImport));
   }
 

--- a/test/input/build/imports/foo/foo.js
+++ b/test/input/build/imports/foo/foo.js
@@ -1,4 +1,5 @@
 import "npm:d3";
+import "npm:@example/url-import";
 import {bar} from "../bar/bar.js";
 export {top} from "/top.js";
 

--- a/test/javascript/module-test.ts
+++ b/test/javascript/module-test.ts
@@ -8,8 +8,8 @@ const emptyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b
 // through the code and verifying that they consider all the relevant files.
 describe("getModuleHash(root, path)", () => {
   it("returns the transitive content hash for the specified module", () => {
-    assert.strictEqual(getModuleHash("test/input/build/imports", "foo/foo.js"), "32f934a52fa34ba1b06aa6089fe5922dc442c9bf2dcddef864bc649a39d9eace"); // prettier-ignore
-    assert.strictEqual(getModuleHash("test/input/build/imports", "bar/bar.js"), "7fe009c8bb0049d9b84d53a00b29fb172bbf07d8232d2ace5f7c6f220b23eb16"); // prettier-ignore
+    assert.strictEqual(getModuleHash("test/input/build/imports", "foo/foo.js"), "e743cc5455594df5a3bd78622594dfb7a8ddb9277957be9b9732f33a88955d82"); // prettier-ignore
+    assert.strictEqual(getModuleHash("test/input/build/imports", "bar/bar.js"), "34442bce5f38762986a81229c551723cdc3d4c1509ac14dde193555e65013d76"); // prettier-ignore
     assert.strictEqual(getModuleHash("test/input/build/imports", "top.js"), "160847a6b4890d59f8e8862911bfbe3b8066955d31f2708cafbe51945c3c57b6"); // prettier-ignore
     assert.strictEqual(getModuleHash("test/input/build/fetches", "foo/foo.js"), "3bb4a170d2f3539934168741572d4aa3cd11da649d4ca88b408edefb5c287360"); // prettier-ignore
     assert.strictEqual(getModuleHash("test/input/build/fetches", "top.js"), "6c858de52de6ff26b19508e95448288da02fac62251b7ca2710a308a0ebfd7ba"); // prettier-ignore
@@ -27,8 +27,8 @@ describe("getModuleInfo(root, path)", () => {
     assert.deepStrictEqual(redactModuleInfo("test/input/build/imports", "foo/foo.js"), {
       fileMethods: new Set(),
       files: new Set(),
-      hash: "c77c2490ea7b9a89dce7bad39973995e5158921bf8576955ae4a596c47a5a2a4",
-      globalStaticImports: new Set(["npm:d3"]),
+      hash: "17e03fbc08c28530c84ab1163901890915302d3f1d5af2c9256e3e8cab1324a9",
+      globalStaticImports: new Set(["npm:@example/url-import", "npm:d3"]),
       globalDynamicImports: new Set(),
       localDynamicImports: new Set(),
       localStaticImports: new Set(["../bar/bar.js", "../top.js"])

--- a/test/mocks/jsdelivr.ts
+++ b/test/mocks/jsdelivr.ts
@@ -1,7 +1,8 @@
 import {getCurrentAgent, mockAgent} from "./undici.js";
 
-const packages: [name: string, {version: string; dependencies?: Record<string, string>}][] = [
+const packages: [name: string, {version: string; contents?: string; dependencies?: Record<string, string>}][] = [
   ["@duckdb/duckdb-wasm", {version: "1.28.0"}],
+  ["@example/url-import", {version: "1.0.0", contents: "import('https://example.com');"}],
   ["@observablehq/inputs", {version: "0.10.6"}],
   ["@observablehq/plot", {version: "0.6.11"}],
   ["@observablehq/sample-datasets", {version: "1.0.1"}],
@@ -50,7 +51,7 @@ export function mockJsDelivr() {
         .persist(); // prettier-ignore
       cdnClient
         .intercept({path: new RegExp(`^/npm/${name}@${pkg.version}/`), method: "GET"})
-        .reply(200, "", {headers: {"cache-control": "public, immutable", "content-type": "text/javascript; charset=utf-8"}})
+        .reply(200, pkg.contents ?? "", {headers: {"cache-control": "public, immutable", "content-type": "text/javascript; charset=utf-8"}})
         .persist(); // prettier-ignore
     }
   });

--- a/test/output/build/imports/_import/bar/bar.13bb8056.js
+++ b/test/output/build/imports/_import/bar/bar.13bb8056.js
@@ -1,1 +1,0 @@
-export {bar} from "./baz.cdbfb28b.js";

--- a/test/output/build/imports/_import/bar/bar.4460ccc2.js
+++ b/test/output/build/imports/_import/bar/bar.4460ccc2.js
@@ -1,0 +1,1 @@
+export {bar} from "./baz.2add1dd0.js";

--- a/test/output/build/imports/_import/bar/baz.2add1dd0.js
+++ b/test/output/build/imports/_import/bar/baz.2add1dd0.js
@@ -1,4 +1,4 @@
-import {foo} from "../foo/foo.5963bf78.js";
+import {foo} from "../foo/foo.bcd720b2.js";
 
 export const bar = "bar";
 export const foobar = foo + "bar";

--- a/test/output/build/imports/_import/foo/foo.bcd720b2.js
+++ b/test/output/build/imports/_import/foo/foo.bcd720b2.js
@@ -1,5 +1,6 @@
 import "../../_npm/d3@7.8.5/cd372fb8.js";
-import {bar} from "../bar/bar.13bb8056.js";
+import "../../_npm/@example/url-import@1.0.0/1dd108c5.js";
+import {bar} from "../bar/bar.4460ccc2.js";
 export {top} from "../top.160847a6.js";
 
 export const foo = "foo";

--- a/test/output/build/imports/_npm/@example/url-import@1.0.0/1dd108c5.js
+++ b/test/output/build/imports/_npm/@example/url-import@1.0.0/1dd108c5.js
@@ -1,0 +1,1 @@
+import('https://example.com');

--- a/test/output/build/imports/foo/foo.html
+++ b/test/output/build/imports/foo/foo.html
@@ -14,11 +14,12 @@
 <link rel="modulepreload" href="../_observablehq/runtime.00000002.js">
 <link rel="modulepreload" href="../_observablehq/stdlib.00000003.js">
 <link rel="modulepreload" href="../_npm/d3@7.8.5/cd372fb8.js">
-<link rel="modulepreload" href="../_import/bar/bar.13bb8056.js">
+<link rel="modulepreload" href="../_import/bar/bar.4460ccc2.js">
 <link rel="modulepreload" href="../_import/top.160847a6.js">
 <link rel="modulepreload" href="../_import/foo/foo bar.b173d3de.js">
-<link rel="modulepreload" href="../_import/bar/baz.cdbfb28b.js">
-<link rel="modulepreload" href="../_import/foo/foo.5963bf78.js">
+<link rel="modulepreload" href="../_import/bar/baz.2add1dd0.js">
+<link rel="modulepreload" href="../_import/foo/foo.bcd720b2.js">
+<link rel="modulepreload" href="../_npm/@example/url-import@1.0.0/1dd108c5.js">
 <script type="module">
 
 import {define} from "../_observablehq/client.00000001.js";
@@ -28,7 +29,7 @@ registerFile("../top.js", {"name":"../top.js","mimeType":"text/javascript","path
 registerFile("./hello.txt", {"name":"./hello.txt","mimeType":"text/plain","path":"../_file/foo/hello.5891b5b5.txt","lastModified":/* ts */1706742000000,"size":6});
 
 define({id: "261e010e", inputs: ["display","FileAttachment"], outputs: ["d3","bar","top"], body: async (display,FileAttachment) => {
-const [d3, {bar}, {top}] = await Promise.all([import("../_npm/d3@7.8.5/cd372fb8.js"), import("../_import/bar/bar.13bb8056.js"), import("../_import/top.160847a6.js")]);
+const [d3, {bar}, {top}] = await Promise.all([import("../_npm/d3@7.8.5/cd372fb8.js"), import("../_import/bar/bar.4460ccc2.js"), import("../_import/top.160847a6.js")]);
 
 display(bar);
 display(top);


### PR DESCRIPTION
Fixes #1755. ~~I’d like a test here, but I think it would require us to mock out the contents of jsDelivr responses. I tested manually using the repro in the linked issue.~~ Added an automated test, easy enough.