### PR TITLE
use /client for react-dom

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -267,6 +267,8 @@ export async function resolveNpmImport(root: string, specifier: string): Promise
       ? "dist/jquery-ui.js/+esm"
       : name === "deck.gl"
       ? "dist.min.js/+esm"
+      : name === "react-dom"
+      ? "client"
       : "+esm"
   } = parseNpmSpecifier(specifier);
   const version = await resolveNpmVersion(root, {name, range});


### PR DESCRIPTION
Alternative to #1870. Fixes #1866.

It sounds like you tried this already (“I'm trying to see if we can reroute "npm:react-dom" to "npm:react-dom/client" for asc. compat. (NO)”) but it works for me?