### PR TITLE
Add locale-aware config and localized framework UI defaults

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -106,17 +106,35 @@ In this case, the path to the stylesheet is resolved relative to the page’s Ma
 
 The app’s title. If specified, this text is appended to page titles with a separating pipe symbol (“|”). For instance, a page titled “Sales” in an app titled “ACME, Inc.” will display “Sales | ACME, Inc.” in the browser’s title bar. See also the [**home** option](#home).
 
+## locale
+
+The app’s default locale, such as `en-US`, `fr-FR`, or `ar-EG`. This locale is used for Framework-owned UI defaults such as the footer date, search placeholder, pager labels, and other built-in labels. If [**lang**](#lang) is not specified, it defaults to the locale’s language subtag.
+
+Page-level YAML front matter may override the locale for an individual page.
+
+## lang
+
+The document language, used to set the root HTML `lang` attribute. If not specified, it defaults to the language subtag of [**locale**](#locale), if any.
+
+Page-level YAML front matter may override the language for an individual page.
+
+## dir
+
+The document direction, either `ltr` or `rtl`, used to set the root HTML `dir` attribute. If not specified, Framework derives the direction from the page language when possible.
+
+Page-level YAML front matter may override the direction for an individual page.
+
 ## sidebar
 
 Whether to show the sidebar. Defaults to true if **pages** is not empty.
 
 ## home <a href="https://github.com/observablehq/framework/releases/tag/v1.12.0" class="observablehq-version-badge" data-version="^1.12.0" title="Added in 1.12.0"></a>
 
-An HTML fragment to render the link to the home page in the top of the sidebar. Defaults to the [app’s title](#title), if any, and otherwise the word “Home”. If specified as a function, receives an object with the page’s `title`, (front-matter) `data`, and `path`, and must return a string.
+An HTML fragment to render the link to the home page in the top of the sidebar. Defaults to the [app’s title](#title), if any, and otherwise a localized equivalent of “Home” based on [**locale**](#locale) or [**lang**](#lang). If specified as a function, receives an object with the page’s `title`, (front-matter) `data`, and `path`, and must return a string.
 
 ## pages
 
-An array containing pages and sections. If not specified, it defaults to all Markdown files found in the source root in directory listing order.
+An array containing pages and sections. If not specified, it defaults to all Markdown files found in the source root in directory listing order. Pages without an inferred title use a localized equivalent of “Untitled” based on [**locale**](#locale) or [**lang**](#lang).
 
 Both pages and sections have a **name**, which typically corresponds to the page’s title. The name gets displayed in the sidebar. Sections are used to group related pages; each section must specify an array of **pages**. (Sections can only contain pages; nested sections are not currently supported.)
 
@@ -185,7 +203,7 @@ By default, the header is fixed to the top of the window. To instead have the he
 
 ## footer
 
-An HTML fragment to add to the footer. Defaults to “Built with Observable.” If specified as a function, receives an object with the page’s `title`, (front-matter) `data`, and `path`, and must return a string.
+An HTML fragment to add to the footer. By default, Framework renders a localized “Built with Observable on [date].” footer based on [**locale**](#locale) or [**lang**](#lang), and page-level front matter locale overrides are respected. If specified as a function, receives an object with the page’s `title`, (front-matter) `data`, and `path`, and must return a string.
 
 For example, the following adds a link to the bottom of each page:
 
@@ -218,7 +236,7 @@ export interface TableOfContents {
 }
 ```
 
-If **show** is not set, it defaults to true. If **label** is not set, it defaults to “Contents”. The **toc** option can also be set to a boolean, in which case it is shorthand for **toc.show**.
+If **show** is not set, it defaults to true. If **label** is not set, it defaults to a localized equivalent of “Contents” based on [**locale**](#locale) or [**lang**](#lang). The **toc** option can also be set to a boolean, in which case it is shorthand for **toc.show**.
 
 If shown, the table of contents enumerates the second-level headings (H2 elements, such as `## Section name`) on the right-hand side of the page. The currently-shown section is highlighted in the table of contents.
 
@@ -232,7 +250,7 @@ toc: false
 
 ## search
 
-If true, enable [search](./search); defaults to false. The **search** option may also be specified as an object with an **index** method <a href="https://github.com/observablehq/framework/releases/tag/v1.9.0" class="observablehq-version-badge" data-version="^1.9.0" title="Added in 1.9.0"></a>, in which case additional results can be added to the search index. Each result is specified as:
+If true, enable [search](./search); defaults to false. Framework localizes the built-in search placeholder from [**locale**](#locale) or [**lang**](#lang). The **search** option may also be specified as an object with an **index** method <a href="https://github.com/observablehq/framework/releases/tag/v1.9.0" class="observablehq-version-badge" data-version="^1.9.0" title="Added in 1.9.0"></a>, in which case additional results can be added to the search index. Each result is specified as:
 
 ```ts run=false
 interface SearchResult {

--- a/src/client/sidebar.js
+++ b/src/client/sidebar.js
@@ -31,7 +31,8 @@ if (toggle) {
       event.preventDefault();
     }
   });
-  const title = `Toggle sidebar ${
+  const baseTitle = toggle.dataset.title || "Toggle sidebar";
+  const title = `${baseTitle} ${
     /Mac|iPhone/.test(navigator.platform)
       ? /Firefox/.test(navigator.userAgent)
         ? "⌥" // option symbol for mac firefox

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ import {DUCKDB_CORE_ALIASES, DUCKDB_CORE_EXTENSIONS} from "./duckdb.js";
 import {visitFiles} from "./files.js";
 import {formatIsoDate, formatLocaleDate} from "./format.js";
 import type {FrontMatter} from "./frontMatter.js";
+import {getFrameworkLanguage, getFrameworkLocale, getFrameworkMessages} from "./i18n.js";
 import {findModule} from "./javascript/module.js";
 import {LoaderResolver} from "./loader.js";
 import {createMarkdownIt, parseMarkdownMetadata} from "./markdown.js";
@@ -100,6 +101,9 @@ export interface Config {
   base: string; // defaults to "/"
   home: string; // defaults to the (escaped) title, or "Home"
   title?: string;
+  lang?: string;
+  dir?: "ltr" | "rtl";
+  locale?: string;
   sidebar: boolean; // defaults to true if pages isn’t empty
   pages: (Page | Section<Page>)[];
   pager: boolean; // defaults to true
@@ -135,6 +139,9 @@ export interface ConfigSpec {
   interpreters?: unknown;
   home?: unknown;
   title?: unknown;
+  lang?: unknown;
+  dir?: unknown;
+  locale?: unknown;
   pages?: unknown;
   pager?: unknown;
   dynamicPaths?: unknown;
@@ -206,7 +213,8 @@ async function resolveDefaultConfig(root?: string): Promise<string | undefined> 
 
 let cachedPages: {key: string; pages: Page[]} | null = null;
 
-function readPages(root: string, md: MarkdownIt): Page[] {
+function readPages(root: string, md: MarkdownIt, locale?: string, lang?: string): Page[] {
+  const messages = getFrameworkMessages(locale, lang);
   const files: {file: string; source: string}[] = [];
   const hash = createHash("sha256");
   for (const file of visitFiles(root, (name) => !isParameterized(name))) {
@@ -225,7 +233,7 @@ function readPages(root: string, md: MarkdownIt): Page[] {
     if (data.draft) continue;
     const name = basename(file, ".md");
     const {pager = "main"} = data;
-    const page = {path: join("/", dirname(file), name), name: title ?? "Untitled", pager};
+    const page = {path: join("/", dirname(file), name), name: title ?? messages.untitled, pager};
     if (name === "index") pages.unshift(page);
     else pages.push(page);
   }
@@ -269,16 +277,20 @@ export function normalizeConfig(spec: ConfigSpec = {}, defaultRoot?: string, wat
     markdownIt: spec.markdownIt as any
   });
   const title = spec.title === undefined ? undefined : String(spec.title);
-  const home = spec.home === undefined ? he.escape(title ?? "Home") : String(spec.home); // eslint-disable-line import/no-named-as-default-member
+  const locale = spec.locale === undefined ? undefined : String(spec.locale);
+  const lang = spec.lang === undefined ? getFrameworkLanguage(locale) : String(spec.lang);
+  const dir = spec.dir === undefined ? undefined : normalizeDir(spec.dir);
+  const messages = getFrameworkMessages(locale, lang);
+  const home = spec.home === undefined ? he.escape(title ?? messages.home) : String(spec.home); // eslint-disable-line import/no-named-as-default-member
   const pages = spec.pages === undefined ? undefined : normalizePages(spec.pages);
   const pager = spec.pager === undefined ? true : Boolean(spec.pager);
   const dynamicPaths = normalizeDynamicPaths(spec.dynamicPaths);
-  const toc = normalizeToc(spec.toc as any);
+  const toc = normalizeToc(spec.toc as any, messages.contents);
   const sidebar = spec.sidebar === undefined ? undefined : Boolean(spec.sidebar);
   const scripts = spec.scripts === undefined ? [] : normalizeScripts(spec.scripts);
   const head = pageFragment(spec.head === undefined ? "" : spec.head);
   const header = pageFragment(spec.header === undefined ? "" : spec.header);
-  const footer = pageFragment(spec.footer === undefined ? defaultFooter() : spec.footer);
+  const footer = pageFragment(spec.footer === undefined ? defaultFooter(locale, lang) : spec.footer);
   const search = spec.search == null || spec.search === false ? null : normalizeSearch(spec.search as any);
   const interpreters = normalizeInterpreters(spec.interpreters as any);
   const normalizePath = getPathNormalizer(spec);
@@ -301,6 +313,9 @@ export function normalizeConfig(spec: ConfigSpec = {}, defaultRoot?: string, wat
     base,
     home,
     title,
+    lang,
+    dir,
+    locale,
     sidebar: sidebar!, // see below
     pages: pages!, // see below
     pager,
@@ -336,7 +351,7 @@ export function normalizeConfig(spec: ConfigSpec = {}, defaultRoot?: string, wat
     watchPath,
     duckdb
   };
-  if (pages === undefined) Object.defineProperty(config, "pages", {get: () => readPages(root, md)});
+  if (pages === undefined) Object.defineProperty(config, "pages", {get: () => readPages(root, md, locale, lang)});
   if (sidebar === undefined) Object.defineProperty(config, "sidebar", {get: () => config.pages.length > 0});
   configCache.set(spec, config);
   return config;
@@ -378,11 +393,16 @@ function defaultGlobalStylesheets(): string[] {
   ];
 }
 
-function defaultFooter(): string {
-  const date = currentDate ?? new Date();
-  return `Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="${formatIsoDate(
-    date
-  )}">${formatLocaleDate(date)}</a>.`;
+function defaultFooter(projectLocale?: string, projectLang?: string): PageFragmentFunction {
+  return ({data}) => {
+    const locale = data.locale ?? projectLocale;
+    const lang = data.lang ?? getFrameworkLanguage(data.locale) ?? projectLang ?? getFrameworkLanguage(projectLocale);
+    const date = currentDate ?? new Date();
+    const messages = getFrameworkMessages(locale, lang);
+    return `${messages.footerPrefix} <a href="https://observablehq.com/" target="_blank">Observable</a> ${
+      messages.footerDatePreposition
+    } <a title="${formatIsoDate(date)}">${formatLocaleDate(date, getFrameworkLocale(locale, lang))}</a>.`;
+  };
 }
 
 function findDefaultRoot(defaultRoot?: string): string {
@@ -414,6 +434,12 @@ function normalizeBase(spec: unknown): string {
   if (!base.startsWith("/")) throw new Error(`base must start with slash: ${base}`);
   if (!base.endsWith("/")) base += "/";
   return base;
+}
+
+function normalizeDir(spec: unknown): "ltr" | "rtl" {
+  const dir = String(spec);
+  if (dir !== "ltr" && dir !== "rtl") throw new Error(`invalid dir: ${dir}`);
+  return dir;
 }
 
 function normalizeGlobalStylesheets(spec: unknown): string[] {
@@ -489,9 +515,9 @@ function normalizeInterpreters(spec: {[key: string]: unknown} = {}): {[key: stri
   );
 }
 
-function normalizeToc(spec: TableOfContentsSpec | boolean = true): TableOfContents {
+function normalizeToc(spec: TableOfContentsSpec | boolean = true, defaultLabel = "Contents"): TableOfContents {
   const toc = typeof spec === "boolean" ? {show: spec} : (spec as TableOfContentsSpec);
-  const label = toc.label === undefined ? "Contents" : String(toc.label);
+  const label = toc.label === undefined ? defaultLabel : String(toc.label);
   const show = toc.show === undefined ? true : Boolean(toc.show);
   return {label, show};
 }

--- a/src/frontMatter.ts
+++ b/src/frontMatter.ts
@@ -4,6 +4,9 @@ import {yellow} from "./tty.js";
 
 export interface FrontMatter {
   title?: string | null;
+  lang?: string | null;
+  dir?: "ltr" | "rtl" | null;
+  locale?: string | null;
   toc?: {show?: boolean; label?: string};
   style?: string | null;
   theme?: string[];
@@ -36,6 +39,9 @@ export function normalizeFrontMatter(spec: any = {}): FrontMatter {
   if (spec == null || typeof spec !== "object") return frontMatter;
   const {title, sidebar, toc, index, keywords, draft, sql, head, header, footer, pager, style, theme} = spec;
   if (title !== undefined) frontMatter.title = stringOrNull(title);
+  if (spec.lang !== undefined) frontMatter.lang = stringOrNull(spec.lang);
+  if (spec.dir !== undefined) frontMatter.dir = normalizeDir(spec.dir);
+  if (spec.locale !== undefined) frontMatter.locale = stringOrNull(spec.locale);
   if (sidebar !== undefined) frontMatter.sidebar = Boolean(sidebar);
   if (toc !== undefined) frontMatter.toc = normalizeToc(toc);
   if (index !== undefined) frontMatter.index = Boolean(index);
@@ -70,4 +76,11 @@ function normalizeSql(spec: unknown): {[key: string]: string} {
   const sql: {[key: string]: string} = {};
   for (const key in spec) sql[key] = String(spec[key]);
   return sql;
+}
+
+function normalizeDir(spec: unknown): "ltr" | "rtl" | null {
+  if (spec == null || spec === false) return null;
+  const dir = String(spec);
+  if (dir !== "ltr" && dir !== "rtl") throw new Error(`invalid front matter dir: ${dir}`);
+  return dir;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,86 @@
+const rtlLanguages = new Set([
+  "ar",
+  "fa",
+  "he",
+  "ks",
+  "ku",
+  "ps",
+  "sd",
+  "ug",
+  "ur",
+  "yi"
+]);
+
+export interface FrameworkMessages {
+  home: string;
+  contents: string;
+  untitled: string;
+  search: string;
+  toggleSidebar: string;
+  previousPage: string;
+  nextPage: string;
+  footerPrefix: string;
+  footerDatePreposition: string;
+}
+
+const frameworkMessages: Record<string, FrameworkMessages> = {
+  en: {
+    home: "Home",
+    contents: "Contents",
+    untitled: "Untitled",
+    search: "Search",
+    toggleSidebar: "Toggle sidebar",
+    previousPage: "Previous page",
+    nextPage: "Next page",
+    footerPrefix: "Built with",
+    footerDatePreposition: "on"
+  },
+  fr: {
+    home: "Accueil",
+    contents: "Sommaire",
+    untitled: "Sans titre",
+    search: "Rechercher",
+    toggleSidebar: "Basculer la barre latérale",
+    previousPage: "Page précédente",
+    nextPage: "Page suivante",
+    footerPrefix: "Créé avec",
+    footerDatePreposition: "le"
+  },
+  ar: {
+    home: "الرئيسية",
+    contents: "المحتويات",
+    untitled: "بدون عنوان",
+    search: "بحث",
+    toggleSidebar: "تبديل الشريط الجانبي",
+    previousPage: "الصفحة السابقة",
+    nextPage: "الصفحة التالية",
+    footerPrefix: "أُنشئ باستخدام",
+    footerDatePreposition: "في"
+  }
+};
+
+export function getFrameworkLanguage(locale?: string | null, lang?: string | null): string | undefined {
+  return languageSubtag(lang) ?? languageSubtag(locale);
+}
+
+export function getFrameworkDirection(
+  locale?: string | null,
+  lang?: string | null
+): "ltr" | "rtl" | undefined {
+  const language = getFrameworkLanguage(locale, lang);
+  return language ? (rtlLanguages.has(language) ? "rtl" : "ltr") : undefined;
+}
+
+export function getFrameworkLocale(locale?: string | null, lang?: string | null): string {
+  return locale ?? lang ?? "en-US";
+}
+
+export function getFrameworkMessages(locale?: string | null, lang?: string | null): FrameworkMessages {
+  const language = getFrameworkLanguage(locale, lang);
+  return (language && frameworkMessages[language]) || frameworkMessages.en;
+}
+
+function languageSubtag(tag?: string | null): string | undefined {
+  const match = tag?.trim().match(/^([A-Za-z]{2,3})(?:[-_]|$)/);
+  return match?.[1].toLowerCase();
+}

--- a/src/pager.ts
+++ b/src/pager.ts
@@ -1,4 +1,5 @@
 import type {Config, Page} from "./config.js";
+import {getFrameworkMessages} from "./i18n.js";
 
 export type PageLink =
   | {prev: undefined; next: Page} // first page
@@ -45,7 +46,8 @@ export function findLink(path: string, config: Config): PageLink | undefined {
  * adds a link at the beginning to the home page (/index).
  */
 function walk(config: Config): Iterable<Iterable<Page>> {
-  const {pages, loaders, title = "Home"} = config;
+  const {pages, loaders, title} = config;
+  const {home} = getFrameworkMessages(config.locale, config.lang);
   const pageGroups = new Map<string, Page[]>();
   const visited = new Set<string>();
 
@@ -57,7 +59,7 @@ function walk(config: Config): Iterable<Iterable<Page>> {
     pageGroup.push(page);
   }
 
-  if (loaders.findPage("/index")) visit({name: title, path: "/index", pager: "main"});
+  if (loaders.findPage("/index")) visit({name: title ?? home, path: "/index", pager: "main"});
 
   for (const page of pages) {
     if (page.path !== null) visit(page as Page);

--- a/src/render.ts
+++ b/src/render.ts
@@ -17,6 +17,7 @@ import {isAssetPath, resolvePath, resolveRelativePath} from "./path.js";
 import type {Resolvers} from "./resolvers.js";
 import {getModuleResolver, getModuleStaticImports, getResolvers} from "./resolvers.js";
 import {rollupClient} from "./rollup.js";
+import {getFrameworkDirection, getFrameworkLanguage, getFrameworkMessages} from "./i18n.js";
 
 export interface RenderOptions extends Config {
   root: string;
@@ -33,10 +34,18 @@ export async function renderPage(page: MarkdownPage, options: RenderOptions & Re
   const {base, path, title, preview} = options;
   const {loaders, resolvers = await getResolvers(page, options)} = options;
   const {draft = false, sidebar = options.sidebar} = data;
+  const locale = data.locale ?? options.locale;
+  const lang = data.lang ?? getFrameworkLanguage(data.locale) ?? options.lang ?? getFrameworkLanguage(options.locale);
+  const dir =
+    data.dir ??
+    (data.lang !== undefined || data.locale !== undefined ? getFrameworkDirection(data.locale, lang) : undefined) ??
+    options.dir ??
+    getFrameworkDirection(options.locale, options.lang);
+  const messages = getFrameworkMessages(locale, lang);
   const toc = mergeToc(data.toc, options.toc);
   const {files, resolveFile, resolveImport} = resolvers;
   return String(html`<!DOCTYPE html>
-<html>
+<html${lang ? html` lang="${lang}"` : ""}${dir ? html` dir="${dir}"` : ""}>
 <head>
 <meta charset="utf-8">${path === "/404" ? html`\n<base href="${preview ? "/" : base}">` : ""}
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -85,12 +94,12 @@ ${preview ? `\nopen({hash: ${JSON.stringify(resolvers.hash)}, eval: (body) => ev
     .join("")}`)}
 </script>
 </head>
-<body>${sidebar ? html`\n${await renderSidebar(options, resolvers)}` : ""}
+<body>${sidebar ? html`\n${await renderSidebar(options, resolvers, messages)}` : ""}
 <div id="observablehq-center">${renderHeader(page.header, resolvers)}${
     toc.show ? html`\n${renderToc(findHeaders(page), toc.label)}` : ""
   }
 <main id="observablehq-main" class="observablehq${draft ? " observablehq--draft" : ""}">
-${html.unsafe(rewriteHtml(page.body, resolvers))}</main>${renderFooter(page.footer, resolvers, options)}
+${html.unsafe(rewriteHtml(page.body, resolvers))}</main>${renderFooter(page.footer, resolvers, options, messages)}
 </div>
 </body>
 </html>
@@ -137,19 +146,23 @@ function registerFile(
   })});`;
 }
 
-async function renderSidebar(options: RenderOptions, {resolveImport, resolveLink}: Resolvers): Promise<Html> {
+async function renderSidebar(
+  options: RenderOptions,
+  {resolveImport, resolveLink}: Resolvers,
+  messages: ReturnType<typeof getFrameworkMessages>
+): Promise<Html> {
   const {home, pages, root, path, search} = options;
-  return html`<input id="observablehq-sidebar-toggle" type="checkbox" title="Toggle sidebar">
-<label id="observablehq-sidebar-backdrop" for="observablehq-sidebar-toggle"></label>
+  return html`<input id="observablehq-sidebar-toggle" type="checkbox" title="${messages.toggleSidebar}" data-title="${messages.toggleSidebar}">
+<label id="observablehq-sidebar-backdrop" for="observablehq-sidebar-toggle" title="${messages.toggleSidebar}" data-title="${messages.toggleSidebar}"></label>
 <nav id="observablehq-sidebar">
   <ol>
-    <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle"></label>
+    <label id="observablehq-sidebar-close" for="observablehq-sidebar-toggle" title="${messages.toggleSidebar}" data-title="${messages.toggleSidebar}"></label>
     <li class="observablehq-link${
       normalizePath(path) === "/index" ? " observablehq-link-active" : ""
     }"><a href="${encodeURI(resolveLink("/"))}">${html.unsafe(home)}</a></li>
   </ol>${
     search
-      ? html`\n  <div id="observablehq-search"><input type="search" placeholder="Search"></div>
+      ? html`\n  <div id="observablehq-search"><input type="search" placeholder="${messages.search}" aria-label="${messages.search}"></div>
   <div id="observablehq-search-results"></div>
   <script>{${html.unsafe(
     (await rollupClient(getClientPath("search-init.js"), root, path, {resolveImport, minify: true})).trim()
@@ -261,25 +274,34 @@ function renderHeader(header: MarkdownPage["header"], resolvers: HtmlResolvers):
     : null;
 }
 
-function renderFooter(footer: MarkdownPage["footer"], resolvers: HtmlResolvers, options: RenderOptions): Html | null {
+function renderFooter(
+  footer: MarkdownPage["footer"],
+  resolvers: HtmlResolvers,
+  options: RenderOptions,
+  messages: ReturnType<typeof getFrameworkMessages>
+): Html | null {
   const {path} = options;
   const link = options.pager ? findLink(path, options) : null;
   return link || footer
-    ? html`\n<footer id="observablehq-footer">${link ? renderPager(link, resolvers.resolveLink) : ""}${
+    ? html`\n<footer id="observablehq-footer">${link ? renderPager(link, resolvers.resolveLink, messages) : ""}${
         footer ? html`\n<div>${html.unsafe(rewriteHtml(footer, resolvers))}</div>` : ""
       }
 </footer>`
     : null;
 }
 
-function renderPager({prev, next}: PageLink, resolveLink: (href: string) => string): Html {
-  return html`\n<nav>${prev ? renderRel(prev, "prev", resolveLink) : ""}${
-    next ? renderRel(next, "next", resolveLink) : ""
+function renderPager(
+  {prev, next}: PageLink,
+  resolveLink: (href: string) => string,
+  messages: ReturnType<typeof getFrameworkMessages>
+): Html {
+  return html`\n<nav>${prev ? renderRel(prev, "prev", resolveLink, messages.previousPage) : ""}${
+    next ? renderRel(next, "next", resolveLink, messages.nextPage) : ""
   }</nav>`;
 }
 
-function renderRel(page: Page, rel: "prev" | "next", resolveLink: (href: string) => string): Html {
-  return html`<a rel="${rel}" href="${encodeURI(resolveLink(page.path))}"><span>${page.name}</span></a>`;
+function renderRel(page: Page, rel: "prev" | "next", resolveLink: (href: string) => string, label: string): Html {
+  return html`<a rel="${rel}" data-label="${label}" href="${encodeURI(resolveLink(page.path))}"><span>${page.name}</span></a>`;
 }
 
 function hasGoogleFonts(stylesheets: Set<string>): boolean {

--- a/src/style/layout.css
+++ b/src/style/layout.css
@@ -101,11 +101,11 @@ body {
 }
 
 #observablehq-footer nav a[rel="prev"]::before {
-  content: "Previous page";
+  content: attr(data-label);
 }
 
 #observablehq-footer nav a[rel="next"]::before {
-  content: "Next page";
+  content: attr(data-label);
 }
 
 #observablehq-center {

--- a/test/config-test.ts
+++ b/test/config-test.ts
@@ -3,6 +3,7 @@ import {resolve} from "node:path";
 import MarkdownIt from "markdown-it";
 import type {DuckDBConfig} from "../src/config.js";
 import {normalizeConfig as config, mergeToc, readConfig, setCurrentDate} from "../src/config.js";
+import {formatLocaleDate} from "../src/format.js";
 import {LoaderResolver} from "../src/loader.js";
 
 const DUCKDB_DEFAULTS: DuckDBConfig = {
@@ -28,10 +29,17 @@ describe("readConfig(undefined, root)", () => {
   before(() => setCurrentDate(new Date("2024-01-10T16:00:00")));
   after(() => setCurrentDate(null));
   it("imports the config file at the specified root", async () => {
-    const {md, loaders, paths, normalizePath, ...config} = await readConfig(undefined, "test/input/build/config");
+    const {md, loaders, paths, normalizePath, footer, ...config} = await readConfig(undefined, "test/input/build/config");
     assert(md instanceof MarkdownIt);
     assert(loaders instanceof LoaderResolver);
     assert.strictEqual(typeof normalizePath, "function");
+    assert.strictEqual(typeof footer, "function");
+    if (typeof footer === "function") {
+      assert.strictEqual(
+        footer({title: null, data: {}, path: "index.md"}),
+        'Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.'
+      );
+    }
     assert.deepStrictEqual(config, {
       root: "test/input/build/config",
       output: "dist",
@@ -55,24 +63,32 @@ describe("readConfig(undefined, root)", () => {
         }
       ],
       title: undefined,
+      lang: undefined,
+      dir: undefined,
+      locale: undefined,
       home: "Home",
       toc: {label: "On this page", show: true},
       pager: true,
       scripts: [],
       head: "",
       header: "",
-      footer:
-        'Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.',
       search: null,
       watchPath: resolve("test/input/build/config/observablehq.config.js"),
       duckdb: DUCKDB_DEFAULTS
     });
   });
   it("returns the default config if no config file is found", async () => {
-    const {md, loaders, paths, normalizePath, ...config} = await readConfig(undefined, "test/input/build/simple");
+    const {md, loaders, paths, normalizePath, footer, ...config} = await readConfig(undefined, "test/input/build/simple");
     assert(md instanceof MarkdownIt);
     assert(loaders instanceof LoaderResolver);
     assert.strictEqual(typeof normalizePath, "function");
+    assert.strictEqual(typeof footer, "function");
+    if (typeof footer === "function") {
+      assert.strictEqual(
+        footer({title: null, data: {}, path: "index.md"}),
+        'Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.'
+      );
+    }
     assert.deepStrictEqual(config, {
       root: "test/input/build/simple",
       output: "dist",
@@ -84,14 +100,15 @@ describe("readConfig(undefined, root)", () => {
       sidebar: true,
       pages: [{name: "Build test case", path: "/simple", pager: "main"}],
       title: undefined,
+      lang: undefined,
+      dir: undefined,
+      locale: undefined,
       home: "Home",
       toc: {label: "Contents", show: true},
       pager: true,
       scripts: [],
       head: "",
       header: "",
-      footer:
-        'Built with <a href="https://observablehq.com/" target="_blank">Observable</a> on <a title="2024-01-10T16:00:00">Jan 10, 2024</a>.',
       search: null,
       watchPath: undefined,
       duckdb: DUCKDB_DEFAULTS
@@ -109,10 +126,32 @@ describe("normalizeConfig(spec, root)", () => {
     assert.strictEqual(config({pages: []}, root).title, undefined);
     assert.strictEqual(config({title: undefined, pages: []}, root).title, undefined);
   });
+  it("accepts lang, dir, and locale", () => {
+    const c = config({pages: [], lang: "fr", dir: "ltr", locale: "fr-FR"}, root);
+    assert.strictEqual(c.lang, "fr");
+    assert.strictEqual(c.dir, "ltr");
+    assert.strictEqual(c.locale, "fr-FR");
+  });
   it("defaults the home to the escaped title", () => {
     assert.strictEqual(config({title: "dollar&pound", pages: []}, root).home, "dollar&amp;pound");
     assert.strictEqual(config({title: 42, pages: []}, root).home, "42");
     assert.strictEqual(config({title: null, pages: []}, root).home, "null");
+  });
+  it("localizes defaults from locale", () => {
+    setCurrentDate(new Date("2024-01-10T16:00:00"));
+    const c = config({pages: [], locale: "fr-FR"}, root);
+    assert.strictEqual(c.lang, "fr");
+    assert.strictEqual(c.home, "Accueil");
+    assert.deepStrictEqual(c.toc, {label: "Sommaire", show: true});
+    assert.strictEqual(
+      typeof c.footer === "function" ? c.footer({title: null, data: {}, path: "index.md"}) : c.footer,
+      `Créé avec <a href="https://observablehq.com/" target="_blank">Observable</a> le <a title="2024-01-10T16:00:00">${formatLocaleDate(new Date("2024-01-10T16:00:00"), "fr-FR")}</a>.`
+    );
+    setCurrentDate(null);
+  });
+  it("localizes untitled page fallbacks", () => {
+    const c = config({root: "test/input/build/files", locale: "fr-FR"});
+    assert.strictEqual(c.pages[0].name, "Sans titre");
   });
   it("populates default pages", () => {
     assert.deepStrictEqual(config({}, root).pages, [

--- a/test/frontMatter-test.ts
+++ b/test/frontMatter-test.ts
@@ -21,6 +21,16 @@ describe("normalizeFrontMatter(spec)", () => {
     assert.deepStrictEqual(normalizeFrontMatter({title: "foo"}), {title: "foo"});
     assert.deepStrictEqual(normalizeFrontMatter({title: {toString: () => "foo"}}), {title: "foo"});
   });
+  it("coerces lang, dir, and locale", () => {
+    assert.deepStrictEqual(normalizeFrontMatter({lang: 42}), {lang: "42"});
+    assert.deepStrictEqual(normalizeFrontMatter({lang: null}), {lang: null});
+    assert.deepStrictEqual(normalizeFrontMatter({locale: "fr-FR"}), {locale: "fr-FR"});
+    assert.deepStrictEqual(normalizeFrontMatter({locale: false}), {locale: null});
+    assert.deepStrictEqual(normalizeFrontMatter({dir: "ltr"}), {dir: "ltr"});
+    assert.deepStrictEqual(normalizeFrontMatter({dir: "rtl"}), {dir: "rtl"});
+    assert.deepStrictEqual(normalizeFrontMatter({dir: null}), {dir: null});
+    assert.throws(() => normalizeFrontMatter({dir: "auto"}), /invalid front matter dir/);
+  });
   it("coerces the toc to {show?, label?}", () => {
     assert.deepStrictEqual(normalizeFrontMatter({toc: false}), {toc: {show: false}});
     assert.deepStrictEqual(normalizeFrontMatter({toc: true}), {toc: {show: true}});

--- a/test/pager-test.ts
+++ b/test/pager-test.ts
@@ -72,6 +72,14 @@ describe("findLink(path, options)", () => {
     assert.deepStrictEqual(findLink("/b", config), {prev: a, next: c});
     assert.deepStrictEqual(findLink("/c", config), {prev: b, next: undefined});
   });
+  it("localizes the implicit home page label", () => {
+    const a = {name: "a", path: "/a", pager: "main"};
+    const config = normalizeConfig({pages: [a], locale: "fr-FR"});
+    assert.deepStrictEqual(findLink("/a", config), {
+      prev: {name: "Accueil", path: "/index", pager: "main"},
+      next: undefined
+    });
+  });
   it("normalizes / to /index", async () => {
     const config = normalizeConfig({pages: [{name: "Home", path: "/", pager: "main"}]});
     assert.strictEqual(findLink("/index", config), undefined);

--- a/test/render-test.ts
+++ b/test/render-test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert";
+import {normalizeConfig} from "../src/config.js";
+import {parseMarkdown} from "../src/markdown.js";
+import {renderPage} from "../src/render.js";
+
+describe("renderPage(page, options)", () => {
+  it("renders html lang and dir from config", async () => {
+    const config = normalizeConfig({root: "test/input/build/simple", pages: [], lang: "fr", dir: "ltr"});
+    const page = parseMarkdown("# Hello", {path: "index.md", md: config.md});
+    const html = await renderPage(page, {...config, path: "/index", root: config.root});
+    assert.match(html, /<html lang="fr" dir="ltr">/);
+  });
+
+  it("front matter lang and dir override config", async () => {
+    const config = normalizeConfig({root: "test/input/build/simple", pages: [], lang: "fr", dir: "ltr"});
+    const page = parseMarkdown("---\nlang: ar\ndir: rtl\n---\n# Hello", {path: "index.md", md: config.md});
+    const html = await renderPage(page, {...config, path: "/index", root: config.root});
+    assert.match(html, /<html lang="ar" dir="rtl">/);
+  });
+
+  it("derives html lang and dir from locale", async () => {
+    const config = normalizeConfig({root: "test/input/build/simple", pages: [], locale: "ar-EG"});
+    const page = parseMarkdown("# Hello", {path: "index.md", md: config.md});
+    const html = await renderPage(page, {...config, path: "/index", root: config.root});
+    assert.match(html, /<html lang="ar" dir="rtl">/);
+  });
+
+  it("localizes sidebar, pager, and footer labels", async () => {
+    const config = normalizeConfig({
+      root: "test/input/build/config",
+      locale: "fr-FR",
+      search: {},
+      pages: [{name: "Chapitre", path: "/chapitre", pager: "main"}]
+    });
+    const page = parseMarkdown("# Hello", {
+      path: "index.md",
+      md: config.md,
+      footer: config.footer,
+      header: config.header,
+      head: config.head
+    });
+    const html = await renderPage(page, {...config, path: "/chapitre", root: config.root});
+    assert.match(html, /title="Basculer la barre latérale"/);
+    assert.match(html, /placeholder="Rechercher"/);
+    assert.match(html, /data-label="Page précédente"/);
+    assert.match(html, /<span>Accueil<\/span>/);
+    assert.match(html, /Créé avec /);
+    assert.match(html, /Observable<\/a> le /);
+  });
+
+  it("localizes render-time strings from front matter locale overrides", async () => {
+    const config = normalizeConfig({
+      root: "test/input/build/config",
+      locale: "fr-FR",
+      search: {},
+      pages: [{name: "Section", path: "/section", pager: "main"}]
+    });
+    const page = parseMarkdown("---\nlocale: ar-EG\n---\n# Hello", {
+      path: "index.md",
+      md: config.md,
+      footer: config.footer,
+      header: config.header,
+      head: config.head
+    });
+    const html = await renderPage(page, {...config, path: "/section", root: config.root});
+    assert.match(html, /title="تبديل الشريط الجانبي"/);
+    assert.match(html, /placeholder="بحث"/);
+    assert.match(html, /data-label="الصفحة السابقة"/);
+    assert.match(html, /أُنشئ باستخدام /);
+    assert.match(html, /Observable<\/a> في /);
+  });
+});


### PR DESCRIPTION
This PR adds project- and page-level locale support to Framework and localizes Framework-owned UI defaults.

Changes:
  - add `locale`, `lang`, and `dir` to Framework config
  - add front matter overrides for `locale`, `lang`, and `dir`
  - set root HTML `lang` / `dir` during render
  - localize Framework-owned default UI strings, including:
    - home
    - contents / table of contents label
    - untitled page fallback
    - search placeholder
    - sidebar toggle title
    - pager labels
    - default footer text and date formatting
  - update docs and tests

This intentionally keeps translation catalogs and fallback policy out of Framework core; those remain user-land concerns.

This is the Framework-side companion to the [Plot locale work](https://github.com/observablehq/plot/pull/2396), keeping translation catalogs and fallback logic out of Framework core.