### PR TITLE
fix sqlite implicit dependencies

### DIFF
--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -90,8 +90,7 @@ export function getImplicitDownloads(imports: Iterable<string>, duckdb?: DuckDBC
       }
     }
   }
-  if (set.has("npm:@observablehq/sqlite")) {
-    implicits.add("npm:sql.js/dist/sql-wasm.js");
+  if (set.has("npm:sql.js")) {
     implicits.add("npm:sql.js/dist/sql-wasm.wasm");
   }
   if (set.has("npm:leaflet")) {
@@ -176,7 +175,9 @@ export function getImplicitDependencies(imports: Iterable<string>): Set<string> 
   if (set.has("npm:@observablehq/duckdb")) implicits.add("npm:@duckdb/duckdb-wasm");
   if (set.has("npm:@observablehq/inputs")) implicits.add("npm:htl").add("npm:isoformat");
   if (set.has("npm:@observablehq/mermaid")) implicits.add("npm:mermaid");
+  if (set.has("npm:@observablehq/sqlite")) implicits.add("npm:sql.js");
   if (set.has("npm:@observablehq/tex")) implicits.add("npm:katex");
+  if (set.has("observablehq:stdlib/sqlite")) implicits.add("npm:sql.js");
   if (set.has("observablehq:stdlib/xlsx")) implicits.add("npm:exceljs");
   if (set.has("observablehq:stdlib/zip")) implicits.add("npm:jszip");
   if (set.has("observablehq:stdlib/vega-lite")) implicits.add("npm:vega-lite-api").add("npm:vega-lite").add("npm:vega");

--- a/test/libraries-test.ts
+++ b/test/libraries-test.ts
@@ -61,10 +61,7 @@ describe("getImplicitDownloads(imports)", () => {
         "npm:@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js"
       ])
     );
-    assert.deepStrictEqual(
-      getImplicitDownloads(["npm:@observablehq/sqlite"]),
-      new Set(["npm:sql.js/dist/sql-wasm.js", "npm:sql.js/dist/sql-wasm.wasm"])
-    );
+    assert.deepStrictEqual(getImplicitDownloads(["npm:sql.js"]), new Set(["npm:sql.js/dist/sql-wasm.wasm"]));
   });
 });
 
@@ -74,7 +71,9 @@ describe("getImplicitDependencies(imports)", () => {
     assert.deepStrictEqual(getImplicitDependencies(["npm:@observablehq/duckdb"]), new Set(["npm:@duckdb/duckdb-wasm"]));
     assert.deepStrictEqual(getImplicitDependencies(["npm:@observablehq/inputs"]), new Set(["npm:htl", "npm:isoformat"])); // prettier-ignore
     assert.deepStrictEqual(getImplicitDependencies(["npm:@observablehq/mermaid"]), new Set(["npm:mermaid"]));
+    assert.deepStrictEqual(getImplicitDependencies(["npm:@observablehq/sqlite"]), new Set(["npm:sql.js"]));
     assert.deepStrictEqual(getImplicitDependencies(["npm:@observablehq/tex"]), new Set(["npm:katex"]));
+    assert.deepStrictEqual(getImplicitDependencies(["observablehq:stdlib/sqlite"]), new Set(["npm:sql.js"]));
     assert.deepStrictEqual(getImplicitDependencies(["observablehq:stdlib/xlsx"]), new Set(["npm:exceljs"]));
     assert.deepStrictEqual(getImplicitDependencies(["observablehq:stdlib/zip"]), new Set(["npm:jszip"]));
     assert.deepStrictEqual(getImplicitDependencies(["observablehq:stdlib/vega-lite"]), new Set(["npm:vega-lite-api", "npm:vega-lite", "npm:vega"])); // prettier-ignore


### PR DESCRIPTION
Fixes #1907.

Fixes a regression in #1759 where an implicit download (via fetch) was promoted to an implicit dependencies (via import).