### PR TITLE
fix react-dom@19

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -72,7 +72,7 @@ import {useState} from "npm:react";
 React DOM is also available as `ReactDOM` in Markdown, or can be imported as:
 
 ```js run=false
-import * as ReactDOM from "npm:react-dom";
+import * as ReactDOM from "npm:react-dom/client";
 ```
 
 You can define components in JSX modules. For example, if this were `components/Card.jsx`:

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -94,7 +94,7 @@ function reject(root, error) {
 }
 
 function displayJsx(root, value) {
-  return (root._root ??= import("npm:react-dom").then(({createRoot}) => {
+  return (root._root ??= import("npm:react-dom/client").then(({createRoot}) => {
     const node = document.createElement("DIV");
     return [node, createRoot(node)];
   })).then(([node, client]) => {

--- a/src/client/stdlib/recommendedLibraries.js
+++ b/src/client/stdlib/recommendedLibraries.js
@@ -15,7 +15,7 @@ export const mapboxgl = () => import("npm:mapbox-gl").then((module) => module.de
 export const mermaid = () => import("observablehq:stdlib/mermaid").then((mermaid) => mermaid.default);
 export const Plot = () => import("npm:@observablehq/plot");
 export const React = () => import("npm:react");
-export const ReactDOM = () => import("npm:react-dom");
+export const ReactDOM = () => import("npm:react-dom/client");
 export const sql = () => import("observablehq:stdlib/duckdb").then((duckdb) => duckdb.sql);
 export const SQLite = () => import("observablehq:stdlib/sqlite").then((sqlite) => sqlite.default);
 export const SQLiteDatabaseClient = () => import("observablehq:stdlib/sqlite").then((sqlite) => sqlite.SQLiteDatabaseClient); // prettier-ignore

--- a/src/node.ts
+++ b/src/node.ts
@@ -83,7 +83,13 @@ export function extractNodeSpecifier(path: string): string {
  */
 function isBadCommonJs(specifier: string): boolean {
   const {name} = parseNpmSpecifier(specifier);
-  return name === "react" || name === "react-dom" || name === "react-is" || name === "scheduler";
+  return (
+    name === "react" ||
+    name === "react-dom" ||
+    name === "react-dom/client" ||
+    name === "react-is" ||
+    name === "scheduler"
+  );
 }
 
 function shimCommonJs(specifier: string, require: NodeRequire): string {

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -153,8 +153,8 @@ export async function getResolvers(page: MarkdownPage, config: ResolversConfig):
 
   // Add React for JSX blocks.
   if (page.code.some((c) => c.mode === "jsx")) {
-    staticImports.add("npm:react-dom");
-    globalImports.add("npm:react-dom");
+    staticImports.add("npm:react-dom/client");
+    globalImports.add("npm:react-dom/client");
   }
 
   return {


### PR DESCRIPTION
The root cause is https://github.com/facebook/react/pull/28271 that was merged into version 19, which means we now have to pull in ReactDOM from "npm:react-dom/client" instead of "npm:react-dom".

This is (barely) documented in the release notes https://github.com/facebook/react/releases/tag/v19.0.0

From some manual testing, this PR is compatible with react-dom@18, but not @\17.

- I'm trying to see if we can reroute "npm:react-dom" to "npm:react-dom/client" for asc. compat. (NO)
- how to make this work with node (local install) (I DON'T KNOW)

closes #1866