### PR TITLE
Expires cached files after configured seconds

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,16 @@ The path to the source root; defaults to `src`. (Prior to <a href="https://githu
 
 The path to the output root; defaults to `dist`.
 
+## cacheExpiration
+
+The duration in seconds after which the cache is considered expired causing the data loader to reload the data.
+
+To set a cache expiration of 3600 seconds (one hour):
+
+```js run=false
+cacheExpiration: 3600
+```
+
 ## theme
 
 The theme name or names, if any; defaults to `default`. [Themes](./themes) affect visual appearance by specifying colors and fonts, or by augmenting default styles. The theme option is a shorthand alternative to specifying a [custom stylesheet](#style).

--- a/docs/data-loaders.md
+++ b/docs/data-loaders.md
@@ -297,6 +297,8 @@ During preview, Framework considers the cache “fresh” if the modification ti
 
 During build, Framework ignores modification times and only runs a data loader if its output is not cached. Continuous integration caches typically don’t preserve modification times, so this design makes it easier to control which data loaders to run by selectively populating the cache.
 
+A custom [cache expiration](./config#cache-expiration) can be set, causing the cache to expire if the cached output's modification time exceeds the specified value. The data loader will then reload the data.
+
 To purge the data loader cache and force all data loaders to run on the next build, delete the entire cache. For example:
 
 ```sh

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,7 @@ interface DuckDBExtensionConfigSpec {
 export interface Config {
   root: string; // defaults to src
   output: string; // defaults to dist
+  cacheExpiration?: number; // cache expiration in seconds
   base: string; // defaults to "/"
   home: string; // defaults to the (escaped) title, or "Home"
   title?: string;
@@ -122,6 +123,7 @@ export interface Config {
 export interface ConfigSpec {
   root?: unknown;
   output?: unknown;
+  cacheExpiration?: unknown;
   base?: unknown;
   sidebar?: unknown;
   style?: unknown;
@@ -251,6 +253,7 @@ export function normalizeConfig(spec: ConfigSpec = {}, defaultRoot?: string, wat
   if (cachedConfig) return cachedConfig;
   const root = spec.root === undefined ? findDefaultRoot(defaultRoot) : String(spec.root);
   const output = spec.output === undefined ? "dist" : String(spec.output);
+  const cacheExpiration = spec.cacheExpiration === undefined ? undefined : Number(spec.cacheExpiration);
   const base = spec.base === undefined ? "/" : normalizeBase(spec.base);
   const style =
     spec.style === null
@@ -298,6 +301,7 @@ export function normalizeConfig(spec: ConfigSpec = {}, defaultRoot?: string, wat
   const config: Config = {
     root,
     output,
+    cacheExpiration,
     base,
     home,
     title,

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -119,7 +119,7 @@ export class PreviewServer {
 
   _handleRequest: RequestListener = async (req, res) => {
     const config = await this._readConfig();
-    const {root, loaders, duckdb} = config;
+    const {root, loaders, duckdb, cacheExpiration} = config;
     if (this._verbose) console.log(faint(req.method!), req.url);
     const url = new URL(req.url!, "http://localhost");
     const {origin} = req.headers;
@@ -180,7 +180,7 @@ export class PreviewServer {
         const path = pathname.slice("/_file".length);
         const loader = loaders.find(path);
         if (!loader) throw enoent(path);
-        send(req, await loader.load(), {root}).pipe(res);
+        send(req, await loader.load({cacheExpiration}), {root}).pipe(res);
       } else {
         if ((pathname = normalize(pathname)).startsWith("..")) throw new Error("Invalid path: " + pathname);
 


### PR DESCRIPTION
This change makes it possible to expire cached files based on an expiration time in seconds. 

I'm using Framework for several dashboards in a local setting and find myself manually clearing the cache and restarting the server multiple times a day. I think this would be a very useful feature for those more lightweight scenarios where there's no full CI build to recompile the data.

First PR on project so creating as a draft for your feedback.