### PR TITLE
Edit documentation to cite Observable Cloud support for embedding

### DIFF
--- a/docs/embeds.md
+++ b/docs/embeds.md
@@ -10,6 +10,8 @@ In addition to standalone apps, you can use Framework to embed interactive views
 - [exported files](#exported-files) for hotlinking images, data, and other assets, or
 - [iframe embeds](#iframe-embeds) for compatibility.
 
+You can deploy to Observable Cloud for [additional features](https://observablehq.com/documentation/data-apps/embeds)<a href="https://github.com/observablehq/framework/releases/tag/v1.13.0" class="observablehq-version-badge" data-version="^1.13.0" title="Added in v1.13.0"></a> like secure private embedding on approved domains and analytics to see which exports are used.
+
 ## Exported modules
 
 Framework allows [JavaScript modules](./imports#local-imports) to be exported for use in another application. Exported modules are vanilla JavaScript and behave identically in an external web application as on a Framework page. As with local modules, exported modules can load data from a [static file](./files) or a [data loader](./data-loaders), [import](./imports) other local modules, and import libraries from [npm](./imports#npm-imports) or [JSR](./imports#jsr-imports).
@@ -75,9 +77,9 @@ document.body.append(await Chart());
 </script>
 ```
 
-<div class="warning" label="Coming soon">
+<div class="tip">
 
-Observable Cloud support for cross-origin resource sharing (CORS) is not yet generally available and is needed for exported modules. If you are interested in beta-testing this feature, please [email us](mailto:support@observablehq.com). For public apps, you can use a third-party host supporting CORS such as GitHub Pages.
+Observable Cloud supports cross-origin resource sharing (CORS), which is needed for exported modules. [Learn more…](https://observablehq.com/documentation/data-apps/embeds#cors)
 
 </div>
 

--- a/docs/embeds.md
+++ b/docs/embeds.md
@@ -10,7 +10,7 @@ In addition to standalone apps, you can use Framework to embed interactive views
 - [exported files](#exported-files) for hotlinking images, data, and other assets, or
 - [iframe embeds](#iframe-embeds) for compatibility.
 
-You can deploy to Observable Cloud for [additional features](https://observablehq.com/documentation/data-apps/embeds)<a href="https://github.com/observablehq/framework/releases/tag/v1.13.0" class="observablehq-version-badge" data-version="^1.13.0" title="Added in v1.13.0"></a> like secure private embedding on approved domains and analytics to see which exports are used.
+You can deploy to Observable Cloud for [additional features](https://observablehq.com/documentation/data-apps/embeds)<a href="https://github.com/observablehq/framework/releases/tag/v1.13.0" class="observablehq-version-badge" data-version="^1.13.0" title="Added in v1.13.0"></a> including secure private embedding on approved domains and analytics to see which exports are used.
 
 ## Exported modules
 
@@ -79,7 +79,7 @@ document.body.append(await Chart());
 
 <div class="tip">
 
-Observable Cloud supports cross-origin resource sharing (CORS), which is needed for exported modules. [Learn more…](https://observablehq.com/documentation/data-apps/embeds#cors)
+Observable Cloud supports [cross-origin resource sharing](https://observablehq.com/documentation/data-apps/embeds#cors) (CORS), which is needed for exported modules.
 
 </div>
 


### PR DESCRIPTION
Adds one sentence at the top and one tip replacing the previous "Coming soon" callout. (Supersedes https://github.com/observablehq/framework/pull/1830, in which I branched off the wrong branch!)

Before|After
-|-
![image](https://github.com/user-attachments/assets/73e213ae-e913-4dfa-a7b8-62d997da0ea6)|![image](https://github.com/user-attachments/assets/8f7ab35a-3ce7-4c2d-82b5-3b53bf2dac8b)
![image](https://github.com/user-attachments/assets/5d25c445-36b9-42bf-8645-b677bcaf8974)|![image](https://github.com/user-attachments/assets/6d77074c-7af4-4e73-81a1-bb89e0550b53)
