### PR TITLE
use event.target.value

### DIFF
--- a/src/client/stdlib/generators/input.js
+++ b/src/client/stdlib/generators/input.js
@@ -4,7 +4,7 @@ export function input(element) {
   return observe((change) => {
     const event = eventof(element);
     let value = valueof(element);
-    const inputted = () => change(valueof(element));
+    const inputted = (event) => change(valueof(event.target));
     element.addEventListener(event, inputted);
     if (value !== undefined) change(value);
     return () => element.removeEventListener(event, inputted);


### PR DESCRIPTION
Currently when you wrap an interactive element in a `div`, maybe for aesthetic reasons, or because you want to add a title etc, you can't use `Generators.input` to read the value — or you need to copy the value somehow to the top-level element, as we do in Plot with the `figure` element.

(This, even though the `input` event bubbles up, which makes `Generators.input` slightly inconsistent.)

This change makes Generators.input read the value on the `input` event’s **target**, making it easier to read the value of, say, a chart within a `resize` call.

~~~~md
```js echo
function scatterPlot(width) {
  return Plot.plot({
    width,
  marks: [Plot.dot(cars, { x: "power (hp)", y: "economy (mpg)", tip: true })]
})};
```

<div id=chart class="grid grid-cols-1">
  <div class="card">${resize((width) => scatterPlot(width))}</div>
</div>

```js echo
const v = Generators.input(document.getElementById("chart"));
```

<pre>${JSON.stringify(v, null, 2)}</pre>
~~~~ 

Note: if there are several inputs inside the "chart", so that whichever input (chart) you're touching returns its value. To combine values, you still need to use Inputs.form (but maybe Inputs.form could benefit from the same treatment?)

(OP: https://github.com/observablehq/framework/discussions/1806#discussioncomment-11211770)


Leaving as a draft as there may be unwanted consequences that I'm not seeing.