### PR TITLE
Add support for dark mode in custom CSS

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -74,6 +74,7 @@ The custom stylesheet should typically import `observablehq:default.css` to buil
 ```css
 @import url("observablehq:default.css");
 @import url("observablehq:theme-air.css");
+@import url("observablehq:theme-near-midnight.css") (prefers-color-scheme: dark);
 
 :root {
   --theme-foreground-focus: green;


### PR DESCRIPTION
This took me a little while to figure out how to do (after initially assuming it was impossible) so I thought including it in the docs might help someone else.