### PR TITLE
adopt picocolors

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "mime": "^4.0.0",
     "minisearch": "^6.3.0",
     "open": "^10.1.0",
+    "picocolors": "^1.1.1",
     "pkg-dir": "^8.0.0",
     "resolve.exports": "^2.0.2",
     "rollup": "^4.6.0",

--- a/src/commandInstruction.ts
+++ b/src/commandInstruction.ts
@@ -1,5 +1,4 @@
 import {getObservableUiOrigin} from "./observableApiClient.js";
-import type {TtyColor} from "./tty.js";
 import {bold, magenta} from "./tty.js";
 
 export function commandInstruction(
@@ -7,9 +6,12 @@ export function commandInstruction(
   {
     color = (s) => magenta(bold(s)),
     env = process.env
-  }: {color?: TtyColor | null; env?: Record<string, string | undefined>} = {}
+  }: {
+    color?: ((s: string) => string) | null;
+    env?: Record<string, string | undefined>;
+  } = {}
 ): string {
-  if (!color) color = (s) => s;
+  color ??= (s) => s;
 
   const prefix = env["npm_config_user_agent"]?.includes("yarn/")
     ? "yarn observable"

--- a/src/tty.ts
+++ b/src/tty.ts
@@ -1,27 +1,22 @@
 import {isatty} from "node:tty";
 import * as clack from "@clack/prompts";
+import pc from "picocolors";
 import type {ClackEffects} from "./clack.js";
 import type {Logger} from "./logger.js";
 
-export const reset = color(0, 0);
-export const bold = color(1, 22);
-export const faint = color(2, 22);
-export const italic = color(3, 23);
-export const underline = color(4, 24);
-export const inverse = color(7, 27);
-export const strikethrough = color(9, 29);
-export const red = color(31, 39);
-export const green = color(32, 39);
-export const yellow = color(33, 39);
-export const blue = color(34, 39);
-export const magenta = color(35, 39);
-export const cyan = color(36, 39);
-
-export type TtyColor = (text: string) => string;
-
-function color(code: number, reset: number): TtyColor {
-  return process.stdout.isTTY ? (text: string) => `\x1b[${code}m${text}\x1b[${reset}m` : String;
-}
+export const reset = pc.reset;
+export const bold = pc.bold;
+export const faint = pc.gray;
+export const italic = pc.italic;
+export const underline = pc.underline;
+export const inverse = pc.inverse;
+export const strikethrough = pc.strikethrough;
+export const red = pc.red;
+export const green = pc.green;
+export const yellow = pc.yellow;
+export const blue = pc.blue;
+export const magenta = pc.magenta;
+export const cyan = pc.cyan;
 
 export interface TtyEffects {
   clack: ClackEffects;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,11 +2548,6 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
-is-unicode-supported@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
-  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
-
 is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
@@ -3133,10 +3128,10 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-picocolors@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
-  integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
+picocolors@^1.0.0, picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
Replaces our hand-rolled version with the popular [picocolors](https://github.com/alexeyraspopov/picocolors), offering support for `NO_COLOR` and relying on picocolor’s own color support detection. As an alternative, we could also use [yoctocolors](https://github.com/sindresorhus/yoctocolors) which already uses [`hasColors`](https://nodejs.org/api/tty.html#writestreamhascolorscount-env)… but I figured picocolors is nice because it’s already a dependency of clack.

Related #1764.