### PR TITLE
deploy to github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,26 +11,30 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      deployments: write
+      pages: write
       id-token: write
-      packages: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
-          cache: 'yarn'
-      - run: yarn --frozen-lockfile
+          node-version: 24
+          cache: yarn
       - id: date
         run: echo "date=$(TZ=America/Los_Angeles date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - id: cache-data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: docs/.observablehq/cache
           key: data-${{ hashFiles('docs/data/*') }}-${{ steps.date.outputs.date }}
       - run: yarn build
       - run: yarn docs:build
-      - run: yarn docs:deploy
-        env:
-          OBSERVABLE_TOKEN: ${{ secrets.OBSERVABLE_API_TOKEN }}
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/examples/observablehq.config.js
+++ b/examples/observablehq.config.js
@@ -12,7 +12,8 @@ export default {
   sidebar: false,
   ...baseConfig,
   title: "Observable Framework",
-  head: `<script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
+  head: `<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`,
   header: `<style>
 

--- a/observablehq.config.ts
+++ b/observablehq.config.ts
@@ -115,6 +115,7 @@ export default {
 <link rel="icon" type="image/png" href="/observable.png" sizes="32x32">${
     process.env.CI
       ? `
+<script type="module" async src="https://events.observablehq.com/client.js?pageLoad"></script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9B88TP6PKQ"></script>
 <script>window.dataLayer=window.dataLayer||[];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js',new Date());\ngtag('config','G-9B88TP6PKQ');</script>`
       : ""


### PR DESCRIPTION
Essentially reverts #1566, but adopting GitHub Pages instead of Cloudflare Pages. Modeled after [Plot’s deploy.yml](https://github.com/observablehq/plot/blob/main/.github/workflows/deploy.yml), though I updated to the latest versions of various GitHub Actions.