### PR TITLE
page fragment loaders

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,10 @@ console.log(`The current version of Node is: <b>${process.env.npm_package_versio
 uname -a
 ```
 
+```sh server echo
+date
+```
+
 <style>
 
 .hero {

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,11 +2,11 @@
 index: false
 ---
 
-```js server
+```js server echo
 console.log(`The current version of Node is: <b>${process.env.npm_package_version}.`);
 ```
 
-```sh server
+```sh server echo
 uname -a
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,14 @@
 index: false
 ---
 
+```js server
+console.log(`The current version of Node is: <b>${process.env.npm_package_version}.`);
+```
+
+```sh server
+uname -a
+```
+
 <style>
 
 .hero {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -81,7 +81,7 @@ export class LoaderResolver {
     const loader = this.findPage(path);
     if (!loader) throw enoent(path);
     const input = await readFile(join(this.root, await loader.load(options, effects)), "utf8");
-    return parseMarkdown(input, {source: loader.path, params: loader.params, ...options});
+    return await parseMarkdown(input, {source: loader.path, params: loader.params, ...options});
   }
 
   /**

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -62,7 +62,7 @@ export interface LoaderOptions {
 
 export class LoaderResolver {
   private readonly root: string;
-  private readonly interpreters: Map<string, string[]>;
+  public readonly interpreters: Map<string, string[]>; // TODO cleaner
 
   constructor({root, interpreters}: {root: string; interpreters?: Record<string, string[] | null>}) {
     this.root = root;

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -243,7 +243,7 @@ export function createMarkdownIt({
   return markdownIt === undefined ? md : markdownIt(md);
 }
 
-export function parseMarkdown(input: string, options: ParseOptions): MarkdownPage {
+export async function parseMarkdown(input: string, options: ParseOptions): Promise<MarkdownPage> {
   const {md, path, source = path, params} = options;
   const {content, data} = readFrontMatter(input);
   const code: MarkdownCode[] = [];

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-named-as-default-member */
 import {createHash} from "node:crypto";
 import slugify from "@sindresorhus/slugify";
+import {spawn} from "cross-spawn";
 import he from "he";
 import MarkdownIt from "markdown-it";
 import type {RuleCore} from "markdown-it/lib/parser_core.mjs";
@@ -12,7 +13,7 @@ import type {Config} from "./config.js";
 import {mergeStyle} from "./config.js";
 import type {FrontMatter} from "./frontMatter.js";
 import {readFrontMatter} from "./frontMatter.js";
-import {html, rewriteHtmlPaths} from "./html.js";
+import {html, parseHtml, rewriteHtmlPaths} from "./html.js";
 import {parseInfo} from "./info.js";
 import {transformJavaScriptSync} from "./javascript/module.js";
 import type {JavaScriptNode} from "./javascript/parse.js";
@@ -31,6 +32,12 @@ export interface MarkdownCode {
   mode: "inline" | "block" | "jsx";
 }
 
+export interface FragmentLoader {
+  id: string;
+  tag: string;
+  source: string;
+}
+
 export interface MarkdownPage {
   title: string | null;
   head: string | null;
@@ -46,6 +53,7 @@ export interface MarkdownPage {
 
 interface ParseContext {
   code: MarkdownCode[];
+  fragments: FragmentLoader[];
   startLine: number;
   currentLine: number;
   path: string;
@@ -119,14 +127,25 @@ function makeFenceRenderer(baseRenderer: RenderRule): RenderRule {
     let html = "";
     let source: string | undefined;
     try {
-      source = isFalse(attributes.run) ? undefined : getLiveSource(token.content, tag, attributes);
+      source =
+        attributes.server != null
+          ? token.content
+          : isFalse(attributes.run)
+          ? undefined
+          : getLiveSource(token.content, tag, attributes);
       if (source != null) {
+        let loading = false;
         const id = uniqueCodeId(context, source);
         // TODO const sourceLine = context.startLine + context.currentLine;
-        const node = parseJavaScript(source, {path, params});
-        context.code.push({id, node, mode: tag === "jsx" || tag === "tsx" ? "jsx" : "block"});
+        if (attributes.server != null) {
+          context.fragments.push({id, tag, source});
+        } else {
+          const node = parseJavaScript(source, {path, params});
+          context.code.push({id, node, mode: tag === "jsx" || tag === "tsx" ? "jsx" : "block"});
+          loading = node.expression;
+        }
         html += `<div class="observablehq observablehq--block">${
-          node.expression ? "<observablehq-loading></observablehq-loading>" : ""
+          loading ? "<observablehq-loading></observablehq-loading>" : ""
         }<!--:${id}:--></div>\n`;
       }
     } catch (error) {
@@ -214,6 +233,7 @@ export interface ParseOptions {
   path: string;
   style?: Config["style"];
   scripts?: Config["scripts"];
+  loaders?: Config["loaders"];
   head?: Config["head"];
   header?: Config["header"];
   footer?: Config["footer"];
@@ -247,10 +267,44 @@ export async function parseMarkdown(input: string, options: ParseOptions): Promi
   const {md, path, source = path, params} = options;
   const {content, data} = readFrontMatter(input);
   const code: MarkdownCode[] = [];
-  const context: ParseContext = {code, startLine: 0, currentLine: 0, path, params};
+  const fragments: FragmentLoader[] = [];
+  const context: ParseContext = {code, fragments, startLine: 0, currentLine: 0, path, params};
   const tokens = md.parse(content, context);
-  const body = md.renderer.render(tokens, md.options, context); // Note: mutates code!
   const title = data.title !== undefined ? data.title : findTitle(tokens);
+  let body = md.renderer.render(tokens, md.options, context); // Note: mutates code!
+
+  // Rewrite body to render fragments.
+  if (fragments.length) {
+    const {document} = parseHtml(body);
+    const roots = findRoots(document, document.body);
+    const interpreters = options.loaders!.interpreters;
+    for (const fragment of fragments) {
+      const root: Comment = roots.get(fragment.id);
+      const [command, ...args] = interpreters.get(`.${fragment.tag}`)!;
+      let target = "";
+      const subprocess = spawn(command, args, {
+        windowsHide: true,
+        stdio: ["pipe", "pipe", "inherit"]
+      });
+      subprocess.stdin.write(fragment.source);
+      subprocess.stdin.end();
+      subprocess.stdout.on("data", (data) => {
+        target += data.toString();
+      });
+      const code = await new Promise((resolve, reject) => {
+        subprocess.on("error", reject);
+        subprocess.on("close", resolve);
+      });
+      if (code !== 0) {
+        throw new Error(`loader exited with code ${code}`);
+      }
+      const template = document.createElement("template");
+      template.innerHTML = target;
+      root.replaceWith(template.content.cloneNode(true));
+    }
+    body = document.body.innerHTML;
+  }
+
   return {
     head: getHead(title, data, options),
     header: getHeader(title, data, options),
@@ -263,6 +317,22 @@ export async function parseMarkdown(input: string, options: ParseOptions): Promi
     path: source,
     params
   };
+}
+
+function findRoots(document, root) {
+  const roots = new Map();
+  const iterator = document.createNodeIterator(root, 128, null);
+  let node;
+  while ((node = iterator.nextNode())) {
+    if (isRoot(node)) {
+      roots.set(node.data.slice(1, -1), node);
+    }
+  }
+  return roots;
+}
+
+function isRoot(node) {
+  return node.nodeType === 8 && /^:[0-9a-f]{8}(?:-\d+)?:$/.test(node.data);
 }
 
 /** Like parseMarkdown, but optimized to return only metadata. */

--- a/test/markdown-test.ts
+++ b/test/markdown-test.ts
@@ -23,7 +23,7 @@ describe("parseMarkdown(input)", () => {
 
     (only ? it.only : skip ? it.skip : it)(`test/input/${name}`, async () => {
       const source = await readFile(path, "utf8");
-      const snapshot = parseMarkdown(source, {path: name, md});
+      const snapshot = await parseMarkdown(source, {path: name, md});
       let allequal = true;
       for (const ext of ["html", "json"]) {
         const actual = ext === "json" ? jsonMeta(snapshot) : snapshot.body;

--- a/test/resolvers-test.ts
+++ b/test/resolvers-test.ts
@@ -14,74 +14,74 @@ describe("getResolvers(page, {root, path})", () => {
   const builtins = ["observablehq:runtime", "observablehq:stdlib", "observablehq:client"];
   it("resolves directly-attached files", async () => {
     const options = getOptions({root: "test/input", path: "attached.md"});
-    const page = parseMarkdown("${FileAttachment('foo.csv')}", options);
+    const page = await parseMarkdown("${FileAttachment('foo.csv')}", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.files, new Set(["./foo.csv"]));
   });
   it("ignores files that are outside of the source root", async () => {
     const options = getOptions({root: "test/input", path: "attached.md"});
-    const page = parseMarkdown("${FileAttachment('../foo.csv')}", options);
+    const page = await parseMarkdown("${FileAttachment('../foo.csv')}", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.files, new Set([]));
   });
   it("detects file methods", async () => {
     const options = getOptions({root: "test/input", path: "attached.md"});
-    const page = parseMarkdown("${FileAttachment('foo.csv').csv}", options);
+    const page = await parseMarkdown("${FileAttachment('foo.csv').csv}", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(["npm:d3-dsv", ...builtins]));
   });
   it("detects local static imports", async () => {
     const options = getOptions({root: "test/input/imports", path: "attached.md"});
-    const page = parseMarkdown("```js\nimport './bar.js';\n```", options);
+    const page = await parseMarkdown("```js\nimport './bar.js';\n```", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(["./bar.js", ...builtins]));
     assert.deepStrictEqual(resolvers.localImports, new Set(["./bar.js"]));
   });
   it("detects local transitive static imports", async () => {
     const options = getOptions({root: "test/input/imports", path: "attached.md"});
-    const page = parseMarkdown("```js\nimport './other/foo.js';\n```", options);
+    const page = await parseMarkdown("```js\nimport './other/foo.js';\n```", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(["./other/foo.js", "./bar.js", ...builtins]));
     assert.deepStrictEqual(resolvers.localImports, new Set(["./other/foo.js", "./bar.js"]));
   });
   it("detects local transitive static imports (2)", async () => {
     const options = getOptions({root: "test/input/imports", path: "attached.md"});
-    const page = parseMarkdown("```js\nimport './transitive-static-import.js';\n```", options);
+    const page = await parseMarkdown("```js\nimport './transitive-static-import.js';\n```", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(["./transitive-static-import.js", "./other/foo.js", "./bar.js", ...builtins])); // prettier-ignore
     assert.deepStrictEqual(resolvers.localImports, new Set(["./transitive-static-import.js", "./other/foo.js", "./bar.js"])); // prettier-ignore
   });
   it("detects local transitive dynamic imports", async () => {
     const options = getOptions({root: "test/input/imports", path: "attached.md"});
-    const page = parseMarkdown("```js\nimport './dynamic-import.js';\n```", options);
+    const page = await parseMarkdown("```js\nimport './dynamic-import.js';\n```", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(["./dynamic-import.js", ...builtins]));
     assert.deepStrictEqual(resolvers.localImports, new Set(["./dynamic-import.js", "./bar.js"]));
   });
   it("detects local transitive dynamic imports (2)", async () => {
     const options = getOptions({root: "test/input/imports", path: "attached.md"});
-    const page = parseMarkdown("```js\nimport('./dynamic-import.js');\n```", options);
+    const page = await parseMarkdown("```js\nimport('./dynamic-import.js');\n```", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(builtins));
     assert.deepStrictEqual(resolvers.localImports, new Set(["./dynamic-import.js", "./bar.js"]));
   });
   it("detects local transitive dynamic imports (3)", async () => {
     const options = getOptions({root: "test/input/imports", path: "attached.md"});
-    const page = parseMarkdown("```js\nimport('./transitive-dynamic-import.js');\n```", options);
+    const page = await parseMarkdown("```js\nimport('./transitive-dynamic-import.js');\n```", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(builtins));
     assert.deepStrictEqual(resolvers.localImports, new Set(["./transitive-dynamic-import.js", "./other/foo.js", "./bar.js"])); // prettier-ignore
   });
   it("detects local transitive dynamic imports (4)", async () => {
     const options = getOptions({root: "test/input/imports", path: "attached.md"});
-    const page = parseMarkdown("```js\nimport('./transitive-static-import.js');\n```", options);
+    const page = await parseMarkdown("```js\nimport('./transitive-static-import.js');\n```", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(builtins));
     assert.deepStrictEqual(resolvers.localImports, new Set(["./transitive-static-import.js", "./other/foo.js", "./bar.js"])); // prettier-ignore
   });
   it("detects local dynamic imports", async () => {
     const options = getOptions({root: "test/input", path: "attached.md"});
-    const page = parseMarkdown("${import('./foo.js')}", options);
+    const page = await parseMarkdown("${import('./foo.js')}", options);
     const resolvers = await getResolvers(page, options);
     assert.deepStrictEqual(resolvers.staticImports, new Set(builtins));
     assert.deepStrictEqual(resolvers.localImports, new Set(["./foo.js"]));
@@ -89,9 +89,9 @@ describe("getResolvers(page, {root, path})", () => {
 });
 
 describe("resolveLink(href) with {preserveExtension: true}", () => {
-  const options = getOptions({root: "test/input", path: "sub/index.html", preserveExtension: true});
-  const page = parseMarkdown("", options);
   async function getResolveLink() {
+    const options = getOptions({root: "test/input", path: "sub/index.html", preserveExtension: true});
+    const page = await parseMarkdown("", options);
     const resolvers = await getResolvers(page, options);
     return resolvers.resolveLink;
   }
@@ -164,9 +164,9 @@ describe("resolveLink(href) with {preserveExtension: true}", () => {
 });
 
 describe("resolveLink(href) with {preserveExtension: false}", () => {
-  const options = getOptions({root: "test/input", path: "sub/index.html", preserveExtension: false});
-  const page = parseMarkdown("", options);
   async function getResolveLink() {
+    const options = getOptions({root: "test/input", path: "sub/index.html", preserveExtension: false});
+    const page = await parseMarkdown("", options);
     const resolvers = await getResolvers(page, options);
     return resolvers.resolveLink;
   }


### PR DESCRIPTION
This adds a `server` option to fenced code blocks. When present, the code is run on the server when the page is rendered in the same fashion as a data or page loader; the interpreter is passed the source of the fenced code block as input. The output of a page fragment loader must be HTML, which then replaces the comment placeholder (_e.g._, `<!--:85902a01:-->`).

<img width="942" alt="Screenshot 2024-11-09 at 9 40 39 AM" src="https://github.com/user-attachments/assets/60f5e539-be7b-45b8-b2fb-078b877610a6">

Marking this as a draft because I haven’t thought through how caching should work. Currently page fragment loaders run every time the page is loaded, but I think they should only run when the page is edited, similar to page and data loaders. That means we’ll need to cache the output of page fragment loaders (or more likely the HTML of the entire page).

I also think the implementation could be cleaned up slightly, for example by moving the rendering of page fragments into a function, and by exposing the normalized interpreters on the config instead of on loaders… or maybe the loaders object should have a method for evaluating fragments.

Fixes #234. Probably also fixes #145, which we should consider duplicate.