### PR TITLE
support cjs and mjs file extensions

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -265,7 +265,9 @@ The **interpreters** option specifies additional interpreted languages for data 
 
 ```js run=false
 {
+  ".cjs": ["node", "--no-warnings=ExperimentalWarning"],
   ".js": ["node", "--no-warnings=ExperimentalWarning"],
+  ".mjs": ["node", "--no-warnings=ExperimentalWarning"],
   ".ts": ["tsx"],
   ".py": ["python3"],
   ".r": ["Rscript"],

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -24,7 +24,9 @@ import {cyan, faint, green, red, yellow} from "./tty.js";
 const runningCommands = new Map<string, Promise<string>>();
 
 export const defaultInterpreters: Record<string, string[]> = {
+  ".cjs": ["node", "--no-warnings=ExperimentalWarning"],
   ".js": ["node", "--no-warnings=ExperimentalWarning"],
+  ".mjs": ["node", "--no-warnings=ExperimentalWarning"],
   ".ts": ["tsx"],
   ".py": ["python3"],
   ".r": ["Rscript"],


### PR DESCRIPTION
I was surprised to find that these default node file extensions weren't supported by default, so I added them

This is particularly helpful so that you can write data loader scripts with top-level await and with ESM import syntax, by saving them with the `.mjs` file extension